### PR TITLE
ci: add Semgrep SAST scanning workflow (#34)

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,36 @@
+# Semgrep SAST Scanning workflow for NEAT-AI-Examples
+#
+# Performs Static Application Security Testing (SAST) on every pull
+# request. Runs the Semgrep CLI inside the official semgrep/semgrep
+# container image against the default community ruleset (p/default).
+#
+# The SEMGREP_APP_TOKEN secret is optional: when set, results are
+# uploaded to Semgrep AppSec Platform; when unset, the scan still runs
+# locally and fails the job if any findings are reported.
+#
+# Actions are pinned to 40-character commit SHAs (not floating tags)
+# in line with the project's supply-chain hardening rules.
+
+name: Semgrep
+
+on:
+  pull_request:
+    branches: ["*"]
+
+permissions:
+  contents: read
+
+jobs:
+  semgrep:
+    name: SAST scan
+    runs-on: ubuntu-latest
+    container:
+      image: semgrep/semgrep
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Run Semgrep
+        run: semgrep ci --config p/default
+        env:
+          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}

--- a/.github/workflows/semgrep_test.ts
+++ b/.github/workflows/semgrep_test.ts
@@ -1,0 +1,178 @@
+/**
+ * Tests for the Semgrep SAST Scanning workflow configuration.
+ *
+ * These tests parse the workflow YAML file and verify that it
+ * contains the required configuration to perform Static Application
+ * Security Testing (SAST) on pull requests using Semgrep.
+ */
+import { assertEquals, assertExists } from "@std/assert";
+import { parse } from "@std/yaml";
+
+const WORKFLOW_PATH = ".github/workflows/semgrep.yml";
+
+/** Helper to load and parse the workflow file. */
+function loadWorkflow(): Record<string, unknown> {
+  const content = Deno.readTextFileSync(WORKFLOW_PATH);
+  const parsed = parse(content);
+  if (typeof parsed !== "object" || parsed === null) {
+    throw new Error("Workflow file did not parse as an object");
+  }
+  return parsed as Record<string, unknown>;
+}
+
+Deno.test("semgrep workflow file exists and is valid YAML", () => {
+  const workflow = loadWorkflow();
+  assertExists(workflow, "Workflow should parse as a valid YAML object");
+});
+
+Deno.test("semgrep workflow has a descriptive name", () => {
+  const workflow = loadWorkflow();
+  assertExists(workflow.name, "Workflow should have a name field");
+  assertEquals(typeof workflow.name, "string");
+});
+
+Deno.test("semgrep workflow triggers on pull_request events", () => {
+  const workflow = loadWorkflow();
+
+  // The 'on' key may be parsed as the boolean `true` by some YAML parsers
+  // when unquoted, so we check for both 'on' and true as keys.
+  const triggers = (workflow["on"] ?? workflow[String(true)]) as Record<
+    string,
+    unknown
+  >;
+  assertExists(triggers, "Workflow should have trigger configuration");
+
+  const pr = triggers["pull_request"];
+  assertExists(pr, "Workflow should trigger on pull_request events");
+});
+
+Deno.test("semgrep workflow declares read-only contents permission", () => {
+  const workflow = loadWorkflow();
+  const permissions = workflow["permissions"] as Record<string, unknown>;
+  assertExists(permissions, "Workflow should declare permissions");
+  assertEquals(
+    permissions["contents"],
+    "read",
+    "Workflow should grant read-only access to repository contents",
+  );
+});
+
+Deno.test("semgrep workflow defines a semgrep job", () => {
+  const workflow = loadWorkflow();
+  const jobs = workflow["jobs"] as Record<string, unknown>;
+  assertExists(jobs, "Workflow should define jobs");
+  assertEquals(
+    Object.keys(jobs).length > 0,
+    true,
+    "Workflow should have at least one job",
+  );
+});
+
+Deno.test("semgrep workflow checks out the repository", () => {
+  const workflow = loadWorkflow();
+  const jobs = workflow["jobs"] as Record<string, Record<string, unknown>>;
+
+  let checksOut = false;
+  for (const name of Object.keys(jobs)) {
+    const steps = jobs[name]["steps"] as Array<Record<string, unknown>>;
+    if (!steps) continue;
+    for (const step of steps) {
+      const uses = step["uses"] as string | undefined;
+      if (uses && uses.startsWith("actions/checkout@")) {
+        checksOut = true;
+        break;
+      }
+    }
+    if (checksOut) break;
+  }
+  assertEquals(
+    checksOut,
+    true,
+    "Workflow should check out the repository before scanning",
+  );
+});
+
+Deno.test("semgrep workflow runs semgrep to scan for vulnerabilities", () => {
+  const workflow = loadWorkflow();
+  const jobs = workflow["jobs"] as Record<string, Record<string, unknown>>;
+
+  let runsSemgrep = false;
+  for (const name of Object.keys(jobs)) {
+    const steps = jobs[name]["steps"] as Array<Record<string, unknown>>;
+    if (!steps) continue;
+    for (const step of steps) {
+      const run = step["run"] as string | undefined;
+      if (run && run.includes("semgrep")) {
+        runsSemgrep = true;
+        break;
+      }
+      const uses = step["uses"] as string | undefined;
+      if (uses && uses.startsWith("semgrep/")) {
+        runsSemgrep = true;
+        break;
+      }
+    }
+    if (runsSemgrep) break;
+  }
+  assertEquals(
+    runsSemgrep,
+    true,
+    "Workflow should run semgrep to perform SAST scanning",
+  );
+});
+
+Deno.test("semgrep workflow uses the semgrep container image", () => {
+  const workflow = loadWorkflow();
+  const jobs = workflow["jobs"] as Record<string, Record<string, unknown>>;
+
+  let usesContainer = false;
+  for (const name of Object.keys(jobs)) {
+    const container = jobs[name]["container"];
+    if (typeof container === "string" && container.includes("semgrep")) {
+      usesContainer = true;
+      break;
+    }
+    if (typeof container === "object" && container !== null) {
+      const img = (container as Record<string, unknown>)["image"];
+      if (typeof img === "string" && img.includes("semgrep")) {
+        usesContainer = true;
+        break;
+      }
+    }
+  }
+  assertEquals(
+    usesContainer,
+    true,
+    "Workflow should run inside a semgrep container image",
+  );
+});
+
+Deno.test("semgrep workflow pins actions to commit SHAs", () => {
+  const workflow = loadWorkflow();
+  const jobs = workflow["jobs"] as Record<string, Record<string, unknown>>;
+
+  // Per the project's supply-chain rules, third-party actions should be
+  // pinned to a 40-character commit SHA rather than a moving tag.
+  const sha40 = /^[0-9a-f]{40}$/;
+
+  for (const name of Object.keys(jobs)) {
+    const steps = jobs[name]["steps"] as Array<Record<string, unknown>>;
+    if (!steps) continue;
+    for (const step of steps) {
+      const uses = step["uses"] as string | undefined;
+      if (!uses) continue;
+      const atIdx = uses.lastIndexOf("@");
+      assertEquals(
+        atIdx > 0,
+        true,
+        `Step '${uses}' should pin a version with '@'`,
+      );
+      const ref = uses.slice(atIdx + 1);
+      assertEquals(
+        sha40.test(ref),
+        true,
+        `Step '${uses}' should be pinned to a 40-character commit SHA, not '${ref}'`,
+      );
+    }
+  }
+});

