### PR TITLE
De-duplicate and unify documentation with README.md as source of truth (#25)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,18 +63,8 @@ benchmark will expose the regression.
 
 ## Running Quality Checks
 
-```bash
-./quality.sh
-```
-
-This runs:
-
-1. **Linting** — `deno lint` with the recommended rule set.
-2. **Formatting** — `deno fmt --check` to enforce consistent style.
-3. **Unit tests** — `deno test` across the entire project.
-4. **Example programs** — each example runner script, verifying the full end-to-end workflow.
-
-All steps must pass before merging.
+Run `./quality.sh` before merging. It executes linting, formatting, unit tests, and all example
+programs. See [README.md](README.md#quality-check) for full details.
 
 ## Project Structure
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,7 @@
 # Contributing to NEAT-AI-Examples
 
-Thank you for your interest in contributing! This guide covers everything you need to get started.
+Thank you for your interest in contributing! This guide covers contributor-specific details. For
+project overview, running examples, testing commands, and benchmarks, see [README.md](README.md).
 
 ## Prerequisites
 
@@ -40,45 +41,9 @@ Then copy the compiled library to `~/.cargo/lib/`:
 
 ## Development Workflow
 
-### Running the Quality Gate
-
-Before submitting any changes, run the full quality gate:
-
-```bash
-./quality.sh
-```
-
-This executes, in order:
-
-1. `deno lint` — static analysis with the recommended rule set
-2. `deno fmt --check` — formatting verification (2-space indent, 100-char line width, double quotes)
-3. `deno test` — all unit tests across the project
-4. Each example runner script (`run.sh`) — end-to-end verification
-
-All steps must pass before merging.
-
-### Running Tests Independently
-
-```bash
-# All unit tests
-deno test --no-check --allow-read --allow-write --allow-env
-
-# A single test file
-deno test --no-check --allow-read --allow-write --allow-env crossover/crossover_example_test.ts
-```
-
-### Linting and Formatting
-
-```bash
-# Check for lint issues
-deno lint
-
-# Check formatting without modifying files
-deno fmt --check
-
-# Auto-fix formatting
-deno fmt
-```
+Before submitting any changes, run the full quality gate (`./quality.sh`), which runs `deno lint`,
+`deno fmt --check`, `deno test`, and all example runner scripts. See
+[Quality Check](README.md#quality-check) in the README for full details on each step.
 
 ## Adding a New Example
 
@@ -103,7 +68,7 @@ import { setupWorkingDirs } from "../common/working_dirs.ts";
 
 Create `my_example/my_example_test.ts` next to the module. Tests must be "what" tests — call real
 functions with test data and assert on outputs, exit codes, or side effects. See
-[Testing Guidelines](#testing-guidelines) below.
+[AGENTS.md](AGENTS.md) for the full testing philosophy.
 
 ### 4. Write the runner script
 
@@ -156,49 +121,13 @@ Run the full quality gate to confirm everything passes:
 ./quality.sh
 ```
 
-## Testing Guidelines
-
-Every test must be a **"what" test** — it verifies _what_ the code produces, never _how_ it produces
-it.
-
-**Good (what tests):**
-
-- Call a function with known input and assert the output value
-- Create a creature, activate it, and check that the result is finite
-- Generate data files and verify their existence and size
-- Remove a neuron and confirm the creature still validates
-
-**Bad (how tests — do not write these):**
-
-- Grep source code for a pattern or function name
-- Assert that one function calls another
-- Check that a specific algorithm or data structure is used internally
-
-For the full testing philosophy, including unit tests vs benchmarks, see [AGENTS.md](AGENTS.md).
-
-### Test file conventions
-
-- Place test files next to the module they test: `<module>_test.ts`
-- Use `Deno.test(...)` with descriptive names
-- Import the functions under test directly
-- Clean up temporary files in a `finally` block
-- Use `Deno.makeTempDirSync()` for any file I/O so tests never pollute the working tree
-
 ## Code Style
 
 ### Australian English
 
-All code, comments, and documentation **must** use Australian English spelling. Common examples:
-
-| American English | Australian English |
-| ---------------- | ------------------ |
-| color            | colour             |
-| behavior         | behaviour          |
-| organization     | organisation       |
-| favor            | favour             |
-| meter            | metre              |
-| center           | centre             |
-| optimize         | optimise           |
+All code, comments, and documentation **must** use Australian English spelling (e.g. colour,
+behaviour, organisation, favour, metre, centre, optimise). See [AGENTS.md](AGENTS.md) for the
+complete list of spelling conventions.
 
 ### Formatting
 
@@ -221,15 +150,10 @@ Before submitting a pull request, verify the following:
 - [ ] Commit messages are clear and reference the relevant issue number
 - [ ] The PR targets the `Develop` branch
 
-## Continuous Integration
-
-A GitHub Actions workflow automatically runs the quality checks on every push and pull request to
-the `Develop` branch. Failing checks will block merges.
-
 ## Getting Help
 
 If you have questions about the project or need guidance, open a GitHub issue or check the existing
 documentation:
 
-- [README.md](README.md) — project overview and example descriptions
-- [AGENTS.md](AGENTS.md) — detailed coding and testing guidelines
+- [README.md](README.md) — project overview, examples, testing, linting, and benchmarks
+- [AGENTS.md](AGENTS.md) — AI agent instructions and detailed testing guidelines

--- a/README.md
+++ b/README.md
@@ -246,6 +246,11 @@ suggestions as GitHub issues, use the GH CLI:
 gh issue create --title "Improvement title" --label "enhancement" --body "Description"
 ```
 
+## Contributing
+
+Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, how to add
+new examples, coding standards, and the pull request checklist.
+
 ## License
 
 See [LICENSE](LICENSE) for details.

--- a/docs/archive_test.ts
+++ b/docs/archive_test.ts
@@ -28,8 +28,9 @@ Deno.test("PR summary files exist in docs/archive/", () => {
 Deno.test("No PR summary files remain in docs/ root", () => {
   for (const entry of Deno.readDirSync("docs/")) {
     if (entry.isFile && entry.name.startsWith("pr-summary-")) {
-      // pr-summary-24.md is the current PR summary, not an archived one
+      // Current PR summaries that have not yet been archived
       if (entry.name === "pr-summary-24.md") continue;
+      if (entry.name === "pr-summary-25.md") continue;
       throw new Error(
         `Found unexpected PR summary file in docs/ root: ${entry.name}`,
       );

--- a/docs/pr-summary-25.md
+++ b/docs/pr-summary-25.md
@@ -1,0 +1,45 @@
+## Summary
+
+De-duplicated and unified documentation so that README.md is the single source of truth. Closes #25.
+
+### Changes
+
+- **CONTRIBUTING.md**: Removed duplicated content (quality gate steps, test commands, linting
+  commands, testing guidelines) that was nearly identical to README.md. Replaced with concise
+  references back to README.md sections. Retained contributor-specific content: detailed
+  prerequisites, adding new examples, code style, and PR checklist.
+
+- **AGENTS.md**: Condensed the "Running Quality Checks" section to a brief reference to README.md,
+  removing the duplicated step-by-step breakdown. Kept all agent-specific content (testing
+  philosophy, unit tests vs benchmarks, writing tests, project structure).
+
+- **README.md**: Added a "Contributing" section that links to CONTRIBUTING.md for development setup,
+  coding standards, and PR workflow. README remains the comprehensive reference for all user-facing
+  information.
+
+- **docs/archive_test.ts**: Updated to allow pr-summary-25.md in the docs root.
+
+### Duplications Resolved
+
+| Content Area                                   | Resolution                                          |
+| ---------------------------------------------- | --------------------------------------------------- |
+| Running tests (`deno test` commands)           | CONTRIBUTING.md references README.md                |
+| Linting & formatting (`deno lint`, `deno fmt`) | CONTRIBUTING.md references README.md                |
+| Quality gate steps                             | CONTRIBUTING.md references README.md                |
+| Unit tests vs benchmarks guidance              | AGENTS.md kept (agent-specific audience)            |
+| Australian English spelling rules              | CONTRIBUTING.md references AGENTS.md for full list  |
+| Testing philosophy/guidelines                  | CONTRIBUTING.md references AGENTS.md                |
+| CI information                                 | Removed from CONTRIBUTING.md (already in README.md) |
+
+## Evidence
+
+- All 117 unit tests pass including contributing_test.ts which validates CONTRIBUTING.md content
+- `./quality.sh` passes cleanly (lint, format, tests, all examples)
+- All internal cross-references and links verified
+
+## Test Plan
+
+- Existing `contributing_test.ts` (14 tests) validates CONTRIBUTING.md still contains all required
+  sections and references
+- Existing `docs/archive_test.ts` updated to allow pr-summary-25.md
+- No new tests needed — this is a documentation-only change verified by existing test suite


### PR DESCRIPTION
## Summary

De-duplicated and unified documentation so that README.md is the single source of truth. Closes #25.

### Changes

- **CONTRIBUTING.md**: Removed duplicated content (quality gate steps, test commands, linting
  commands, testing guidelines) that was nearly identical to README.md. Replaced with concise
  references back to README.md sections. Retained contributor-specific content: detailed
  prerequisites, adding new examples, code style, and PR checklist.

- **AGENTS.md**: Condensed the "Running Quality Checks" section to a brief reference to README.md,
  removing the duplicated step-by-step breakdown. Kept all agent-specific content (testing
  philosophy, unit tests vs benchmarks, writing tests, project structure).

- **README.md**: Added a "Contributing" section that links to CONTRIBUTING.md for development setup,
  coding standards, and PR workflow. README remains the comprehensive reference for all user-facing
  information.

- **docs/archive_test.ts**: Updated to allow pr-summary-25.md in the docs root.

### Duplications Resolved

| Content Area                                   | Resolution                                          |
| ---------------------------------------------- | --------------------------------------------------- |
| Running tests (`deno test` commands)           | CONTRIBUTING.md references README.md                |
| Linting & formatting (`deno lint`, `deno fmt`) | CONTRIBUTING.md references README.md                |
| Quality gate steps                             | CONTRIBUTING.md references README.md                |
| Unit tests vs benchmarks guidance              | AGENTS.md kept (agent-specific audience)            |
| Australian English spelling rules              | CONTRIBUTING.md references AGENTS.md for full list  |
| Testing philosophy/guidelines                  | CONTRIBUTING.md references AGENTS.md                |
| CI information                                 | Removed from CONTRIBUTING.md (already in README.md) |

## Evidence

- All 117 unit tests pass including contributing_test.ts which validates CONTRIBUTING.md content
- `./quality.sh` passes cleanly (lint, format, tests, all examples)
- All internal cross-references and links verified

## Test Plan

- Existing `contributing_test.ts` (14 tests) validates CONTRIBUTING.md still contains all required
  sections and references
- Existing `docs/archive_test.ts` updated to allow pr-summary-25.md
- No new tests needed — this is a documentation-only change verified by existing test suite

---

## Automated Fix Details
This PR addresses issue #25: **De-duplicate and unify documentation with README.md as source of truth**


## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #25
---

🤖 Processed by: stservice