### PR TITLE
ci: add ShellCheck Lint workflow (#37)

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,35 @@
+# ShellCheck Lint workflow for NEAT-AI-Examples
+#
+# Lints every shell script in the repository on each pull request using
+# ShellCheck. Catches common bugs and portability problems in Bash scripts
+# (such as quality.sh and the per-example run.sh scripts) before they reach
+# the default branch.
+#
+# Severity is set to `warning` so style-only suggestions do not fail the
+# build but real warnings (and errors) do.
+#
+# Actions are pinned to 40-character commit SHAs (not floating tags)
+# in line with the project's supply-chain hardening rules.
+
+name: ShellCheck
+
+on:
+  pull_request:
+    branches: ["*"]
+
+permissions:
+  contents: read
+
+jobs:
+  shellcheck:
+    name: Lint shell scripts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # v2.0.0
+        with:
+          scandir: .
+          severity: warning

--- a/.github/workflows/shellcheck_test.ts
+++ b/.github/workflows/shellcheck_test.ts
@@ -1,0 +1,188 @@
+/**
+ * Tests for the ShellCheck Lint workflow configuration.
+ *
+ * These tests parse the workflow YAML file and verify that it
+ * contains the required configuration to lint shell scripts on
+ * pull requests using ShellCheck.
+ */
+import { assertEquals, assertExists } from "@std/assert";
+import { parse } from "@std/yaml";
+
+const WORKFLOW_PATH = ".github/workflows/shellcheck.yml";
+
+/** Helper to load and parse the workflow file. */
+function loadWorkflow(): Record<string, unknown> {
+  const content = Deno.readTextFileSync(WORKFLOW_PATH);
+  const parsed = parse(content);
+  if (typeof parsed !== "object" || parsed === null) {
+    throw new Error("Workflow file did not parse as an object");
+  }
+  return parsed as Record<string, unknown>;
+}
+
+Deno.test("shellcheck workflow file exists and is valid YAML", () => {
+  const workflow = loadWorkflow();
+  assertExists(workflow, "Workflow should parse as a valid YAML object");
+});
+
+Deno.test("shellcheck workflow has a descriptive name", () => {
+  const workflow = loadWorkflow();
+  assertExists(workflow.name, "Workflow should have a name field");
+  assertEquals(typeof workflow.name, "string");
+});
+
+Deno.test("shellcheck workflow triggers on pull_request events", () => {
+  const workflow = loadWorkflow();
+
+  // The 'on' key may be parsed as the boolean `true` by some YAML parsers
+  // when unquoted, so we check for both 'on' and true as keys.
+  const triggers = (workflow["on"] ?? workflow[String(true)]) as Record<
+    string,
+    unknown
+  >;
+  assertExists(triggers, "Workflow should have trigger configuration");
+
+  const pr = triggers["pull_request"];
+  assertExists(pr, "Workflow should trigger on pull_request events");
+});
+
+Deno.test("shellcheck workflow declares read-only contents permission", () => {
+  const workflow = loadWorkflow();
+  const permissions = workflow["permissions"] as Record<string, unknown>;
+  assertExists(permissions, "Workflow should declare permissions");
+  assertEquals(
+    permissions["contents"],
+    "read",
+    "Workflow should grant read-only access to repository contents",
+  );
+});
+
+Deno.test("shellcheck workflow defines a shellcheck job", () => {
+  const workflow = loadWorkflow();
+  const jobs = workflow["jobs"] as Record<string, unknown>;
+  assertExists(jobs, "Workflow should define jobs");
+  assertEquals(
+    Object.keys(jobs).length > 0,
+    true,
+    "Workflow should have at least one job",
+  );
+});
+
+Deno.test("shellcheck workflow checks out the repository", () => {
+  const workflow = loadWorkflow();
+  const jobs = workflow["jobs"] as Record<string, Record<string, unknown>>;
+
+  let checksOut = false;
+  for (const name of Object.keys(jobs)) {
+    const steps = jobs[name]["steps"] as Array<Record<string, unknown>>;
+    if (!steps) continue;
+    for (const step of steps) {
+      const uses = step["uses"] as string | undefined;
+      if (uses && uses.startsWith("actions/checkout@")) {
+        checksOut = true;
+        break;
+      }
+    }
+    if (checksOut) break;
+  }
+  assertEquals(
+    checksOut,
+    true,
+    "Workflow should check out the repository before scanning",
+  );
+});
+
+Deno.test("shellcheck workflow runs shellcheck to lint shell scripts", () => {
+  const workflow = loadWorkflow();
+  const jobs = workflow["jobs"] as Record<string, Record<string, unknown>>;
+
+  let runsShellcheck = false;
+  for (const name of Object.keys(jobs)) {
+    const steps = jobs[name]["steps"] as Array<Record<string, unknown>>;
+    if (!steps) continue;
+    for (const step of steps) {
+      const uses = step["uses"] as string | undefined;
+      if (uses && uses.startsWith("ludeeus/action-shellcheck@")) {
+        runsShellcheck = true;
+        break;
+      }
+      const run = step["run"] as string | undefined;
+      if (run && run.includes("shellcheck")) {
+        runsShellcheck = true;
+        break;
+      }
+    }
+    if (runsShellcheck) break;
+  }
+  assertEquals(
+    runsShellcheck,
+    true,
+    "Workflow should run shellcheck to lint shell scripts",
+  );
+});
+
+Deno.test("shellcheck workflow pins actions to commit SHAs", () => {
+  const workflow = loadWorkflow();
+  const jobs = workflow["jobs"] as Record<string, Record<string, unknown>>;
+
+  // Per the project's supply-chain rules, third-party actions should be
+  // pinned to a 40-character commit SHA rather than a moving tag.
+  const sha40 = /^[0-9a-f]{40}$/;
+
+  for (const name of Object.keys(jobs)) {
+    const steps = jobs[name]["steps"] as Array<Record<string, unknown>>;
+    if (!steps) continue;
+    for (const step of steps) {
+      const uses = step["uses"] as string | undefined;
+      if (!uses) continue;
+      const atIdx = uses.lastIndexOf("@");
+      assertEquals(
+        atIdx > 0,
+        true,
+        `Step '${uses}' should pin a version with '@'`,
+      );
+      const ref = uses.slice(atIdx + 1);
+      assertEquals(
+        sha40.test(ref),
+        true,
+        `Step '${uses}' should be pinned to a 40-character commit SHA, not '${ref}'`,
+      );
+    }
+  }
+});
+
+Deno.test("shellcheck workflow configures severity at warning or stricter", () => {
+  const workflow = loadWorkflow();
+  const jobs = workflow["jobs"] as Record<string, Record<string, unknown>>;
+
+  // The issue's suggested template requests `severity: warning` so that
+  // style-only suggestions do not fail the build but real warnings do.
+  const allowed = new Set(["warning", "error"]);
+
+  let hasSeverity = false;
+  for (const name of Object.keys(jobs)) {
+    const steps = jobs[name]["steps"] as Array<Record<string, unknown>>;
+    if (!steps) continue;
+    for (const step of steps) {
+      const withCfg = step["with"] as Record<string, unknown> | undefined;
+      if (withCfg && typeof withCfg["severity"] === "string") {
+        const sev = withCfg["severity"] as string;
+        assertEquals(
+          allowed.has(sev),
+          true,
+          `Severity '${sev}' should be one of ${[...allowed].join(", ")}`,
+        );
+        hasSeverity = true;
+      }
+      const run = step["run"] as string | undefined;
+      if (run && run.includes("--severity")) {
+        hasSeverity = true;
+      }
+    }
+  }
+  assertEquals(
+    hasSeverity,
+    true,
+    "Workflow should configure shellcheck severity (warning or error)",
+  );
+});

--- a/docs/archive_test.ts
+++ b/docs/archive_test.ts
@@ -37,6 +37,7 @@ Deno.test("No PR summary files remain in docs/ root", () => {
       if (entry.name === "pr-summary-33.md") continue;
       if (entry.name === "pr-summary-35.md") continue;
       if (entry.name === "pr-summary-36.md") continue;
+      if (entry.name === "pr-summary-37.md") continue;
       throw new Error(
         `Found unexpected PR summary file in docs/ root: ${entry.name}`,
       );

--- a/docs/pr-summary-37.md
+++ b/docs/pr-summary-37.md
@@ -1,0 +1,42 @@
+## Summary
+
+Adds a ShellCheck Lint GitHub Actions workflow that runs on every pull request, linting all shell
+scripts in the repository (`quality.sh` and the per-example `run.sh` scripts). The workflow uses the
+`ludeeus/action-shellcheck` action pinned to a 40-character commit SHA (v2.0.0), with
+`severity: warning` so style suggestions do not fail the build but real warnings and errors do.
+Closes #37.
+
+## Evidence
+
+This change is a CI configuration only — there is no UI to screenshot. Verification was done by:
+
+- Running `shellcheck --severity=warning` locally against every `*.sh` file in the repository — all
+  pass cleanly.
+- TDD: adding `.github/workflows/shellcheck_test.ts` with 9 tests that parse the workflow YAML and
+  assert on its structure (name, triggers, permissions, jobs, checkout step, shellcheck invocation,
+  SHA pinning, and severity configuration). Tests fail without the workflow file and pass once it is
+  added.
+
+```mermaid
+flowchart LR
+    PR[Pull Request] --> CO[actions/checkout]
+    CO --> SC[ludeeus/action-shellcheck severity=warning]
+    SC -->|pass| OK[CI green]
+    SC -->|warning or error| FAIL[CI red]
+```
+
+## Test Plan
+
+- Added `.github/workflows/shellcheck_test.ts` (9 tests):
+  - workflow file exists and is valid YAML
+  - has a descriptive name
+  - triggers on `pull_request` events
+  - declares read-only `contents` permission
+  - defines a shellcheck job
+  - checks out the repository
+  - runs shellcheck (via `ludeeus/action-shellcheck` or CLI)
+  - pins all third-party actions to 40-character commit SHAs
+  - configures `severity` at `warning` or stricter
+- Updated `docs/archive_test.ts` to allowlist `pr-summary-37.md`.
+- Existing `quality.sh` and `*/run.sh` scripts already pass `shellcheck --severity=warning`, so the
+  new workflow will be green from the first run.


### PR DESCRIPTION
## Summary

Adds a ShellCheck Lint GitHub Actions workflow that runs on every pull request, linting all shell
scripts in the repository (`quality.sh` and the per-example `run.sh` scripts). The workflow uses the
`ludeeus/action-shellcheck` action pinned to a 40-character commit SHA (v2.0.0), with
`severity: warning` so style suggestions do not fail the build but real warnings and errors do.
Closes #37.

## Evidence

This change is a CI configuration only — there is no UI to screenshot. Verification was done by:

- Running `shellcheck --severity=warning` locally against every `*.sh` file in the repository — all
  pass cleanly.
- TDD: adding `.github/workflows/shellcheck_test.ts` with 9 tests that parse the workflow YAML and
  assert on its structure (name, triggers, permissions, jobs, checkout step, shellcheck invocation,
  SHA pinning, and severity configuration). Tests fail without the workflow file and pass once it is
  added.

```mermaid
flowchart LR
    PR[Pull Request] --> CO[actions/checkout]
    CO --> SC[ludeeus/action-shellcheck severity=warning]
    SC -->|pass| OK[CI green]
    SC -->|warning or error| FAIL[CI red]
```

## Test Plan

- Added `.github/workflows/shellcheck_test.ts` (9 tests):
  - workflow file exists and is valid YAML
  - has a descriptive name
  - triggers on `pull_request` events
  - declares read-only `contents` permission
  - defines a shellcheck job
  - checks out the repository
  - runs shellcheck (via `ludeeus/action-shellcheck` or CLI)
  - pins all third-party actions to 40-character commit SHAs
  - configures `severity` at `warning` or stricter
- Updated `docs/archive_test.ts` to allowlist `pr-summary-37.md`.
- Existing `quality.sh` and `*/run.sh` scripts already pass `shellcheck --severity=warning`, so the
  new workflow will be green from the first run.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-37 -->