### PR TITLE
docs: add Related Repositories section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,40 @@ flowchart TD
     style SUGGEST fill:#50e3c2,stroke:#333,color:#fff
 ```
 
+## Related Repositories
+
+The NEAT-AI project is split across seven public repositories. Each focuses on one concern and
+composes with the others as shown below.
+
+| Repository                                                             | Role                                                                                                              |
+| ---------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| [NEAT-AI](https://github.com/stSoftwareAU/NEAT-AI)                     | Primary Deno/TypeScript neural-network engine (evolution, training, WASM activation).                             |
+| [NEAT-AI-core](https://github.com/stSoftwareAU/NEAT-AI-core)           | Shared native Rust library (`neat-core`) with numerics, topology helpers, and the chunked `.bin` training stream. |
+| [NEAT-AI-Discovery](https://github.com/stSoftwareAU/NEAT-AI-Discovery) | Rust discovery module invoked by NEAT-AI via Deno FFI to search architectures and hyper-parameters.               |
+| [NEAT-AI-Snapshot](https://github.com/stSoftwareAU/NEAT-AI-Snapshot)   | Creature/genome snapshot format and fixtures produced by NEAT-AI and consumed by downstream tools.                |
+| [NEAT-AI-scorer](https://github.com/stSoftwareAU/NEAT-AI-scorer)       | Production forward-only scoring application built on `neat-core` via a path dependency.                           |
+| [NEAT-AI-Explore](https://github.com/stSoftwareAU/NEAT-AI-Explore)     | Visualiser for creatures that reads NEAT-AI-Snapshot data.                                                        |
+| [NEAT-AI-Examples](https://github.com/stSoftwareAU/NEAT-AI-Examples)   | Worked examples and tutorials that depend on NEAT-AI.                                                             |
+
+### Dependency graph
+
+```mermaid
+graph TD
+    Core[NEAT-AI-core<br/>Rust shared lib]
+    Main[NEAT-AI<br/>Deno/TypeScript engine]
+    Discovery[NEAT-AI-Discovery<br/>Rust, via Deno FFI]
+    Snapshot[NEAT-AI-Snapshot<br/>creature data]
+    Scorer[NEAT-AI-scorer<br/>Rust scorer app]
+    Explore[NEAT-AI-Explore<br/>visualiser]
+    Examples[NEAT-AI-Examples<br/>tutorials]
+
+    Main -->|Deno FFI| Discovery
+    Main -->|produces| Snapshot
+    Scorer -->|path dependency| Core
+    Explore -->|reads| Snapshot
+    Examples -->|depends on| Main
+```
+
 ## 📋 Prerequisites
 
 - [Deno](https://deno.land/) runtime installed

--- a/docs/pr-summary-32.md
+++ b/docs/pr-summary-32.md
@@ -1,0 +1,43 @@
+## Summary
+
+Added a `## Related Repositories` section to `README.md` directly after the existing Examples
+Overview Mermaid diagram, reusing the canonical block defined in stSoftwareAU/NEAT-AI-core#18
+verbatim. The section lists every public NEAT-AI-* repository with a one-line description, links,
+and a Mermaid dependency graph showing how the seven repos compose. Closes #32.
+
+## Evidence
+
+This is a documentation-only change. Verified by:
+
+- `./quality.sh` — passes cleanly (lint, fmt, all unit tests, all example runners).
+- New unit tests in `related_repositories_test.ts` assert that the section exists, mentions every
+  required repo, links to each GitHub URL, and contains the canonical Mermaid dependency diagram.
+
+The inserted dependency diagram (rendered on GitHub):
+
+```mermaid
+graph TD
+    Core[NEAT-AI-core<br/>Rust shared lib]
+    Main[NEAT-AI<br/>Deno/TypeScript engine]
+    Discovery[NEAT-AI-Discovery<br/>Rust, via Deno FFI]
+    Snapshot[NEAT-AI-Snapshot<br/>creature data]
+    Scorer[NEAT-AI-scorer<br/>Rust scorer app]
+    Explore[NEAT-AI-Explore<br/>visualiser]
+    Examples[NEAT-AI-Examples<br/>tutorials]
+
+    Main -->|Deno FFI| Discovery
+    Main -->|produces| Snapshot
+    Scorer -->|path dependency| Core
+    Explore -->|reads| Snapshot
+    Examples -->|depends on| Main
+```
+
+## Test Plan
+
+- Added `related_repositories_test.ts` with four "what" tests:
+  - `README.md contains a 'Related Repositories' section`
+  - `Related Repositories section lists all 7 NEAT-AI-* repos`
+  - `Related Repositories section links to the GitHub repos`
+  - `Related Repositories section contains a Mermaid dependency diagram`
+- Existing `mermaid_diagrams_test.ts` continues to pass — the new diagram is well-formed and uses a
+  valid `graph TD` declaration.

