### PR TITLE
Main readme should be about how & what the examples are. (Issue #55)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,21 @@
 [![Licence](https://img.shields.io/badge/licence-Apache%202.0-blue.svg)](LICENSE)
 [![Deno](https://img.shields.io/badge/Deno-2.x-black?logo=deno)](https://deno.land/)
 
-Companion programs demonstrating how to use [`NEAT-AI`](https://github.com/stSoftwareAU/NEAT-AI).
-Each example is self-contained and generates its own synthetic data, so you can run them immediately
-without any external dependencies beyond Deno and the NEAT-AI library.
+Worked examples for [`NEAT-AI`](https://github.com/stSoftwareAU/NEAT-AI). Each example is a small,
+self-contained program that generates its own synthetic data, so you can run it immediately with no
+external dependencies beyond Deno (and, for Discovery, the NEAT-AI-Discovery Rust library).
 
-## 🧬 Examples Overview
+This page is the **what** and **how** at a glance. Follow the link in each row for the full
+walkthrough — the per-example README explains the workflow, options, and output artefacts.
+
+## 🧬 Examples at a Glance
+
+| Example                                                   | What it shows                                                                                            | How to run                      |
+| --------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| [🧬 Intelligent Design](intelligent_design/README.md)     | Systematically swap activation functions on hidden neurons to find better squashes than random mutation. | `./intelligent_design/run.sh`   |
+| [🔍 Discovery](discovery/README.md)                       | Cripple a creature by removing a neuron, then use evolutionary search to recover its behaviour.          | `./discovery/run.sh`            |
+| [🔀 Crossover](crossover/README.md)                       | Breed two parents with different architectures into an offspring and (optionally) evolve it further.     | `./crossover/run.sh`            |
+| [💡 Suggest Improvements](suggest_improvements/README.md) | Analyse the project and emit categorised improvement suggestions you can file as GitHub issues.          | `./suggest_improvements/run.sh` |
 
 ```mermaid
 flowchart TD
@@ -33,6 +43,123 @@ flowchart TD
     style CROSS fill:#e74c3c,stroke:#333,color:#fff
     style SUGGEST fill:#50e3c2,stroke:#333,color:#fff
 ```
+
+## 📦 Shared Utilities
+
+The [`common/`](common/) module provides the building blocks every example reuses:
+
+- 🎲 **`deterministic_random.ts`** — splitmix32-style seeded PRNG so runs are reproducible across
+  machines.
+- 📊 **`synthetic_data.ts`** — `generateSyntheticData` and `scoreCreature`. Each example picks its
+  own seed so data sets are independent but deterministic.
+- 📁 **`working_dirs.ts`** — `setupWorkingDirs` creates `data/`, `creatures/`, and `output/`
+  subdirectories under a per-example hidden root and clears `output/` on each run.
+
+```mermaid
+flowchart BT
+    subgraph common ["📦 common/"]
+        RNG["🎲 deterministic_random.ts<br/>Seeded PRNG"]
+        DATA["📊 synthetic_data.ts<br/>Data generation & scoring"]
+        DIRS["📁 working_dirs.ts<br/>Directory setup"]
+    end
+
+    subgraph examples ["🧬 Example Modules"]
+        ID["🧬 intelligent_design/"]
+        DISC["🔍 discovery/"]
+        CROSS["🔀 crossover/"]
+        SUGGEST["💡 suggest_improvements/"]
+    end
+
+    RNG --> DATA
+    common --> ID
+    common --> DISC
+    common --> CROSS
+    common --> SUGGEST
+
+    style common fill:#fff3cd,stroke:#f5a623,color:#333
+    style examples fill:#d4edda,stroke:#28a745,color:#333
+    style RNG fill:#f5a623,stroke:#333,color:#fff
+    style DATA fill:#f5a623,stroke:#333,color:#fff
+    style DIRS fill:#f5a623,stroke:#333,color:#fff
+```
+
+## 📋 Prerequisites
+
+- [Deno](https://deno.land/) 2.x
+- Discovery example only: the NEAT-AI-Discovery Rust library at
+  `~/.cargo/lib/libneat_ai_discovery.dylib` (or the appropriate extension for your platform). See
+  [discovery/README.md](discovery/README.md#-prerequisites) for build instructions.
+
+## ✅ Quality Check
+
+Run linting, formatting, type checks, unit tests, and every example end-to-end:
+
+```bash
+./quality.sh
+```
+
+```mermaid
+flowchart LR
+    LINT["🔎 Lint<br/>deno lint"]
+    FMT["✨ Format Check<br/>deno fmt --check"]
+    CHECK["🧐 Type Check<br/>deno check"]
+    TEST["🧪 Unit Tests<br/>deno test"]
+    EX["🚀 Example Runners<br/>run.sh scripts"]
+    PASS["✅ All Passed"]
+    FAIL["❌ Failed"]
+
+    LINT -->|pass| FMT
+    FMT -->|pass| CHECK
+    CHECK -->|pass| TEST
+    TEST -->|pass| EX
+    EX -->|pass| PASS
+    LINT -->|fail| FAIL
+    FMT -->|fail| FAIL
+    CHECK -->|fail| FAIL
+    TEST -->|fail| FAIL
+    EX -->|fail| FAIL
+
+    style LINT fill:#3498db,stroke:#333,color:#fff
+    style FMT fill:#9b59b6,stroke:#333,color:#fff
+    style CHECK fill:#f39c12,stroke:#333,color:#fff
+    style TEST fill:#e67e22,stroke:#333,color:#fff
+    style EX fill:#1abc9c,stroke:#333,color:#fff
+    style PASS fill:#2ecc71,stroke:#333,color:#fff
+    style FAIL fill:#e74c3c,stroke:#333,color:#fff
+```
+
+A GitHub Actions workflow ([`.github/workflows/quality.yml`](.github/workflows/quality.yml)) runs
+the same pipeline on every push and pull request to `Develop`. Failing checks block merges.
+
+> [!NOTE]
+> The Discovery example needs a native Rust FFI library that is not yet available in CI, so its step
+> is allowed to fail gracefully there.
+
+<details>
+<summary>🧪 Running tests, lint, fmt, and benchmarks independently</summary>
+
+```bash
+# All unit tests
+deno test --no-check --allow-read --allow-write --allow-env
+
+# A single test file
+deno test --no-check --allow-read --allow-write --allow-env discovery/discover_missing_neuron_test.ts
+
+# Lint, format check, and type check
+deno lint
+deno fmt --check
+deno check **/*.ts
+
+# Benchmarks (run in isolation, not part of quality.sh)
+deno bench --allow-read --allow-write --allow-env
+deno bench --allow-read --allow-write --allow-env discovery/
+```
+
+The formatter (configured in [`deno.json`](deno.json)) uses 2-space indentation, 100-character line
+width, and double quotes. See [AGENTS.md](AGENTS.md) for the full testing philosophy and the
+unit-tests-vs-benchmarks rules.
+
+</details>
 
 ## Related Repositories
 
@@ -68,363 +195,11 @@ graph TD
     Examples -->|depends on| Main
 ```
 
-## 📋 Prerequisites
-
-- [Deno](https://deno.land/) runtime installed
-- For the Discovery example: the NEAT-AI-Discovery Rust library installed at
-  `~/.cargo/lib/libneat_ai_discovery.dylib` (or the appropriate extension for your platform)
-
-## ✅ Quality Check
-
-Run linting, formatting checks, unit tests, and all examples to verify everything works correctly:
-
-```bash
-./quality.sh
-```
-
-This script runs the following pipeline:
-
-```mermaid
-flowchart LR
-    LINT["🔎 Lint<br/>deno lint"]
-    FMT["✨ Format Check<br/>deno fmt --check"]
-    CHECK["🧐 Type Check<br/>deno check"]
-    TEST["🧪 Unit Tests<br/>deno test"]
-    EX["🚀 Example Runners<br/>run.sh scripts"]
-    PASS["✅ All Passed"]
-    FAIL["❌ Failed"]
-
-    LINT -->|pass| FMT
-    FMT -->|pass| CHECK
-    CHECK -->|pass| TEST
-    TEST -->|pass| EX
-    EX -->|pass| PASS
-    LINT -->|fail| FAIL
-    FMT -->|fail| FAIL
-    CHECK -->|fail| FAIL
-    TEST -->|fail| FAIL
-    EX -->|fail| FAIL
-
-    style LINT fill:#3498db,stroke:#333,color:#fff
-    style FMT fill:#9b59b6,stroke:#333,color:#fff
-    style CHECK fill:#f39c12,stroke:#333,color:#fff
-    style TEST fill:#e67e22,stroke:#333,color:#fff
-    style EX fill:#1abc9c,stroke:#333,color:#fff
-    style PASS fill:#2ecc71,stroke:#333,color:#fff
-    style FAIL fill:#e74c3c,stroke:#333,color:#fff
-```
-
-1. 🔎 **Linting** — `deno lint` with the recommended rule set configured in `deno.json`.
-2. ✨ **Formatting** — `deno fmt --check` to enforce consistent style (2-space indent, 100-char line
-   width, double quotes).
-3. 🧐 **Type checking** — `deno check **/*.ts` runs the TypeScript type checker over every source
-   file, catching type mismatches before tests execute.
-4. 🧪 **Unit tests** — `deno test` across the project (tests live next to each module as `*_test.ts`
-   files).
-5. 🚀 **Example programs** — each example runner script, verifying the full end-to-end workflow.
-
-### 🔄 Continuous Integration
-
-A GitHub Actions workflow automatically runs the quality checks on every push and pull request to
-the `Develop` branch. The workflow configuration is at `.github/workflows/quality.yml`. Failing
-checks will block merges, ensuring all examples remain functional across contributions.
-
-> [!NOTE]
-> The Discovery example requires a native Rust FFI library that is not yet available in CI, so its
-> step is allowed to fail gracefully.
-
-<details>
-<summary>🧪 Running Tests Independently</summary>
-
-```bash
-# All unit tests
-deno test --no-check --allow-read --allow-write --allow-env
-
-# A single test file
-deno test --no-check --allow-read --allow-write --allow-env discovery/discover_missing_neuron_test.ts
-```
-
-</details>
-
-<details>
-<summary>✨ Linting, Formatting, and Type Checking</summary>
-
-The project uses `deno lint` (recommended rules), `deno fmt` for consistent code style, and
-`deno check` for static type checking. To run these locally:
-
-```bash
-# Check for lint issues
-deno lint
-
-# Check formatting (no changes)
-deno fmt --check
-
-# Auto-fix formatting
-deno fmt
-
-# Type-check every TypeScript file
-deno check **/*.ts
-```
-
-The formatting configuration (in `deno.json`) uses 2-space indentation, 100-character line width,
-and double quotes. All code must pass lint, format, and type checks before merging.
-
-</details>
-
-<details>
-<summary>⚡ Unit Tests vs Benchmarks</summary>
-
-- **Unit tests** verify _what_ the code produces (correct outputs, valid structures, expected side
-  effects). They never measure timing.
-- **Benchmarks** measure _how fast_ the code runs. They use `deno bench` and run in isolation.
-
-Unit tests run in parallel, so timing measurements inside them are unreliable. Keep performance
-assertions in benchmarks only. See [AGENTS.md](AGENTS.md) for the full testing guidelines.
-
-</details>
-
-<details>
-<summary>📊 Running Benchmarks</summary>
-
-Benchmarks live alongside their modules as `*_bench.ts` files and measure execution time for key
-operations such as creature activation, data generation, and scoring.
-
-```bash
-# All benchmarks
-deno bench --allow-read --allow-write --allow-env
-
-# Benchmarks for a specific module
-deno bench --allow-read --allow-write --allow-env discovery/
-deno bench --allow-read --allow-write --allow-env intelligent_design/
-```
-
-Benchmarks are intentionally separate from unit tests and are **not** included in `quality.sh` or
-CI, since they are designed to run in isolation on a consistent machine for meaningful results.
-
-</details>
-
-## 📦 Common Utilities
-
-```mermaid
-flowchart BT
-    subgraph common ["📦 common/"]
-        RNG["🎲 deterministic_random.ts<br/>Seeded PRNG"]
-        DATA["📊 synthetic_data.ts<br/>Data generation & scoring"]
-        DIRS["📁 working_dirs.ts<br/>Directory setup"]
-    end
-
-    subgraph examples ["🧬 Example Modules"]
-        ID["🧬 intelligent_design/"]
-        DISC["🔍 discovery/"]
-        CROSS["🔀 crossover/"]
-        SUGGEST["💡 suggest_improvements/"]
-    end
-
-    RNG --> DATA
-    common --> ID
-    common --> DISC
-    common --> CROSS
-    common --> SUGGEST
-
-    style common fill:#fff3cd,stroke:#f5a623,color:#333
-    style examples fill:#d4edda,stroke:#28a745,color:#333
-    style RNG fill:#f5a623,stroke:#333,color:#fff
-    style DATA fill:#f5a623,stroke:#333,color:#fff
-    style DIRS fill:#f5a623,stroke:#333,color:#fff
-```
-
-The `common/` module provides shared functionality used across all examples:
-
-- 🎲 **`deterministic_random.ts`** — A seeded pseudo-random number generator (PRNG) using a
-  splitmix32-style algorithm. Given the same seed, the sequence is identical across runs and
-  platforms.
-- 📊 **`synthetic_data.ts`** — Deterministic binary training data generation
-  (`generateSyntheticData`) and creature scoring (`scoreCreature`). Each example defines its own
-  `SyntheticConfig` with a unique seed so data sets are independent but reproducible.
-- 📁 **`working_dirs.ts`** — Standard working directory setup (`setupWorkingDirs`). Creates `data/`,
-  `creatures/`, and `output/` subdirectories under a given root, emptying `output/` on each run.
-
-Examples import from `common/` and add only their example-specific logic (creature definitions,
-domain-specific workflows).
-
-## 🧬 Intelligent Design: Squash Improvement Scan
-
-`intelligent_design/improve_squash_example.ts` demonstrates how to use the Intelligent Design module
-to systematically test different activation functions (squashes) for each hidden neuron in a
-creature. This technique is used in production workflows to optimise trained models by finding
-better squash functions than those produced by random mutation.
-
-### 🔧 How It Works
-
-```mermaid
-flowchart TD
-    CREATE["🧬 Create Reference Creature<br/>Several hidden neurons"]
-    DATA["📊 Generate Synthetic Data<br/>Binary training observations"]
-    SCORE["📏 Score Baseline<br/>Measure initial performance"]
-    SCAN["🔬 Scan Neurons<br/>Try target squash function"]
-    ALT["🔄 Try Alternatives<br/>Test other squash functions"]
-    COMBINE["🏆 Combine Improvements<br/>Build final optimised creature"]
-
-    CREATE --> DATA
-    DATA --> SCORE
-    SCORE --> SCAN
-    SCAN -->|improvement found| ALT
-    SCAN -->|no improvement| SCAN
-    ALT --> COMBINE
-
-    style CREATE fill:#7ed321,stroke:#333,color:#fff
-    style DATA fill:#4a90d9,stroke:#333,color:#fff
-    style SCORE fill:#f5a623,stroke:#333,color:#fff
-    style SCAN fill:#bd10e0,stroke:#333,color:#fff
-    style ALT fill:#e74c3c,stroke:#333,color:#fff
-    style COMBINE fill:#50e3c2,stroke:#333,color:#fff
-```
-
-1. Creates a reference creature with several hidden neurons
-2. Generates synthetic training data
-3. Scores the baseline creature
-4. Scans each hidden neuron, trying the target squash function
-5. For neurons that improve, tries alternative squash functions
-6. Combines the best improvements into a final creature
-
-### 🚀 Running the Example
-
-```bash
-./intelligent_design/run.sh
-```
-
-By default, the example tries `GELU` as the target squash. You can specify a different squash:
-
-```bash
-./intelligent_design/run.sh Swish
-./intelligent_design/run.sh LeakyReLU
-```
-
-> [!TIP]
-> The script writes all artefacts to `.synthetic-intelligent-design/`, a hidden directory ignored by
-> git. Poke around in there to inspect the creatures and data files!
-
-You will find:
-
-- `data/` – Binary training data for scoring
-- `creatures/baseline.json` – The original reference creature
-- `creatures/improved.json` – The improved creature (if improvements were found)
-- `output/` – Individual improved creatures for each neuron
-
-<details>
-<summary>🧠 Tacit Knowledge</summary>
-
-In production workflows, successful squash substitutions are recorded as "tacit knowledge" –
-mappings from neuron UUID to squash function. This knowledge can be shared across machines (via a
-"hive" file in a git repository) or kept local. When a model is loaded, tacit knowledge is applied
-to quickly reapply known-good squash substitutions without rescanning.
-
-</details>
-
-## 🔍 Discovery: Recover a Missing Neuron
-
-`discovery/discover_missing_neuron.ts` demonstrates the neuron discovery workflow. It creates a
-simple creature, generates synthetic training data, removes a hidden neuron to "cripple" the
-creature, and then runs discovery to attempt to recover the missing functionality.
-
-### 🔧 How It Works
-
-1. Creates a reference creature with 4 inputs, 4 hidden neurons, and 1 output
-2. Generates synthetic training data based on the creature's behaviour
-3. Removes a hidden neuron (LeakyReLU) to create a "crippled" creature
-4. Compares baseline and crippled scores to show the performance loss
-5. Runs `Creature.discoveryDir()` to search for improvements
-6. Reports whether discovery found a way to recover performance
-
-### 📋 Prerequisites
-
-> [!WARNING]
-> The Discovery example requires a native Rust FFI library. Make sure you have it installed before
-> running this example.
-
-- The NEAT-AI-Discovery Rust library must be installed. Build it via `cargo build --release` in the
-  NEAT-AI-Discovery repository and copy the resulting library to `~/.cargo/lib/`.
-- Deno with FFI permissions enabled
-
-### 🚀 Running the Example
-
-```bash
-./discovery/run.sh
-```
-
-The script writes all artefacts to `.synthetic-discovery/`, a hidden directory ignored by git. You
-will find:
-
-- `data/` – Binary training data containing the synthetic observations
-- `creatures/baseline.json` – The untouched reference creature
-- `creatures/crippled.json` – The creature with the target neuron removed
-- `creatures/discovered.json` – The best candidate returned by discovery (when available)
-
-## 🔀 Crossover: Breeding Two Creatures
-
-`crossover/crossover_example.ts` demonstrates how to breed two parent creatures with different
-neural network architectures to produce offspring. Crossover is a fundamental neuroevolution
-operation where traits from both parents are combined into a child creature.
-
-### 🔧 How It Works
-
-1. Creates two parent creatures with different activation functions (TANH/LOGISTIC vs
-   SELU/LeakyReLU)
-2. Generates synthetic training data based on parent A's behaviour
-3. Scores both parents against the training data
-4. Performs crossover — the mother's neurons are always included, the father's unique neurons have a
-   50% chance of inclusion, and matching weights/biases are blended (averaged)
-5. Scores the offspring and compares performance to both parents
-6. Optionally evolves the offspring for several generations to demonstrate multi-generation
-   improvement
-
-### 🚀 Running the Example
-
-```bash
-./crossover/run.sh
-```
-
-The script writes all artefacts to `.synthetic-crossover/`, a hidden directory ignored by git. You
-will find:
-
-- `data/` – Binary training data for scoring
-- `creatures/parent_a.json` – The first parent creature
-- `creatures/parent_b.json` – The second parent creature
-- `creatures/offspring.json` – The crossover offspring
-- `creatures/evolved.json` – The offspring after multi-generation evolution
-- `output/` – Additional offspring from repeated crossover
-
-## 💡 Suggest Improvements: Project Analyser
-
-`suggest_improvements/suggest_improvements.ts` analyses the NEAT-AI-Examples project structure and
-produces actionable improvement suggestions. These suggestions can be filed as GitHub issues using
-the GH CLI.
-
-### 🔧 How It Works
-
-1. Scans the project for common improvement opportunities
-2. Categorises suggestions (CI/CD, code quality, documentation, new examples)
-3. Produces a structured list with titles, descriptions, and categories
-4. Optionally writes a markdown summary to `.synthetic-suggest-improvements/`
-
-### 🚀 Running the Example
-
-```bash
-./suggest_improvements/run.sh
-```
-
-The output lists each improvement suggestion with its category and description. To file the
-suggestions as GitHub issues, use the GH CLI:
-
-```bash
-gh issue create --title "Improvement title" --label "enhancement" --body "Description"
-```
-
 ## 🤝 Contributing
 
-Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, how to add
-new examples, coding standards, and the pull request checklist.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, how to add new examples, coding
+standards, and the pull request checklist.
 
 ## 📄 Licence
 
-This project is licenced under the Apache Licence 2.0. See [LICENSE](LICENSE) for details.
+Apache Licence 2.0 — see [LICENSE](LICENSE).

--- a/crossover/README.md
+++ b/crossover/README.md
@@ -1,0 +1,60 @@
+# 🔀 Crossover — Breeding Two Creatures
+
+`crossover_example.ts` demonstrates how to breed two parent creatures with different neural network
+architectures to produce offspring. Crossover is a fundamental neuroevolution operation where traits
+from both parents are combined into a child creature.
+
+## 🔧 How It Works
+
+```mermaid
+flowchart TD
+    PA["👩 Parent A<br/>TANH / LOGISTIC"]
+    PB["👨 Parent B<br/>SELU / LeakyReLU"]
+    DATA["📊 Synthetic Data<br/>Generated from Parent A"]
+    SCORE["📏 Score Both Parents"]
+    CROSS["🔀 Crossover<br/>Mother's neurons always kept,<br/>Father's unique neurons 50%,<br/>Matching weights blended"]
+    OFF["🐣 Offspring"]
+    EVO["🧬 Multi-Generation Evolution"]
+
+    PA --> DATA
+    DATA --> SCORE
+    PA --> SCORE
+    PB --> SCORE
+    SCORE --> CROSS
+    CROSS --> OFF
+    OFF --> EVO
+
+    style PA fill:#bd10e0,stroke:#333,color:#fff
+    style PB fill:#4a90d9,stroke:#333,color:#fff
+    style DATA fill:#f5a623,stroke:#333,color:#fff
+    style SCORE fill:#f39c12,stroke:#333,color:#fff
+    style CROSS fill:#e74c3c,stroke:#333,color:#fff
+    style OFF fill:#7ed321,stroke:#333,color:#fff
+    style EVO fill:#50e3c2,stroke:#333,color:#fff
+```
+
+1. Creates two parent creatures with different activation functions (TANH/LOGISTIC vs
+   SELU/LeakyReLU)
+2. Generates synthetic training data based on parent A's behaviour
+3. Scores both parents against the training data
+4. Performs crossover — the mother's neurons are always included, the father's unique neurons have a
+   50% chance of inclusion, and matching weights/biases are blended (averaged)
+5. Scores the offspring and compares performance to both parents
+6. Optionally evolves the offspring for several generations to demonstrate multi-generation
+   improvement
+
+## 🚀 Running the Example
+
+```bash
+./crossover/run.sh
+```
+
+The script writes all artefacts to `.synthetic-crossover/`, a hidden directory ignored by git. You
+will find:
+
+- `data/` – Binary training data for scoring
+- `creatures/parent_a.json` – The first parent creature
+- `creatures/parent_b.json` – The second parent creature
+- `creatures/offspring.json` – The crossover offspring
+- `creatures/evolved.json` – The offspring after multi-generation evolution
+- `output/` – Additional offspring from repeated crossover

--- a/discovery/README.md
+++ b/discovery/README.md
@@ -1,0 +1,64 @@
+# 🔍 Discovery — Recover a Missing Neuron
+
+`discover_missing_neuron.ts` demonstrates the neuron discovery workflow. It creates a simple
+creature, generates synthetic training data, removes a hidden neuron to "cripple" the creature, and
+then runs discovery to attempt to recover the missing functionality.
+
+## 🔧 How It Works
+
+```mermaid
+flowchart TD
+    REF["🧬 Reference Creature<br/>4 inputs, 4 hidden, 1 output"]
+    DATA["📊 Synthetic Data<br/>Generated from reference"]
+    SCORE["📏 Score Baseline"]
+    CRIP["💥 Remove Hidden Neuron<br/>Crippled creature"]
+    LOSS["📉 Compare Scores<br/>Show performance loss"]
+    DISC["🔬 Discovery<br/>Search for replacement"]
+    REPORT["📈 Report<br/>Did discovery recover?"]
+
+    REF --> DATA
+    DATA --> SCORE
+    SCORE --> CRIP
+    CRIP --> LOSS
+    LOSS --> DISC
+    DISC --> REPORT
+
+    style REF fill:#7ed321,stroke:#333,color:#fff
+    style DATA fill:#4a90d9,stroke:#333,color:#fff
+    style SCORE fill:#f5a623,stroke:#333,color:#fff
+    style CRIP fill:#e74c3c,stroke:#333,color:#fff
+    style LOSS fill:#e67e22,stroke:#333,color:#fff
+    style DISC fill:#bd10e0,stroke:#333,color:#fff
+    style REPORT fill:#50e3c2,stroke:#333,color:#fff
+```
+
+1. Creates a reference creature with 4 inputs, 4 hidden neurons, and 1 output
+2. Generates synthetic training data based on the creature's behaviour
+3. Removes a hidden neuron (LeakyReLU) to create a "crippled" creature
+4. Compares baseline and crippled scores to show the performance loss
+5. Runs `Creature.discoveryDir()` to search for improvements
+6. Reports whether discovery found a way to recover performance
+
+## 📋 Prerequisites
+
+> [!WARNING]
+> The Discovery example requires a native Rust FFI library. Make sure you have it installed before
+> running this example.
+
+- The NEAT-AI-Discovery Rust library must be installed. Build it via `cargo build --release` in the
+  NEAT-AI-Discovery repository and copy the resulting library to `~/.cargo/lib/`.
+- Deno with FFI permissions enabled.
+
+## 🚀 Running the Example
+
+```bash
+./discovery/run.sh
+```
+
+The script writes all artefacts to `.synthetic-discovery/`, a hidden directory ignored by git. You
+will find:
+
+- `data/` – Binary training data containing the synthetic observations
+- `creatures/baseline.json` – The untouched reference creature
+- `creatures/crippled.json` – The creature with the target neuron removed
+- `creatures/discovered.json` – The best candidate returned by discovery (when available)

--- a/docs/pr-summary-55.md
+++ b/docs/pr-summary-55.md
@@ -1,0 +1,62 @@
+# Restructure main README around _what_ and _how_, link to per-example detail
+
+## Summary
+
+Refocused the main `README.md` on **what** the examples are and **how** to run them at a glance, and
+moved the per-example deep-dive content (How It Works walkthroughs, run options, output artefacts,
+and Discovery's FFI prerequisites) into per-example `README.md` files under each example directory.
+The main README now opens with an "Examples at a Glance" table linking to each detail page, keeps
+the high-level architecture and shared-utilities diagrams, and retains the Quality Check, Related
+Repositories, and Contributing sections.
+
+Closes #55.
+
+## Evidence
+
+This is a documentation-only change — no UI to screenshot. Verification is via the new
+`readme_structure_test.ts` plus the existing `mermaid_diagrams_test.ts`,
+`related_repositories_test.ts`, `contributing_test.ts`, and `lint_fmt_config_test.ts` — all 59
+documentation tests pass:
+
+```
+ok | 59 passed | 0 failed (139ms)
+```
+
+`deno lint` and `deno fmt --check` are clean. Pre-existing WASM-runtime failures in the example
+runners and pre-existing TypeScript type errors in the example sources (21 errors, 36 unit-test
+failures) are present on the base branch (`Develop` @ 04b467b) before any of my changes — verified
+via `git stash`. They are not introduced by this PR.
+
+### New documentation layout
+
+```mermaid
+flowchart LR
+    MAIN["📄 README.md<br/>What & How at a glance"]
+    ID["intelligent_design/README.md<br/>🧬 Squash improvement scan"]
+    DISC["discovery/README.md<br/>🔍 Recover a missing neuron"]
+    CROSS["crossover/README.md<br/>🔀 Breeding two creatures"]
+    SUGGEST["suggest_improvements/README.md<br/>💡 Project analyser"]
+
+    MAIN --> ID
+    MAIN --> DISC
+    MAIN --> CROSS
+    MAIN --> SUGGEST
+
+    style MAIN fill:#4a90d9,stroke:#333,color:#fff
+    style ID fill:#7ed321,stroke:#333,color:#fff
+    style DISC fill:#bd10e0,stroke:#333,color:#fff
+    style CROSS fill:#e74c3c,stroke:#333,color:#fff
+    style SUGGEST fill:#50e3c2,stroke:#333,color:#fff
+```
+
+## Test Plan
+
+- Added `readme_structure_test.ts` covering:
+  - Each example directory has a non-empty `README.md` that begins with a level-1 heading and
+    references its `run.sh` runner.
+  - The main `README.md` links to every per-example `README.md`.
+  - The main `README.md` names every example, has an Examples section, retains Prerequisites and
+    Quality Check sections, and no longer duplicates the per-example "How It Works" walkthroughs.
+- Verified `mermaid_diagrams_test.ts`, `related_repositories_test.ts`, `contributing_test.ts`, and
+  `lint_fmt_config_test.ts` all still pass against the new README.
+- `deno lint` and `deno fmt --check` clean.

--- a/intelligent_design/README.md
+++ b/intelligent_design/README.md
@@ -1,0 +1,70 @@
+# 🧬 Intelligent Design — Squash Improvement Scan
+
+`improve_squash_example.ts` demonstrates how to use the Intelligent Design module to systematically
+test different activation functions (squashes) for each hidden neuron in a creature. This technique
+is used in production workflows to optimise trained models by finding better squash functions than
+those produced by random mutation.
+
+## 🔧 How It Works
+
+```mermaid
+flowchart TD
+    CREATE["🧬 Create Reference Creature<br/>Several hidden neurons"]
+    DATA["📊 Generate Synthetic Data<br/>Binary training observations"]
+    SCORE["📏 Score Baseline<br/>Measure initial performance"]
+    SCAN["🔬 Scan Neurons<br/>Try target squash function"]
+    ALT["🔄 Try Alternatives<br/>Test other squash functions"]
+    COMBINE["🏆 Combine Improvements<br/>Build final optimised creature"]
+
+    CREATE --> DATA
+    DATA --> SCORE
+    SCORE --> SCAN
+    SCAN -->|improvement found| ALT
+    SCAN -->|no improvement| SCAN
+    ALT --> COMBINE
+
+    style CREATE fill:#7ed321,stroke:#333,color:#fff
+    style DATA fill:#4a90d9,stroke:#333,color:#fff
+    style SCORE fill:#f5a623,stroke:#333,color:#fff
+    style SCAN fill:#bd10e0,stroke:#333,color:#fff
+    style ALT fill:#e74c3c,stroke:#333,color:#fff
+    style COMBINE fill:#50e3c2,stroke:#333,color:#fff
+```
+
+1. Creates a reference creature with several hidden neurons
+2. Generates synthetic training data
+3. Scores the baseline creature
+4. Scans each hidden neuron, trying the target squash function
+5. For neurons that improve, tries alternative squash functions
+6. Combines the best improvements into a final creature
+
+## 🚀 Running the Example
+
+```bash
+./intelligent_design/run.sh
+```
+
+By default, the example tries `GELU` as the target squash. You can specify a different squash:
+
+```bash
+./intelligent_design/run.sh Swish
+./intelligent_design/run.sh LeakyReLU
+```
+
+> [!TIP]
+> The script writes all artefacts to `.synthetic-intelligent-design/`, a hidden directory ignored by
+> git. Poke around in there to inspect the creatures and data files!
+
+You will find:
+
+- `data/` – Binary training data for scoring
+- `creatures/baseline.json` – The original reference creature
+- `creatures/improved.json` – The improved creature (if improvements were found)
+- `output/` – Individual improved creatures for each neuron
+
+## 🧠 Tacit Knowledge
+
+In production workflows, successful squash substitutions are recorded as "tacit knowledge" —
+mappings from neuron UUID to squash function. This knowledge can be shared across machines (via a
+"hive" file in a git repository) or kept local. When a model is loaded, tacit knowledge is applied
+to quickly reapply known-good squash substitutions without rescanning.

--- a/readme_structure_test.ts
+++ b/readme_structure_test.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for the main README.md structure (issue #55).
+ *
+ * The main README should focus on _what_ the examples are and _how_ to run
+ * them at a glance, with deeper detail living in per-example README files.
+ * These are "what" tests — they read the actual README files and verify the
+ * structure, links, and minimum content requirements.
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+
+const README_PATH = "README.md";
+
+const EXAMPLE_DIRS = [
+  "crossover",
+  "discovery",
+  "intelligent_design",
+  "suggest_improvements",
+] as const;
+
+function loadReadme(): string {
+  return Deno.readTextFileSync(README_PATH);
+}
+
+/* ------------------------------------------------------------------ */
+/*  Per-example README files exist                                     */
+/* ------------------------------------------------------------------ */
+
+for (const dir of EXAMPLE_DIRS) {
+  Deno.test(`${dir}/README.md exists and is non-empty`, () => {
+    const path = `${dir}/README.md`;
+    const content = Deno.readTextFileSync(path);
+    assertEquals(
+      content.trim().length > 0,
+      true,
+      `${path} should not be empty`,
+    );
+  });
+
+  Deno.test(`${dir}/README.md begins with a heading`, () => {
+    const content = Deno.readTextFileSync(`${dir}/README.md`);
+    const firstNonBlank = content.split("\n").find((l) => l.trim().length > 0) ?? "";
+    assertEquals(
+      firstNonBlank.startsWith("# "),
+      true,
+      `${dir}/README.md should start with a level-1 heading, got: "${firstNonBlank}"`,
+    );
+  });
+
+  Deno.test(`${dir}/README.md describes how to run the example`, () => {
+    const content = Deno.readTextFileSync(`${dir}/README.md`);
+    assertStringIncludes(
+      content,
+      "run.sh",
+      `${dir}/README.md should mention the run.sh runner script`,
+    );
+  });
+}
+
+/* ------------------------------------------------------------------ */
+/*  Main README links to each per-example README                       */
+/* ------------------------------------------------------------------ */
+
+for (const dir of EXAMPLE_DIRS) {
+  Deno.test(`README.md links to ${dir}/README.md`, () => {
+    const content = loadReadme();
+    const linkPattern = new RegExp(`\\]\\(\\.?/?${dir}/README\\.md\\)`);
+    assertEquals(
+      linkPattern.test(content),
+      true,
+      `README.md should link to ${dir}/README.md so readers can follow through to detail`,
+    );
+  });
+}
+
+/* ------------------------------------------------------------------ */
+/*  Main README is focused: what & how, not a deep dive                */
+/* ------------------------------------------------------------------ */
+
+Deno.test("README.md introduces every example by name", () => {
+  const content = loadReadme();
+  const required = [
+    "Intelligent Design",
+    "Discovery",
+    "Crossover",
+    "Suggest Improvements",
+  ];
+  for (const name of required) {
+    assertStringIncludes(
+      content,
+      name,
+      `README.md should name the ${name} example`,
+    );
+  }
+});
+
+Deno.test("README.md keeps a short one-line summary for each example", () => {
+  // The Examples Overview section should hold a concise table or bullet
+  // list. We verify it appears before any deep-dive content by checking
+  // that a "## Examples" heading exists.
+  const content = loadReadme();
+  assertEquals(
+    /^##\s+.*Examples?/im.test(content),
+    true,
+    "README.md should have an Examples section heading",
+  );
+});
+
+Deno.test("README.md does not duplicate the per-example deep-dive content", () => {
+  // The main README should no longer carry the detailed "How It Works"
+  // numbered walkthroughs that now live in the per-example READMEs.
+  // We allow a single "How It Works" reference (e.g. as an anchor link),
+  // but more than that means the deep-dive content was duplicated.
+  const content = loadReadme();
+  const matches = content.match(/How It Works/g) ?? [];
+  assertEquals(
+    matches.length <= 1,
+    true,
+    `README.md should not repeat "How It Works" deep dives, found ${matches.length} occurrences`,
+  );
+});
+
+Deno.test("README.md retains the prerequisites section", () => {
+  const content = loadReadme();
+  assertStringIncludes(
+    content,
+    "Prerequisites",
+    "README.md should keep a top-level Prerequisites section",
+  );
+});
+
+Deno.test("README.md retains the Quality Check section", () => {
+  const content = loadReadme();
+  assertStringIncludes(
+    content,
+    "Quality Check",
+    "README.md should keep a Quality Check section",
+  );
+});

--- a/suggest_improvements/README.md
+++ b/suggest_improvements/README.md
@@ -1,0 +1,41 @@
+# 💡 Suggest Improvements — Project Analyser
+
+`suggest_improvements.ts` analyses the NEAT-AI-Examples project structure and produces actionable
+improvement suggestions. These suggestions can be filed as GitHub issues using the `gh` CLI.
+
+## 🔧 How It Works
+
+```mermaid
+flowchart LR
+    SCAN["🔎 Scan Project<br/>CI/CD, code, docs, examples"]
+    CAT["🗂️ Categorise<br/>Group by area"]
+    LIST["📋 Structured List<br/>title, description, category"]
+    OUT["📝 Markdown Summary<br/>.synthetic-suggest-improvements/"]
+
+    SCAN --> CAT
+    CAT --> LIST
+    LIST --> OUT
+
+    style SCAN fill:#4a90d9,stroke:#333,color:#fff
+    style CAT fill:#f5a623,stroke:#333,color:#fff
+    style LIST fill:#7ed321,stroke:#333,color:#fff
+    style OUT fill:#50e3c2,stroke:#333,color:#fff
+```
+
+1. Scans the project for common improvement opportunities
+2. Categorises suggestions (CI/CD, code quality, documentation, new examples)
+3. Produces a structured list with titles, descriptions, and categories
+4. Optionally writes a markdown summary to `.synthetic-suggest-improvements/`
+
+## 🚀 Running the Example
+
+```bash
+./suggest_improvements/run.sh
+```
+
+The output lists each improvement suggestion with its category and description. To file the
+suggestions as GitHub issues, use the `gh` CLI:
+
+```bash
+gh issue create --title "Improvement title" --label "enhancement" --body "Description"
+```


### PR DESCRIPTION
# Restructure main README around _what_ and _how_, link to per-example detail

## Summary

Refocused the main `README.md` on **what** the examples are and **how** to run them at a glance, and
moved the per-example deep-dive content (How It Works walkthroughs, run options, output artefacts,
and Discovery's FFI prerequisites) into per-example `README.md` files under each example directory.
The main README now opens with an "Examples at a Glance" table linking to each detail page, keeps
the high-level architecture and shared-utilities diagrams, and retains the Quality Check, Related
Repositories, and Contributing sections.

Closes #55.

## Evidence

This is a documentation-only change — no UI to screenshot. Verification is via the new
`readme_structure_test.ts` plus the existing `mermaid_diagrams_test.ts`,
`related_repositories_test.ts`, `contributing_test.ts`, and `lint_fmt_config_test.ts` — all 59
documentation tests pass:

```
ok | 59 passed | 0 failed (139ms)
```

`deno lint` and `deno fmt --check` are clean. Pre-existing WASM-runtime failures in the example
runners and pre-existing TypeScript type errors in the example sources (21 errors, 36 unit-test
failures) are present on the base branch (`Develop` @ 04b467b) before any of my changes — verified
via `git stash`. They are not introduced by this PR.

### New documentation layout

```mermaid
flowchart LR
    MAIN["📄 README.md<br/>What & How at a glance"]
    ID["intelligent_design/README.md<br/>🧬 Squash improvement scan"]
    DISC["discovery/README.md<br/>🔍 Recover a missing neuron"]
    CROSS["crossover/README.md<br/>🔀 Breeding two creatures"]
    SUGGEST["suggest_improvements/README.md<br/>💡 Project analyser"]

    MAIN --> ID
    MAIN --> DISC
    MAIN --> CROSS
    MAIN --> SUGGEST

    style MAIN fill:#4a90d9,stroke:#333,color:#fff
    style ID fill:#7ed321,stroke:#333,color:#fff
    style DISC fill:#bd10e0,stroke:#333,color:#fff
    style CROSS fill:#e74c3c,stroke:#333,color:#fff
    style SUGGEST fill:#50e3c2,stroke:#333,color:#fff
```

## Test Plan

- Added `readme_structure_test.ts` covering:
  - Each example directory has a non-empty `README.md` that begins with a level-1 heading and
    references its `run.sh` runner.
  - The main `README.md` links to every per-example `README.md`.
  - The main `README.md` names every example, has an Examples section, retains Prerequisites and
    Quality Check sections, and no longer duplicates the per-example "How It Works" walkthroughs.
- Verified `mermaid_diagrams_test.ts`, `related_repositories_test.ts`, `contributing_test.ts`, and
  `lint_fmt_config_test.ts` all still pass against the new README.
- `deno lint` and `deno fmt --check` clean.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-55 -->