### PR TITLE
ci: pass ACTIONS_PUSH PAT to deno-outdated PR step

### DIFF
--- a/.github/workflows/deno-outdated.yml
+++ b/.github/workflows/deno-outdated.yml
@@ -35,6 +35,10 @@ jobs:
       - name: Open pull request with updates
         uses: peter-evans/create-pull-request@v7
         with:
+          # Org-level PAT (Issue #1636); falls back to GITHUB_TOKEN when
+          # the secret is unset. Using the PAT ensures downstream PR
+          # workflows fire on the resulting pull request.
+          token: ${{ secrets.ACTIONS_PUSH || secrets.GITHUB_TOKEN }}
           commit-message: "chore: update Deno dependencies"
           title: "chore: update Deno dependencies"
           branch: chore/deno-outdated

--- a/.github/workflows/deno_outdated_test.ts
+++ b/.github/workflows/deno_outdated_test.ts
@@ -151,3 +151,36 @@ Deno.test("deno-outdated workflow opens a pull request via create-pull-request a
     "Workflow should use peter-evans/create-pull-request to open the update PR",
   );
 });
+
+Deno.test("deno-outdated workflow uses ACTIONS_PUSH PAT with GITHUB_TOKEN fallback", () => {
+  // Issue #1636: passing the org-level PAT to create-pull-request lets
+  // the resulting PR trigger downstream workflows (e.g. quality.yml).
+  // Without this token, PRs opened by GITHUB_TOKEN do not fire `on: pull_request`.
+  const workflow = loadWorkflow();
+  const jobs = workflow["jobs"] as Record<string, Record<string, unknown>>;
+
+  let token: string | undefined;
+  for (const name of Object.keys(jobs)) {
+    const steps = jobs[name]["steps"] as Array<Record<string, unknown>>;
+    if (!steps) continue;
+    for (const step of steps) {
+      const uses = step["uses"] as string | undefined;
+      if (uses && uses.startsWith("peter-evans/create-pull-request@")) {
+        const withBlock = step["with"] as Record<string, unknown> | undefined;
+        if (withBlock && typeof withBlock["token"] === "string") {
+          token = withBlock["token"] as string;
+        }
+      }
+    }
+  }
+  assertExists(
+    token,
+    "create-pull-request step should set a token to allow downstream workflows to fire",
+  );
+  assertEquals(
+    token!.includes("secrets.ACTIONS_PUSH") &&
+      token!.includes("secrets.GITHUB_TOKEN"),
+    true,
+    "Token should reference secrets.ACTIONS_PUSH with secrets.GITHUB_TOKEN as fallback",
+  );
+});

--- a/docs/pr-summary-50.md
+++ b/docs/pr-summary-50.md
@@ -1,0 +1,40 @@
+## Summary
+
+Aligned the existing Deno Dependency Updates workflow (`.github/workflows/deno-outdated.yml`) with the template specified in issue #50 by adding the `token: ${{ secrets.ACTIONS_PUSH || secrets.GITHUB_TOKEN }}` field to the `peter-evans/create-pull-request` step. Without an org-level PAT, PRs opened by `GITHUB_TOKEN` do not trigger downstream `on: pull_request` workflows (e.g. `quality.yml`); the fallback to `GITHUB_TOKEN` keeps the workflow functional when the secret is unset (Issue #1636). Closes #50.
+
+## Evidence
+
+CLI workflow change — no UI to screenshot. Verified via TDD:
+
+1. Added `deno-outdated workflow uses ACTIONS_PUSH PAT with GITHUB_TOKEN fallback` test that asserts the `token` field is present in the create-pull-request step and references both `secrets.ACTIONS_PUSH` and `secrets.GITHUB_TOKEN`.
+2. Confirmed the test failed against the unmodified workflow.
+3. Updated the workflow with the token line and verified all 8 tests pass.
+
+```text
+ok | 8 passed | 0 failed (11ms)
+```
+
+The remaining `quality.sh` failures (Deno type-check errors in `intelligent_design/` and a WASM error in the crossover example) are pre-existing on `Develop` and unrelated to this change — confirmed by running `quality.sh` against the unmodified base branch.
+
+```mermaid
+sequenceDiagram
+    participant Cron as Schedule (Mon 06:00 UTC)
+    participant WF as deno-outdated.yml
+    participant Deno as deno outdated --update --latest
+    participant CPR as create-pull-request@v7
+    participant PR as Pull Request
+    participant Quality as quality.yml
+
+    Cron->>WF: Trigger workflow
+    WF->>Deno: Refresh deno.json / deno.lock
+    Deno-->>WF: Updated dep files
+    WF->>CPR: Open PR (token = ACTIONS_PUSH || GITHUB_TOKEN)
+    CPR->>PR: Create PR on chore/deno-outdated
+    PR->>Quality: Fires on: pull_request (PAT enables downstream events)
+```
+
+## Test Plan
+
+- Added `deno-outdated workflow uses ACTIONS_PUSH PAT with GITHUB_TOKEN fallback` to `.github/workflows/deno_outdated_test.ts`.
+- All 8 tests in `deno_outdated_test.ts` pass.
+- All 61 workflow tests in `.github/workflows/` pass.


### PR DESCRIPTION
## Summary

Aligned the existing Deno Dependency Updates workflow (`.github/workflows/deno-outdated.yml`) with the template specified in issue #50 by adding the `token: ${{ secrets.ACTIONS_PUSH || secrets.GITHUB_TOKEN }}` field to the `peter-evans/create-pull-request` step. Without an org-level PAT, PRs opened by `GITHUB_TOKEN` do not trigger downstream `on: pull_request` workflows (e.g. `quality.yml`); the fallback to `GITHUB_TOKEN` keeps the workflow functional when the secret is unset (Issue #1636). Closes #50.

## Evidence

CLI workflow change — no UI to screenshot. Verified via TDD:

1. Added `deno-outdated workflow uses ACTIONS_PUSH PAT with GITHUB_TOKEN fallback` test that asserts the `token` field is present in the create-pull-request step and references both `secrets.ACTIONS_PUSH` and `secrets.GITHUB_TOKEN`.
2. Confirmed the test failed against the unmodified workflow.
3. Updated the workflow with the token line and verified all 8 tests pass.

```text
ok | 8 passed | 0 failed (11ms)
```

The remaining `quality.sh` failures (Deno type-check errors in `intelligent_design/` and a WASM error in the crossover example) are pre-existing on `Develop` and unrelated to this change — confirmed by running `quality.sh` against the unmodified base branch.

```mermaid
sequenceDiagram
    participant Cron as Schedule (Mon 06:00 UTC)
    participant WF as deno-outdated.yml
    participant Deno as deno outdated --update --latest
    participant CPR as create-pull-request@v7
    participant PR as Pull Request
    participant Quality as quality.yml

    Cron->>WF: Trigger workflow
    WF->>Deno: Refresh deno.json / deno.lock
    Deno-->>WF: Updated dep files
    WF->>CPR: Open PR (token = ACTIONS_PUSH || GITHUB_TOKEN)
    CPR->>PR: Create PR on chore/deno-outdated
    PR->>Quality: Fires on: pull_request (PAT enables downstream events)
```

## Test Plan

- Added `deno-outdated workflow uses ACTIONS_PUSH PAT with GITHUB_TOKEN fallback` to `.github/workflows/deno_outdated_test.ts`.
- All 8 tests in `deno_outdated_test.ts` pass.
- All 61 workflow tests in `.github/workflows/` pass.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-50 -->