### PR TITLE
Add Markdown Lint workflow (Issue #49)

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -1,0 +1,36 @@
+# Markdown Lint workflow for NEAT-AI-Examples
+#
+# Runs markdownlint-cli2 against every Markdown file in the repository
+# on each pull request and push to the default branch. Rule
+# customisations live in `.markdownlint-cli2.jsonc` at the repository
+# root.
+
+name: Markdown Lint
+
+on:
+  pull_request:
+    branches: ["*"]
+  push:
+    branches: [main, master]
+
+permissions:
+  contents: read
+
+jobs:
+  markdownlint:
+    name: Lint Markdown
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "lts/*"
+
+      - name: Install markdownlint-cli2
+        run: npm install -g markdownlint-cli2
+
+      - name: Run markdownlint-cli2
+        run: markdownlint-cli2 "**/*.md" "#node_modules"

--- a/.github/workflows/markdown_lint_test.ts
+++ b/.github/workflows/markdown_lint_test.ts
@@ -1,0 +1,183 @@
+/**
+ * Tests for the Markdown Lint workflow configuration.
+ *
+ * These tests parse the workflow YAML file and verify that it
+ * contains the required configuration to lint Markdown files on
+ * pull requests and pushes via markdownlint-cli2.
+ */
+import { assertEquals, assertExists } from "@std/assert";
+import { parse } from "@std/yaml";
+
+const WORKFLOW_PATH = ".github/workflows/markdown-lint.yml";
+
+/** Helper to load and parse the workflow file. */
+function loadWorkflow(): Record<string, unknown> {
+  const content = Deno.readTextFileSync(WORKFLOW_PATH);
+  const parsed = parse(content);
+  if (typeof parsed !== "object" || parsed === null) {
+    throw new Error("Workflow file did not parse as an object");
+  }
+  return parsed as Record<string, unknown>;
+}
+
+Deno.test("markdown-lint workflow file exists and is valid YAML", () => {
+  const workflow = loadWorkflow();
+  assertExists(workflow, "Workflow should parse as a valid YAML object");
+});
+
+Deno.test("markdown-lint workflow has a descriptive name", () => {
+  const workflow = loadWorkflow();
+  assertExists(workflow.name, "Workflow should have a name field");
+  assertEquals(typeof workflow.name, "string");
+});
+
+Deno.test("markdown-lint workflow triggers on pull_request and push events", () => {
+  const workflow = loadWorkflow();
+
+  // The 'on' key may be parsed as the boolean `true` by some YAML parsers
+  // when unquoted, so we check for both 'on' and true as keys.
+  const triggers = (workflow["on"] ?? workflow[String(true)]) as Record<
+    string,
+    unknown
+  >;
+  assertExists(triggers, "Workflow should have trigger configuration");
+
+  assertExists(
+    triggers["pull_request"],
+    "Workflow should trigger on pull_request events",
+  );
+  assertExists(triggers["push"], "Workflow should trigger on push events");
+});
+
+Deno.test("markdown-lint workflow declares read-only contents permission", () => {
+  const workflow = loadWorkflow();
+  const permissions = workflow["permissions"] as Record<string, unknown>;
+  assertExists(permissions, "Workflow should declare permissions");
+  assertEquals(
+    permissions["contents"],
+    "read",
+    "Workflow should grant read-only access to repository contents",
+  );
+});
+
+Deno.test("markdown-lint workflow defines at least one job", () => {
+  const workflow = loadWorkflow();
+  const jobs = workflow["jobs"] as Record<string, unknown>;
+  assertExists(jobs, "Workflow should define jobs");
+  assertEquals(
+    Object.keys(jobs).length > 0,
+    true,
+    "Workflow should have at least one job",
+  );
+});
+
+Deno.test("markdown-lint workflow checks out the repository", () => {
+  const workflow = loadWorkflow();
+  const jobs = workflow["jobs"] as Record<string, Record<string, unknown>>;
+
+  let checksOut = false;
+  for (const name of Object.keys(jobs)) {
+    const steps = jobs[name]["steps"] as Array<Record<string, unknown>>;
+    if (!steps) continue;
+    for (const step of steps) {
+      const uses = step["uses"] as string | undefined;
+      if (uses && uses.startsWith("actions/checkout@")) {
+        checksOut = true;
+        break;
+      }
+    }
+    if (checksOut) break;
+  }
+  assertEquals(
+    checksOut,
+    true,
+    "Workflow should check out the repository before linting",
+  );
+});
+
+Deno.test("markdown-lint workflow sets up Node.js", () => {
+  const workflow = loadWorkflow();
+  const jobs = workflow["jobs"] as Record<string, Record<string, unknown>>;
+
+  let setsUpNode = false;
+  for (const name of Object.keys(jobs)) {
+    const steps = jobs[name]["steps"] as Array<Record<string, unknown>>;
+    if (!steps) continue;
+    for (const step of steps) {
+      const uses = step["uses"] as string | undefined;
+      if (uses && uses.startsWith("actions/setup-node@")) {
+        setsUpNode = true;
+        break;
+      }
+    }
+    if (setsUpNode) break;
+  }
+  assertEquals(
+    setsUpNode,
+    true,
+    "Workflow should set up Node.js so markdownlint-cli2 can run",
+  );
+});
+
+Deno.test("markdown-lint workflow runs markdownlint-cli2", () => {
+  const workflow = loadWorkflow();
+  const jobs = workflow["jobs"] as Record<string, Record<string, unknown>>;
+
+  let runsLinter = false;
+  for (const name of Object.keys(jobs)) {
+    const steps = jobs[name]["steps"] as Array<Record<string, unknown>>;
+    if (!steps) continue;
+    for (const step of steps) {
+      const run = step["run"] as string | undefined;
+      if (run && run.includes("markdownlint-cli2")) {
+        runsLinter = true;
+        break;
+      }
+    }
+    if (runsLinter) break;
+  }
+  assertEquals(
+    runsLinter,
+    true,
+    "Workflow should invoke markdownlint-cli2 to scan Markdown files",
+  );
+});
+
+Deno.test("markdown-lint workflow pins actions to commit SHAs", () => {
+  const workflow = loadWorkflow();
+  const jobs = workflow["jobs"] as Record<string, Record<string, unknown>>;
+
+  // Per the project's supply-chain rules, third-party actions should be
+  // pinned to a 40-character commit SHA rather than a moving tag.
+  const sha40 = /^[0-9a-f]{40}$/;
+
+  for (const name of Object.keys(jobs)) {
+    const steps = jobs[name]["steps"] as Array<Record<string, unknown>>;
+    if (!steps) continue;
+    for (const step of steps) {
+      const uses = step["uses"] as string | undefined;
+      if (!uses) continue;
+      const atIdx = uses.lastIndexOf("@");
+      assertEquals(
+        atIdx > 0,
+        true,
+        `Step '${uses}' should pin a version with '@'`,
+      );
+      const ref = uses.slice(atIdx + 1);
+      assertEquals(
+        sha40.test(ref),
+        true,
+        `Step '${uses}' should be pinned to a 40-character commit SHA, not '${ref}'`,
+      );
+    }
+  }
+});
+
+Deno.test("markdownlint-cli2 config file exists and is valid", () => {
+  const content = Deno.readTextFileSync(".markdownlint-cli2.jsonc");
+  // Strip JSONC line comments before parsing.
+  const stripped = content.replace(/^\s*\/\/.*$/gm, "");
+  const cfg = JSON.parse(stripped);
+  assertExists(cfg, "Config should parse as JSON");
+  assertExists(cfg.config, "Config should expose a 'config' object of rules");
+});

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 *~
 !.gitignore
 !.github
+!.markdownlint-cli2.jsonc
 deno.lock
 run.log

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,30 @@
+// markdownlint-cli2 configuration
+//
+// Tunes the default markdownlint rules to suit this repository.
+// The CI workflow `.github/workflows/markdown-lint.yml` runs
+// `markdownlint-cli2` against all Markdown files.
+{
+  "config": {
+    // MD013: line length — the repo favours readable prose over hard wrapping.
+    "MD013": false,
+    // MD033: inline HTML — README uses <details>/<summary> for collapsible
+    // sections, which is supported on GitHub.
+    "MD033": false,
+    // MD041: first line in a file should be a top-level heading — pr-summary
+    // files in docs/ legitimately start with `## Summary`.
+    "MD041": false,
+    // MD040: fenced code blocks language — historic pr-summary fences omit a
+    // language; not worth a sweeping rewrite.
+    "MD040": false,
+    // MD018: missing space after hash — one archived pr-summary uses `#NN.`
+    // as a literal issue reference, not a heading.
+    "MD018": false,
+    // MD029: ordered list prefix — archived pr-summary intersperses prose
+    // between numbered items; rewriting historical docs is out of scope.
+    "MD029": false
+  },
+  "ignores": [
+    "node_modules",
+    ".git"
+  ]
+}

--- a/docs/pr-summary-49.md
+++ b/docs/pr-summary-49.md
@@ -1,0 +1,56 @@
+## Summary
+
+Added a Markdown Lint GitHub Actions workflow that runs `markdownlint-cli2` against every `.md` file
+on each pull request and push to the default branch. A repository-level `.markdownlint-cli2.jsonc`
+config tunes a few rules so existing prose, archived pr-summaries, and the `<details>` collapsible
+sections in `README.md` all lint clean. Closes #49.
+
+## Evidence
+
+This change is purely CI/CD configuration with no UI or runtime impact.
+
+- `markdownlint-cli2 "**/*.md" "#node_modules"` runs cleanly against the current tree (28 files, 0
+  errors).
+- `deno test --no-check --allow-read --allow-write --allow-env
+  .github/workflows/markdown_lint_test.ts`
+  — 10/10 tests pass.
+- Quality gate run: `./quality.sh` — lint, format, type check, and unit tests all pass. The
+  pre-existing `crossover/run.sh` failure (WASM loader) is unrelated to this change and reproduces
+  on a clean tree.
+
+```mermaid
+flowchart LR
+    PR[Pull request /<br/>push to main] --> WF[Markdown Lint workflow]
+    WF --> CO[actions/checkout]
+    CO --> NO[actions/setup-node lts/*]
+    NO --> IN[npm i -g markdownlint-cli2]
+    IN --> RU[markdownlint-cli2 **/*.md]
+    RU --> CFG[.markdownlint-cli2.jsonc<br/>rule overrides]
+    RU -- pass --> OK[CI green]
+    RU -- fail --> NG[CI red, blocks merge]
+```
+
+## Test Plan
+
+- Added `.github/workflows/markdown_lint_test.ts` with 10 tests that parse the workflow YAML and
+  assert:
+  - File exists and is valid YAML.
+  - Workflow has a name.
+  - Triggers on `pull_request` and `push` events.
+  - Declares `contents: read` permission.
+  - Defines at least one job.
+  - Job checks out the repository.
+  - Job sets up Node.js.
+  - Job invokes `markdownlint-cli2`.
+  - Every `uses:` reference is pinned to a 40-character commit SHA (supply-chain rule).
+  - `.markdownlint-cli2.jsonc` exists and parses as JSON.
+- Manually ran `markdownlint-cli2` locally and confirmed 0 errors.
+- Manually ran `./quality.sh` and confirmed lint, format, type check, and unit tests all pass.
+
+## Files
+
+- `.github/workflows/markdown-lint.yml` — new workflow.
+- `.github/workflows/markdown_lint_test.ts` — workflow tests.
+- `.markdownlint-cli2.jsonc` — rule config (disables MD013 line-length, MD033 inline HTML, MD041
+  first-line-h1, MD040 fenced-code-language, MD018 missing-space-atx, MD029 ordered-list-prefix to
+  keep historic archived pr-summaries clean).


### PR DESCRIPTION
## Summary

Added a Markdown Lint GitHub Actions workflow that runs `markdownlint-cli2` against every `.md` file
on each pull request and push to the default branch. A repository-level `.markdownlint-cli2.jsonc`
config tunes a few rules so existing prose, archived pr-summaries, and the `<details>` collapsible
sections in `README.md` all lint clean. Closes #49.

## Evidence

This change is purely CI/CD configuration with no UI or runtime impact.

- `markdownlint-cli2 "**/*.md" "#node_modules"` runs cleanly against the current tree (28 files, 0
  errors).
- `deno test --no-check --allow-read --allow-write --allow-env
  .github/workflows/markdown_lint_test.ts`
  — 10/10 tests pass.
- Quality gate run: `./quality.sh` — lint, format, type check, and unit tests all pass. The
  pre-existing `crossover/run.sh` failure (WASM loader) is unrelated to this change and reproduces
  on a clean tree.

```mermaid
flowchart LR
    PR[Pull request /<br/>push to main] --> WF[Markdown Lint workflow]
    WF --> CO[actions/checkout]
    CO --> NO[actions/setup-node lts/*]
    NO --> IN[npm i -g markdownlint-cli2]
    IN --> RU[markdownlint-cli2 **/*.md]
    RU --> CFG[.markdownlint-cli2.jsonc<br/>rule overrides]
    RU -- pass --> OK[CI green]
    RU -- fail --> NG[CI red, blocks merge]
```

## Test Plan

- Added `.github/workflows/markdown_lint_test.ts` with 10 tests that parse the workflow YAML and
  assert:
  - File exists and is valid YAML.
  - Workflow has a name.
  - Triggers on `pull_request` and `push` events.
  - Declares `contents: read` permission.
  - Defines at least one job.
  - Job checks out the repository.
  - Job sets up Node.js.
  - Job invokes `markdownlint-cli2`.
  - Every `uses:` reference is pinned to a 40-character commit SHA (supply-chain rule).
  - `.markdownlint-cli2.jsonc` exists and parses as JSON.
- Manually ran `markdownlint-cli2` locally and confirmed 0 errors.
- Manually ran `./quality.sh` and confirmed lint, format, type check, and unit tests all pass.

## Files

- `.github/workflows/markdown-lint.yml` — new workflow.
- `.github/workflows/markdown_lint_test.ts` — workflow tests.
- `.markdownlint-cli2.jsonc` — rule config (disables MD013 line-length, MD033 inline HTML, MD041
  first-line-h1, MD040 fenced-code-language, MD018 missing-space-atx, MD029 ordered-list-prefix to
  keep historic archived pr-summaries clean).



---

🤖 Processed by: stservice<!-- vibe-worker-issue-49 -->