--- a/docs/pr-summary-34.md
+++ b/docs/pr-summary-34.md
@@ -1,0 +1,47 @@
+## Summary
+
+Adds a Semgrep SAST scanning GitHub Actions workflow that runs on every pull
+request. The job runs the Semgrep CLI inside the official `semgrep/semgrep`
+container image against the `p/default` community ruleset, with results
+optionally uploaded to Semgrep AppSec Platform when `SEMGREP_APP_TOKEN` is
+configured. Closes #34.
+
+## Evidence
+
+This change is a CI configuration only — there is no UI to screenshot.
+Verification was done by:
+
+- Adding `.github/workflows/semgrep_test.ts` (TDD) with 9 tests that parse
+  the workflow YAML and assert on its structure (name, triggers,
+  permissions, jobs, container image, semgrep invocation, and SHA-pinned
+  actions). All tests pass:
+
+  ```
+  ok | 9 passed | 0 failed
+  ```
+
+- Running `./quality.sh` end-to-end — lint, format, full test suite, and
+  every example program completed successfully.
+
+```mermaid
+flowchart LR
+    PR[Pull request opened] --> WF[Semgrep workflow triggers]
+    WF --> CO[actions/checkout]
+    CO --> SCAN["semgrep ci --config p/default"]
+    SCAN -->|findings| FAIL[Fail PR check]
+    SCAN -->|clean| PASS[Pass PR check]
+```
+
+## Test Plan
+
+- Added `.github/workflows/semgrep_test.ts` covering:
+  - Workflow file exists and parses as valid YAML
+  - Workflow has a descriptive `name`
+  - Workflow triggers on `pull_request` events
+  - Workflow declares read-only `contents` permission
+  - Workflow defines at least one job
+  - Workflow checks out the repository
+  - Workflow runs `semgrep` to perform SAST scanning
+  - Workflow uses the `semgrep/semgrep` container image
+  - Workflow pins all `uses:` actions to 40-character commit SHAs
+- Re-ran the full project quality gate (`./quality.sh`) — all checks pass.


### PR DESCRIPTION
## Summary

Adds a Semgrep SAST scanning GitHub Actions workflow that runs on every pull
request. The job runs the Semgrep CLI inside the official `semgrep/semgrep`
container image against the `p/default` community ruleset, with results
optionally uploaded to Semgrep AppSec Platform when `SEMGREP_APP_TOKEN` is
configured. Closes #34.

## Evidence

This change is a CI configuration only — there is no UI to screenshot.
Verification was done by:

- Adding `.github/workflows/semgrep_test.ts` (TDD) with 9 tests that parse
  the workflow YAML and assert on its structure (name, triggers,
  permissions, jobs, container image, semgrep invocation, and SHA-pinned
  actions). All tests pass:

  ```
  ok | 9 passed | 0 failed
  ```

- Running `./quality.sh` end-to-end — lint, format, full test suite, and
  every example program completed successfully.

```mermaid
flowchart LR
    PR[Pull request opened] --> WF[Semgrep workflow triggers]
    WF --> CO[actions/checkout]
    CO --> SCAN["semgrep ci --config p/default"]
    SCAN -->|findings| FAIL[Fail PR check]
    SCAN -->|clean| PASS[Pass PR check]
```

## Test Plan

- Added `.github/workflows/semgrep_test.ts` covering:
  - Workflow file exists and parses as valid YAML
  - Workflow has a descriptive `name`
  - Workflow triggers on `pull_request` events
  - Workflow declares read-only `contents` permission
  - Workflow defines at least one job
  - Workflow checks out the repository
  - Workflow runs `semgrep` to perform SAST scanning
  - Workflow uses the `semgrep/semgrep` container image
  - Workflow pins all `uses:` actions to 40-character commit SHAs
- Re-ran the full project quality gate (`./quality.sh`) — all checks pass.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-34 -->