--- a/related_repositories_test.ts
+++ b/related_repositories_test.ts
@@ -1,0 +1,69 @@
+/**
+ * Tests for the "Related Repositories" section in README.md.
+ *
+ * Verifies that the canonical block defined in stSoftwareAU/NEAT-AI-core#18
+ * has been inserted into the README and lists every public NEAT-AI-* repo
+ * with a Mermaid dependency diagram.
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+
+const README_PATH = "README.md";
+
+function loadReadme(): string {
+  return Deno.readTextFileSync(README_PATH);
+}
+
+/** Extract the content of the "## Related Repositories" section. */
+function extractRelatedRepositoriesSection(content: string): string {
+  const match = content.match(/## Related Repositories\n([\s\S]*?)(?=\n## |\n# |$)/);
+  return match ? match[1] : "";
+}
+
+Deno.test("README.md contains a 'Related Repositories' section", () => {
+  const content = loadReadme();
+  assertStringIncludes(content, "## Related Repositories");
+});
+
+Deno.test("Related Repositories section lists all 7 NEAT-AI-* repos", () => {
+  const section = extractRelatedRepositoriesSection(loadReadme());
+  const required = [
+    "NEAT-AI-core",
+    "NEAT-AI-Discovery",
+    "NEAT-AI-Snapshot",
+    "NEAT-AI-scorer",
+    "NEAT-AI-Explore",
+    "NEAT-AI-Examples",
+  ];
+  for (const repo of required) {
+    assertStringIncludes(section, repo, `Section should mention ${repo}`);
+  }
+  // NEAT-AI must be referenced (without -suffix); use word-boundary regex.
+  const mentionsNeatAi = /NEAT-AI(?![-\w])/.test(section);
+  assertEquals(mentionsNeatAi, true, "Section should mention the NEAT-AI engine repo");
+});
+
+Deno.test("Related Repositories section links to the GitHub repos", () => {
+  const section = extractRelatedRepositoriesSection(loadReadme());
+  const links = [
+    "https://github.com/stSoftwareAU/NEAT-AI",
+    "https://github.com/stSoftwareAU/NEAT-AI-core",
+    "https://github.com/stSoftwareAU/NEAT-AI-Discovery",
+    "https://github.com/stSoftwareAU/NEAT-AI-Snapshot",
+    "https://github.com/stSoftwareAU/NEAT-AI-scorer",
+    "https://github.com/stSoftwareAU/NEAT-AI-Explore",
+    "https://github.com/stSoftwareAU/NEAT-AI-Examples",
+  ];
+  for (const link of links) {
+    assertStringIncludes(section, link, `Section should link to ${link}`);
+  }
+});
+
+Deno.test("Related Repositories section contains a Mermaid dependency diagram", () => {
+  const section = extractRelatedRepositoriesSection(loadReadme());
+  assertStringIncludes(section, "```mermaid", "Section should contain a Mermaid block");
+  // Canonical diagram uses a graph TD declaration with the labelled nodes.
+  assertStringIncludes(section, "graph TD");
+  assertStringIncludes(section, "Deno FFI");
+  assertStringIncludes(section, "path dependency");
+});


### PR DESCRIPTION
## Summary

Added a `## Related Repositories` section to `README.md` directly after the existing Examples
Overview Mermaid diagram, reusing the canonical block defined in stSoftwareAU/NEAT-AI-core#18
verbatim. The section lists every public NEAT-AI-* repository with a one-line description, links,
and a Mermaid dependency graph showing how the seven repos compose. Closes #32.

## Evidence

This is a documentation-only change. Verified by:

- `./quality.sh` — passes cleanly (lint, fmt, all unit tests, all example runners).
- New unit tests in `related_repositories_test.ts` assert that the section exists, mentions every
  required repo, links to each GitHub URL, and contains the canonical Mermaid dependency diagram.

The inserted dependency diagram (rendered on GitHub):

```mermaid
graph TD
    Core[NEAT-AI-core<br/>Rust shared lib]
    Main[NEAT-AI<br/>Deno/TypeScript engine]
    Discovery[NEAT-AI-Discovery<br/>Rust, via Deno FFI]
    Snapshot[NEAT-AI-Snapshot<br/>creature data]
    Scorer[NEAT-AI-scorer<br/>Rust scorer app]
    Explore[NEAT-AI-Explore<br/>visualiser]
    Examples[NEAT-AI-Examples<br/>tutorials]

    Main -->|Deno FFI| Discovery
    Main -->|produces| Snapshot
    Scorer -->|path dependency| Core
    Explore -->|reads| Snapshot
    Examples -->|depends on| Main
```

## Test Plan

- Added `related_repositories_test.ts` with four "what" tests:
  - `README.md contains a 'Related Repositories' section`
  - `Related Repositories section lists all 7 NEAT-AI-* repos`
  - `Related Repositories section links to the GitHub repos`
  - `Related Repositories section contains a Mermaid dependency diagram`
- Existing `mermaid_diagrams_test.ts` continues to pass — the new diagram is well-formed and uses a
  valid `graph TD` declaration.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-32 -->