### PR TITLE
Make intelligent_design/generateSyntheticData deterministic (#10)

### DIFF
--- a/discovery/discover_missing_neuron.ts
+++ b/discovery/discover_missing_neuron.ts
@@ -18,6 +18,9 @@ import { emptyDirSync, ensureDirSync } from "@std/fs";
 import { join } from "@std/path";
 import { Creature, type CreatureExport, CreatureUtil, type NeatOptions } from "@stsoftware/neat-ai";
 
+export { createDeterministicRandom } from "../shared/deterministic_random.ts";
+import { createDeterministicRandom } from "../shared/deterministic_random.ts";
+
 const WORK_ROOT = ".synthetic-discovery";
 const DATA_DIR = join(WORK_ROOT, "data");
 const CREATURE_DIR = join(WORK_ROOT, "creatures");
@@ -28,16 +31,6 @@ export const SYNTHETIC_CONFIG = {
   recordsPerFile: 128,
   seed: 13371337,
 };
-
-export function createDeterministicRandom(seed: number): () => number {
-  let t = seed >>> 0;
-  return () => {
-    t += 0x6d2b79f5;
-    let r = Math.imul(t ^ (t >>> 15), 1 | t);
-    r ^= r + Math.imul(r ^ (r >>> 7), 61 | r);
-    return ((r ^ (r >>> 14)) >>> 0) / 4294967296;
-  };
-}
 
 /**
  * Creates a reference creature for the discovery example.

--- a/docs/pr-summary-10.md
+++ b/docs/pr-summary-10.md
@@ -1,0 +1,37 @@
+## Summary
+
+Make `generateSyntheticData` in the intelligent design module deterministic, consistent with the
+discovery module's approach. Closes #10.
+
+### Changes
+
+- **Seeded PRNG**: Replaced `Math.random()` with a seeded `createDeterministicRandom` function,
+  ensuring identical data is generated across runs for a given seed.
+- **Creature-derived sizes**: Input and output sizes are now derived from the `Creature` object
+  (`creature.input`, `creature.output`) instead of being hardcoded as `4` and `1`.
+- **Creature activation for targets**: Target outputs are generated using the creature's own
+  `activate()` method rather than a separate mathematical formula (`Math.tanh(...)`).
+- **Shared PRNG utility**: Extracted `createDeterministicRandom` into `shared/deterministic_random.ts`
+  so both the discovery and intelligent design modules import from a single source of truth (DRY).
+- **Configurable generation**: Added `SYNTHETIC_CONFIG` (matching the discovery module's pattern)
+  with `totalRecords`, `recordsPerFile`, and `seed` fields.
+
+## Evidence
+
+This is a backend/CLI change with no visual output. Correctness is verified by the test suite:
+
+- All 35 tests pass across intelligent design, discovery, and shared modules
+- The full `quality.sh` pipeline passes (lint, format, tests, example runners)
+
+## Test Plan
+
+- **New test**: `generateSyntheticData is deterministic for the same seed` — generates data twice
+  with the same seed and asserts the binary output is byte-for-byte identical
+- **New test**: `generateSyntheticData splits records across multiple files` — verifies batched
+  file output works correctly
+- **New test**: `SYNTHETIC_CONFIG has expected properties` — validates the configuration constant
+- **New tests**: `shared/deterministic_random_test.ts` — tests for the extracted PRNG (range,
+  determinism, seed diversity)
+- **Updated tests**: All existing `generateSyntheticData` tests updated for the new function
+  signature (`Creature, dataDir, config`) and new file naming pattern (`synthetic_0000.bin`)
+- All 7 original `createReferenceCreature` tests preserved unchanged

--- a/docs/pr-summary-10.md
+++ b/docs/pr-summary-10.md
@@ -11,8 +11,9 @@ discovery module's approach. Closes #10.
   (`creature.input`, `creature.output`) instead of being hardcoded as `4` and `1`.
 - **Creature activation for targets**: Target outputs are generated using the creature's own
   `activate()` method rather than a separate mathematical formula (`Math.tanh(...)`).
-- **Shared PRNG utility**: Extracted `createDeterministicRandom` into `shared/deterministic_random.ts`
-  so both the discovery and intelligent design modules import from a single source of truth (DRY).
+- **Shared PRNG utility**: Extracted `createDeterministicRandom` into
+  `shared/deterministic_random.ts` so both the discovery and intelligent design modules import from
+  a single source of truth (DRY).
 - **Configurable generation**: Added `SYNTHETIC_CONFIG` (matching the discovery module's pattern)
   with `totalRecords`, `recordsPerFile`, and `seed` fields.
 
@@ -27,8 +28,8 @@ This is a backend/CLI change with no visual output. Correctness is verified by t
 
 - **New test**: `generateSyntheticData is deterministic for the same seed` — generates data twice
   with the same seed and asserts the binary output is byte-for-byte identical
-- **New test**: `generateSyntheticData splits records across multiple files` — verifies batched
-  file output works correctly
+- **New test**: `generateSyntheticData splits records across multiple files` — verifies batched file
+  output works correctly
 - **New test**: `SYNTHETIC_CONFIG has expected properties` — validates the configuration constant
 - **New tests**: `shared/deterministic_random_test.ts` — tests for the extracted PRNG (range,
   determinism, seed diversity)

--- a/intelligent_design/improve_squash_example.ts
+++ b/intelligent_design/improve_squash_example.ts
@@ -29,6 +29,13 @@ import {
   scanForSquashImprovements,
 } from "@stsoftware/neat-ai";
 import { addTag, getTag } from "@stsoftware/tags/mod";
+import { createDeterministicRandom } from "../shared/deterministic_random.ts";
+
+export const SYNTHETIC_CONFIG = {
+  totalRecords: 500,
+  recordsPerFile: 500,
+  seed: 42424242,
+};
 
 if (import.meta.main) {
   const start = Date.now();
@@ -66,7 +73,7 @@ if (import.meta.main) {
 
   // Step 2: Generate synthetic training data
   console.log("\n📊 Step 2: Generating synthetic training data...");
-  generateSyntheticData(DATA_DIR, creatureExport);
+  generateSyntheticData(creature, DATA_DIR, SYNTHETIC_CONFIG);
 
   // Step 3: Score the baseline creature
   console.log("\n📈 Step 3: Scoring baseline creature...");
@@ -233,43 +240,58 @@ export function createReferenceCreature(): Creature {
 }
 
 /**
- * Generates synthetic training data for testing.
+ * Generates deterministic synthetic training data using the creature's activation.
  *
- * In a real application, this data would come from your training
- * data generation pipeline (e.g. example.com/data-pipeline).
+ * Uses a seeded PRNG for reproducible input generation and derives
+ * input/output sizes from the creature rather than hardcoding them.
+ * Target outputs come from the creature's own activate() method,
+ * consistent with the discovery module's approach.
  */
-export function generateSyntheticData(dataDir: string, _creature: CreatureExport) {
-  // Generate simple binary training data
-  const inputSize = 4;
-  const outputSize = 1;
-  const recordCount = 500;
+export function generateSyntheticData(
+  creature: Creature,
+  dataDir: string,
+  config: typeof SYNTHETIC_CONFIG,
+): void {
+  const random = createDeterministicRandom(config.seed);
+  const bytesPerRecord = (creature.input + creature.output) * 4;
 
-  // Calculate record size: 4 bytes per float32
-  const recordSize = (inputSize + outputSize) * 4;
-  const buffer = new ArrayBuffer(recordCount * recordSize);
-  const view = new DataView(buffer);
+  let remaining = config.totalRecords;
+  let fileIndex = 0;
 
-  let offset = 0;
-  for (let i = 0; i < recordCount; i++) {
-    // Generate random inputs
-    const inputs = [];
-    for (let j = 0; j < inputSize; j++) {
-      const value = Math.random() * 2 - 1; // Range: -1 to 1
-      inputs.push(value);
-      view.setFloat32(offset, value, true); // little-endian
-      offset += 4;
+  while (remaining > 0) {
+    const batchSize = Math.min(config.recordsPerFile, remaining);
+    const filePath = join(
+      dataDir,
+      `synthetic_${String(fileIndex).padStart(4, "0")}.bin`,
+    );
+
+    const buffer = new Uint8Array(bytesPerRecord * batchSize);
+    const view = new Float32Array(buffer.buffer);
+
+    let offset = 0;
+    for (let record = 0; record < batchSize; record++) {
+      // Generate deterministic random input
+      for (let i = 0; i < creature.input; i++) {
+        view[offset + i] = random() * 2 - 1;
+      }
+
+      // Get creature's output for this input
+      const input = view.subarray(offset, offset + creature.input);
+      creature.clearState();
+      const output = creature.activate(Float32Array.from(input));
+
+      // Store output
+      for (let j = 0; j < creature.output; j++) {
+        view[offset + creature.input + j] = output[j] ?? 0;
+      }
+
+      offset += creature.input + creature.output;
     }
 
-    // Generate target output (some function of inputs)
-    const target = Math.tanh(
-      inputs[0] * 0.5 + inputs[1] * -0.3 + inputs[2] * 0.4 + inputs[3] * -0.2,
-    );
-    view.setFloat32(offset, target, true);
-    offset += 4;
-  }
+    Deno.writeFileSync(filePath, buffer);
+    console.log(`   Generated ${batchSize} records to ${filePath}`);
 
-  // Write to file
-  const dataPath = join(dataDir, "synthetic.bin");
-  Deno.writeFileSync(dataPath, new Uint8Array(buffer));
-  console.log(`   Generated ${recordCount} records to ${dataPath}`);
+    remaining -= batchSize;
+    fileIndex++;
+  }
 }

--- a/intelligent_design/improve_squash_example_test.ts
+++ b/intelligent_design/improve_squash_example_test.ts
@@ -10,7 +10,11 @@ import { assertEquals, assertGreater } from "@std/assert";
 import { ensureDirSync, existsSync } from "@std/fs";
 import { join } from "@std/path";
 
-import { createReferenceCreature, generateSyntheticData } from "./improve_squash_example.ts";
+import {
+  createReferenceCreature,
+  generateSyntheticData,
+  SYNTHETIC_CONFIG,
+} from "./improve_squash_example.ts";
 
 /* ------------------------------------------------------------------ */
 /*  createReferenceCreature                                            */
@@ -80,6 +84,16 @@ Deno.test("createReferenceCreature includes expected synapses", () => {
 });
 
 /* ------------------------------------------------------------------ */
+/*  SYNTHETIC_CONFIG                                                    */
+/* ------------------------------------------------------------------ */
+
+Deno.test("SYNTHETIC_CONFIG has expected properties", () => {
+  assertGreater(SYNTHETIC_CONFIG.totalRecords, 0, "totalRecords should be positive");
+  assertGreater(SYNTHETIC_CONFIG.recordsPerFile, 0, "recordsPerFile should be positive");
+  assertGreater(SYNTHETIC_CONFIG.seed, 0, "seed should be positive");
+});
+
+/* ------------------------------------------------------------------ */
 /*  generateSyntheticData                                              */
 /* ------------------------------------------------------------------ */
 
@@ -90,32 +104,33 @@ Deno.test("generateSyntheticData creates a binary data file", () => {
 
   try {
     const creature = createReferenceCreature();
-    const json = creature.exportJSON();
-    generateSyntheticData(dataDir, json);
+    const config = { totalRecords: 16, recordsPerFile: 16, seed: 42 };
+    generateSyntheticData(creature, dataDir, config);
 
-    const dataPath = join(dataDir, "synthetic.bin");
-    assertEquals(existsSync(dataPath), true, "synthetic.bin should exist");
+    const dataPath = join(dataDir, "synthetic_0000.bin");
+    assertEquals(existsSync(dataPath), true, "synthetic_0000.bin should exist");
   } finally {
     Deno.removeSync(tmpDir, { recursive: true });
   }
 });
 
-Deno.test("generateSyntheticData creates a file with correct size for 500 records", () => {
+Deno.test("generateSyntheticData creates a file with correct size", () => {
   const tmpDir = Deno.makeTempDirSync({ prefix: "neat_id_test_" });
   const dataDir = join(tmpDir, "data");
   ensureDirSync(dataDir);
 
   try {
     const creature = createReferenceCreature();
-    const json = creature.exportJSON();
-    generateSyntheticData(dataDir, json);
+    const recordCount = 50;
+    const config = { totalRecords: recordCount, recordsPerFile: recordCount, seed: 42 };
+    generateSyntheticData(creature, dataDir, config);
 
-    const dataPath = join(dataDir, "synthetic.bin");
+    const dataPath = join(dataDir, "synthetic_0000.bin");
     const stat = Deno.statSync(dataPath);
 
-    // 500 records * (4 inputs + 1 output) * 4 bytes per float32
-    const expectedSize = 500 * (4 + 1) * 4;
-    assertEquals(stat.size, expectedSize, "file size should match 500 records");
+    // records * (4 inputs + 1 output) * 4 bytes per float32
+    const expectedSize = recordCount * (creature.input + creature.output) * 4;
+    assertEquals(stat.size, expectedSize, "file size should match expected record count");
   } finally {
     Deno.removeSync(tmpDir, { recursive: true });
   }
@@ -128,8 +143,8 @@ Deno.test("generateSyntheticData produces data that can be scored by the creatur
 
   try {
     const creature = createReferenceCreature();
-    const json = creature.exportJSON();
-    generateSyntheticData(dataDir, json);
+    const config = { totalRecords: 64, recordsPerFile: 64, seed: 42 };
+    generateSyntheticData(creature, dataDir, config);
 
     // The creature should be able to score against the generated data
     const result = creature.scoreDir(dataDir, {});
@@ -147,19 +162,66 @@ Deno.test("generateSyntheticData file contains valid float32 values", () => {
 
   try {
     const creature = createReferenceCreature();
-    const json = creature.exportJSON();
-    generateSyntheticData(dataDir, json);
+    const config = { totalRecords: 16, recordsPerFile: 16, seed: 42 };
+    generateSyntheticData(creature, dataDir, config);
 
-    const dataPath = join(dataDir, "synthetic.bin");
+    const dataPath = join(dataDir, "synthetic_0000.bin");
     const buffer = Deno.readFileSync(dataPath);
     const view = new DataView(buffer.buffer);
 
     // Spot-check first record: 4 inputs + 1 output = 5 floats
-    const recordFloats = 5;
+    const recordFloats = creature.input + creature.output;
     for (let i = 0; i < recordFloats; i++) {
       const value = view.getFloat32(i * 4, true);
       assertEquals(Number.isFinite(value), true, `float at offset ${i} should be finite`);
     }
+  } finally {
+    Deno.removeSync(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("generateSyntheticData is deterministic for the same seed", () => {
+  const tmpDir1 = Deno.makeTempDirSync({ prefix: "neat_id_test_" });
+  const tmpDir2 = Deno.makeTempDirSync({ prefix: "neat_id_test_" });
+  const dataDir1 = join(tmpDir1, "data");
+  const dataDir2 = join(tmpDir2, "data");
+  ensureDirSync(dataDir1);
+  ensureDirSync(dataDir2);
+
+  try {
+    const creature1 = createReferenceCreature();
+    const creature2 = createReferenceCreature();
+
+    const config = { totalRecords: 32, recordsPerFile: 32, seed: 42 };
+    generateSyntheticData(creature1, dataDir1, config);
+    generateSyntheticData(creature2, dataDir2, config);
+
+    const file1 = Deno.readFileSync(join(dataDir1, "synthetic_0000.bin"));
+    const file2 = Deno.readFileSync(join(dataDir2, "synthetic_0000.bin"));
+
+    assertEquals(file1, file2, "same seed should produce identical data");
+  } finally {
+    Deno.removeSync(tmpDir1, { recursive: true });
+    Deno.removeSync(tmpDir2, { recursive: true });
+  }
+});
+
+Deno.test("generateSyntheticData splits records across multiple files", () => {
+  const tmpDir = Deno.makeTempDirSync({ prefix: "neat_id_test_" });
+  const dataDir = join(tmpDir, "data");
+  ensureDirSync(dataDir);
+
+  try {
+    const creature = createReferenceCreature();
+    const config = { totalRecords: 16, recordsPerFile: 8, seed: 42 };
+    generateSyntheticData(creature, dataDir, config);
+
+    assertEquals(existsSync(join(dataDir, "synthetic_0000.bin")), true, "first file should exist");
+    assertEquals(
+      existsSync(join(dataDir, "synthetic_0001.bin")),
+      true,
+      "second file should exist",
+    );
   } finally {
     Deno.removeSync(tmpDir, { recursive: true });
   }

--- a/shared/deterministic_random.ts
+++ b/shared/deterministic_random.ts
@@ -1,0 +1,16 @@
+/**
+ * A seeded pseudo-random number generator (PRNG) for deterministic data generation.
+ *
+ * Uses a splitmix32-style algorithm to produce reproducible sequences
+ * of numbers in the range [0, 1). Given the same seed, the sequence
+ * is identical across runs and platforms.
+ */
+export function createDeterministicRandom(seed: number): () => number {
+  let t = seed >>> 0;
+  return () => {
+    t += 0x6d2b79f5;
+    let r = Math.imul(t ^ (t >>> 15), 1 | t);
+    r ^= r + Math.imul(r ^ (r >>> 7), 61 | r);
+    return ((r ^ (r >>> 14)) >>> 0) / 4294967296;
+  };
+}

--- a/shared/deterministic_random_test.ts
+++ b/shared/deterministic_random_test.ts
@@ -1,0 +1,43 @@
+/**
+ * Unit tests for the shared deterministic random module.
+ *
+ * These are "what" tests — they verify the PRNG produces correct
+ * values (range, determinism, diversity) without checking the
+ * algorithm internals.
+ */
+
+import { assertEquals, assertGreater } from "@std/assert";
+
+import { createDeterministicRandom } from "./deterministic_random.ts";
+
+Deno.test("createDeterministicRandom produces values between 0 and 1", () => {
+  const rng = createDeterministicRandom(42);
+  for (let i = 0; i < 100; i++) {
+    const value = rng();
+    assertGreater(value, -Number.EPSILON, "value should be >= 0");
+    assertGreater(1 + Number.EPSILON, value, "value should be < 1");
+  }
+});
+
+Deno.test("createDeterministicRandom is deterministic for the same seed", () => {
+  const rng1 = createDeterministicRandom(42);
+  const rng2 = createDeterministicRandom(42);
+
+  for (let i = 0; i < 50; i++) {
+    assertEquals(rng1(), rng2(), `mismatch at iteration ${i}`);
+  }
+});
+
+Deno.test("createDeterministicRandom differs for different seeds", () => {
+  const rng1 = createDeterministicRandom(42);
+  const rng2 = createDeterministicRandom(99);
+
+  let allSame = true;
+  for (let i = 0; i < 20; i++) {
+    if (rng1() !== rng2()) {
+      allSame = false;
+      break;
+    }
+  }
+  assertEquals(allSame, false, "different seeds should produce different sequences");
+});


### PR DESCRIPTION
## Summary

Make `generateSyntheticData` in the intelligent design module deterministic, consistent with the
discovery module's approach. Closes #10.

### Changes

- **Seeded PRNG**: Replaced `Math.random()` with a seeded `createDeterministicRandom` function,
  ensuring identical data is generated across runs for a given seed.
- **Creature-derived sizes**: Input and output sizes are now derived from the `Creature` object
  (`creature.input`, `creature.output`) instead of being hardcoded as `4` and `1`.
- **Creature activation for targets**: Target outputs are generated using the creature's own
  `activate()` method rather than a separate mathematical formula (`Math.tanh(...)`).
- **Shared PRNG utility**: Extracted `createDeterministicRandom` into `shared/deterministic_random.ts`
  so both the discovery and intelligent design modules import from a single source of truth (DRY).
- **Configurable generation**: Added `SYNTHETIC_CONFIG` (matching the discovery module's pattern)
  with `totalRecords`, `recordsPerFile`, and `seed` fields.

## Evidence

This is a backend/CLI change with no visual output. Correctness is verified by the test suite:

- All 35 tests pass across intelligent design, discovery, and shared modules
- The full `quality.sh` pipeline passes (lint, format, tests, example runners)

## Test Plan

- **New test**: `generateSyntheticData is deterministic for the same seed` — generates data twice
  with the same seed and asserts the binary output is byte-for-byte identical
- **New test**: `generateSyntheticData splits records across multiple files` — verifies batched
  file output works correctly
- **New test**: `SYNTHETIC_CONFIG has expected properties` — validates the configuration constant
- **New tests**: `shared/deterministic_random_test.ts` — tests for the extracted PRNG (range,
  determinism, seed diversity)
- **Updated tests**: All existing `generateSyntheticData` tests updated for the new function
  signature (`Creature, dataDir, config`) and new file naming pattern (`synthetic_0000.bin`)
- All 7 original `createReferenceCreature` tests preserved unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)