### PR TITLE
ci: add Deno Quality workflow (lint, fmt, type-check, test+coverage) (#51)

### DIFF
--- a/.github/workflows/deno-quality.yml
+++ b/.github/workflows/deno-quality.yml
@@ -1,0 +1,56 @@
+# Deno Quality workflow for NEAT-AI-Examples
+#
+# Runs Deno lint, format check, type check, and unit tests with code
+# coverage on every pull request, then uploads the lcov report to
+# Codecov. Issue #51.
+
+name: Deno Quality
+
+on:
+  pull_request:
+    branches: ["*"]
+
+permissions:
+  contents: read
+
+jobs:
+  quality:
+    name: Lint, format, type-check, test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Install Deno
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
+        with:
+          deno-version: v2.x
+
+      - name: Run deno lint
+        run: deno lint
+
+      - name: Run deno fmt --check
+        run: deno fmt --check
+
+      - name: Run deno check (type checking)
+        run: deno check **/*.ts
+
+      # Run tests with coverage. The example runner scripts and the
+      # native FFI library are not available in this minimal workflow,
+      # so we only execute the unit tests here. The full quality.yml
+      # workflow continues to run the example programs.
+      - name: Run unit tests with coverage
+        run: deno test --no-check --allow-read --allow-write --allow-env --coverage=cov_profile
+
+      - name: Generate lcov coverage report
+        run: deno coverage cov_profile --lcov --output=coverage.lcov
+
+      # The codecov-action is a no-op when no coverage file is found,
+      # and we set fail_ci_if_error: false so a transient Codecov
+      # outage does not block the PR.
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@0f8570b1a125f4937846a11fcfa3bcd548bd8c97 # v4.6.0
+        with:
+          files: coverage.lcov
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false

--- a/.github/workflows/deno_quality_test.ts
+++ b/.github/workflows/deno_quality_test.ts
@@ -1,0 +1,196 @@
+/**
+ * Tests for the Deno Quality (lint, fmt, type-check, test+coverage) workflow.
+ *
+ * These tests parse the workflow YAML file and verify that it contains
+ * the configuration required by issue #51 — a dedicated workflow that
+ * runs Deno lint, format check, type check, and tests with coverage
+ * uploaded to Codecov on every pull request.
+ */
+import { assertEquals, assertExists } from "@std/assert";
+import { parse } from "@std/yaml";
+
+const WORKFLOW_PATH = ".github/workflows/deno-quality.yml";
+
+/** Helper to load and parse the workflow file. */
+function loadWorkflow(): Record<string, unknown> {
+  const content = Deno.readTextFileSync(WORKFLOW_PATH);
+  const parsed = parse(content);
+  if (typeof parsed !== "object" || parsed === null) {
+    throw new Error("Workflow file did not parse as an object");
+  }
+  return parsed as Record<string, unknown>;
+}
+
+/** Collect every step across every job in the workflow. */
+function allSteps(
+  workflow: Record<string, unknown>,
+): Array<Record<string, unknown>> {
+  const jobs = workflow["jobs"] as Record<string, Record<string, unknown>>;
+  const steps: Array<Record<string, unknown>> = [];
+  for (const name of Object.keys(jobs)) {
+    const jobSteps = jobs[name]["steps"] as Array<Record<string, unknown>>;
+    if (jobSteps) steps.push(...jobSteps);
+  }
+  return steps;
+}
+
+Deno.test("deno-quality workflow file exists and is valid YAML", () => {
+  const workflow = loadWorkflow();
+  assertExists(workflow, "Workflow should parse as a valid YAML object");
+});
+
+Deno.test("deno-quality workflow has a descriptive name", () => {
+  const workflow = loadWorkflow();
+  assertExists(workflow.name, "Workflow should have a name field");
+  assertEquals(typeof workflow.name, "string");
+});
+
+Deno.test("deno-quality workflow triggers on pull_request events", () => {
+  const workflow = loadWorkflow();
+  // The 'on' key may be parsed as the boolean `true` by some YAML parsers
+  // when unquoted, so we check for both 'on' and true as keys.
+  const triggers = (workflow["on"] ?? workflow[String(true)]) as Record<
+    string,
+    unknown
+  >;
+  assertExists(triggers, "Workflow should have trigger configuration");
+  assertExists(
+    triggers["pull_request"],
+    "Workflow should trigger on pull_request events",
+  );
+});
+
+Deno.test("deno-quality workflow declares read-only contents permission", () => {
+  const workflow = loadWorkflow();
+  const permissions = workflow["permissions"] as Record<string, unknown>;
+  assertExists(permissions, "Workflow should declare permissions");
+  assertEquals(
+    permissions["contents"],
+    "read",
+    "Workflow should grant read-only access to repository contents",
+  );
+});
+
+Deno.test("deno-quality workflow defines at least one job", () => {
+  const workflow = loadWorkflow();
+  const jobs = workflow["jobs"] as Record<string, unknown>;
+  assertExists(jobs, "Workflow should define jobs");
+  assertEquals(
+    Object.keys(jobs).length > 0,
+    true,
+    "Workflow should have at least one job",
+  );
+});
+
+Deno.test("deno-quality workflow checks out the repository", () => {
+  const workflow = loadWorkflow();
+  const checksOut = allSteps(workflow).some((s) => {
+    const uses = s["uses"] as string | undefined;
+    return Boolean(uses && uses.startsWith("actions/checkout@"));
+  });
+  assertEquals(
+    checksOut,
+    true,
+    "Workflow should check out the repository",
+  );
+});
+
+Deno.test("deno-quality workflow installs Deno", () => {
+  const workflow = loadWorkflow();
+  const installsDeno = allSteps(workflow).some((s) => {
+    const uses = s["uses"] as string | undefined;
+    return Boolean(uses && uses.startsWith("denoland/setup-deno@"));
+  });
+  assertEquals(
+    installsDeno,
+    true,
+    "Workflow should install Deno via setup-deno action",
+  );
+});
+
+Deno.test("deno-quality workflow runs deno lint", () => {
+  const workflow = loadWorkflow();
+  const runsLint = allSteps(workflow).some((s) => {
+    const run = s["run"] as string | undefined;
+    return Boolean(run && /\bdeno lint\b/.test(run));
+  });
+  assertEquals(runsLint, true, "Workflow should run deno lint");
+});
+
+Deno.test("deno-quality workflow runs deno fmt --check", () => {
+  const workflow = loadWorkflow();
+  const runsFmt = allSteps(workflow).some((s) => {
+    const run = s["run"] as string | undefined;
+    return Boolean(run && run.includes("deno fmt --check"));
+  });
+  assertEquals(runsFmt, true, "Workflow should run deno fmt --check");
+});
+
+Deno.test("deno-quality workflow runs deno check (type checking)", () => {
+  const workflow = loadWorkflow();
+  const runsCheck = allSteps(workflow).some((s) => {
+    const run = s["run"] as string | undefined;
+    return Boolean(run && /\bdeno check\b/.test(run));
+  });
+  assertEquals(runsCheck, true, "Workflow should run deno check for type checking");
+});
+
+Deno.test("deno-quality workflow runs deno test with coverage", () => {
+  const workflow = loadWorkflow();
+  const steps = allSteps(workflow);
+
+  const runsTestCoverage = steps.some((s) => {
+    const run = s["run"] as string | undefined;
+    return Boolean(run && run.includes("deno test") && run.includes("--coverage="));
+  });
+  assertEquals(
+    runsTestCoverage,
+    true,
+    "Workflow should run deno test with --coverage to produce a profile",
+  );
+
+  const generatesLcov = steps.some((s) => {
+    const run = s["run"] as string | undefined;
+    return Boolean(run && run.includes("deno coverage") && run.includes("--lcov"));
+  });
+  assertEquals(
+    generatesLcov,
+    true,
+    "Workflow should generate an lcov coverage report via deno coverage --lcov",
+  );
+});
+
+Deno.test("deno-quality workflow uploads coverage to Codecov", () => {
+  const workflow = loadWorkflow();
+  const usesCodecov = allSteps(workflow).some((s) => {
+    const uses = s["uses"] as string | undefined;
+    return Boolean(uses && uses.startsWith("codecov/codecov-action@"));
+  });
+  assertEquals(
+    usesCodecov,
+    true,
+    "Workflow should upload coverage via the codecov/codecov-action",
+  );
+});
+
+Deno.test("deno-quality workflow pins actions to commit SHAs", () => {
+  const workflow = loadWorkflow();
+  const sha40 = /^[0-9a-f]{40}$/;
+
+  for (const step of allSteps(workflow)) {
+    const uses = step["uses"] as string | undefined;
+    if (!uses) continue;
+    const atIdx = uses.lastIndexOf("@");
+    assertEquals(
+      atIdx > 0,
+      true,
+      `Step '${uses}' should pin a version with '@'`,
+    );
+    const ref = uses.slice(atIdx + 1);
+    assertEquals(
+      sha40.test(ref),
+      true,
+      `Step '${uses}' should be pinned to a 40-character commit SHA, not '${ref}'`,
+    );
+  }
+});

--- a/docs/pr-summary-51.md
+++ b/docs/pr-summary-51.md
@@ -1,0 +1,78 @@
+# Add Deno Quality workflow (lint, fmt, type-check, test + coverage)
+
+## Summary
+
+Added a dedicated `Deno Quality` GitHub Actions workflow at `.github/workflows/deno-quality.yml`
+that runs `deno lint`, `deno fmt --check`, `deno check`, and `deno test` with code coverage, then
+uploads the lcov report to Codecov on every pull request. This complements the existing
+`quality.yml` workflow, which also runs the example programs but is gated on the `Develop` branch
+only. Closes #51.
+
+The workflow follows the project's supply-chain rules — every third-party action is pinned to a
+40-character commit SHA rather than a moving tag.
+
+## Evidence
+
+This is a CI-config-only change (no UI, no runtime code path), so the evidence is the new workflow
+YAML plus the unit tests that lock in its required shape. The new workflow runs on every PR and
+reports its own status in the PR's checks panel; once merged it will execute itself on subsequent
+PRs.
+
+```mermaid
+flowchart LR
+    PR[Pull request opened] --> CO[actions/checkout]
+    CO --> SD[denoland/setup-deno]
+    SD --> L[deno lint]
+    L --> F[deno fmt --check]
+    F --> T[deno check **/*.ts]
+    T --> U[deno test --coverage=cov_profile]
+    U --> C[deno coverage --lcov]
+    C --> CC[codecov/codecov-action]
+```
+
+### Test results
+
+```
+running 13 tests from ./.github/workflows/deno_quality_test.ts
+deno-quality workflow file exists and is valid YAML ... ok
+deno-quality workflow has a descriptive name ... ok
+deno-quality workflow triggers on pull_request events ... ok
+deno-quality workflow declares read-only contents permission ... ok
+deno-quality workflow defines at least one job ... ok
+deno-quality workflow checks out the repository ... ok
+deno-quality workflow installs Deno ... ok
+deno-quality workflow runs deno lint ... ok
+deno-quality workflow runs deno fmt --check ... ok
+deno-quality workflow runs deno check (type checking) ... ok
+deno-quality workflow runs deno test with coverage ... ok
+deno-quality workflow uploads coverage to Codecov ... ok
+deno-quality workflow pins actions to commit SHAs ... ok
+ok | 13 passed | 0 failed
+```
+
+### Pre-existing `quality.sh` failures
+
+Running `./quality.sh` on this branch reports failures in `Deno Format Check`, `Deno Type Check`,
+`Unit Tests`, and the `Intelligent Design`, `Discovery`, and `Crossover` examples. These are
+pre-existing on `Develop` and unrelated to this change — the unit-test failures all originate in
+`@stsoftware/neat-ai`'s WASM loader (the native module is unavailable locally), and the
+`fmt --check` failure is in `docs/pr-summary-50.md` (not touched by this PR).
+
+## Test Plan
+
+- Added `.github/workflows/deno_quality_test.ts` with 13 tests that parse the new workflow YAML and
+  assert on its required structure (TDD — tests were written first and confirmed failing before the
+  workflow file was added):
+  - Valid YAML with a descriptive name
+  - Triggers on `pull_request`
+  - Declares `contents: read` permission
+  - Defines at least one job
+  - Checks out the repository (`actions/checkout`)
+  - Installs Deno (`denoland/setup-deno`)
+  - Runs `deno lint`
+  - Runs `deno fmt --check`
+  - Runs `deno check` for type checking
+  - Runs `deno test` with `--coverage=cov_profile`
+  - Generates an lcov report via `deno coverage --lcov`
+  - Uploads coverage via `codecov/codecov-action`
+  - Pins every action to a 40-character commit SHA


### PR DESCRIPTION
# Add Deno Quality workflow (lint, fmt, type-check, test + coverage)

## Summary

Added a dedicated `Deno Quality` GitHub Actions workflow at `.github/workflows/deno-quality.yml`
that runs `deno lint`, `deno fmt --check`, `deno check`, and `deno test` with code coverage, then
uploads the lcov report to Codecov on every pull request. This complements the existing
`quality.yml` workflow, which also runs the example programs but is gated on the `Develop` branch
only. Closes #51.

The workflow follows the project's supply-chain rules — every third-party action is pinned to a
40-character commit SHA rather than a moving tag.

## Evidence

This is a CI-config-only change (no UI, no runtime code path), so the evidence is the new workflow
YAML plus the unit tests that lock in its required shape. The new workflow runs on every PR and
reports its own status in the PR's checks panel; once merged it will execute itself on subsequent
PRs.

```mermaid
flowchart LR
    PR[Pull request opened] --> CO[actions/checkout]
    CO --> SD[denoland/setup-deno]
    SD --> L[deno lint]
    L --> F[deno fmt --check]
    F --> T[deno check **/*.ts]
    T --> U[deno test --coverage=cov_profile]
    U --> C[deno coverage --lcov]
    C --> CC[codecov/codecov-action]
```

### Test results

```
running 13 tests from ./.github/workflows/deno_quality_test.ts
deno-quality workflow file exists and is valid YAML ... ok
deno-quality workflow has a descriptive name ... ok
deno-quality workflow triggers on pull_request events ... ok
deno-quality workflow declares read-only contents permission ... ok
deno-quality workflow defines at least one job ... ok
deno-quality workflow checks out the repository ... ok
deno-quality workflow installs Deno ... ok
deno-quality workflow runs deno lint ... ok
deno-quality workflow runs deno fmt --check ... ok
deno-quality workflow runs deno check (type checking) ... ok
deno-quality workflow runs deno test with coverage ... ok
deno-quality workflow uploads coverage to Codecov ... ok
deno-quality workflow pins actions to commit SHAs ... ok
ok | 13 passed | 0 failed
```

### Pre-existing `quality.sh` failures

Running `./quality.sh` on this branch reports failures in `Deno Format Check`, `Deno Type Check`,
`Unit Tests`, and the `Intelligent Design`, `Discovery`, and `Crossover` examples. These are
pre-existing on `Develop` and unrelated to this change — the unit-test failures all originate in
`@stsoftware/neat-ai`'s WASM loader (the native module is unavailable locally), and the
`fmt --check` failure is in `docs/pr-summary-50.md` (not touched by this PR).

## Test Plan

- Added `.github/workflows/deno_quality_test.ts` with 13 tests that parse the new workflow YAML and
  assert on its required structure (TDD — tests were written first and confirmed failing before the
  workflow file was added):
  - Valid YAML with a descriptive name
  - Triggers on `pull_request`
  - Declares `contents: read` permission
  - Defines at least one job
  - Checks out the repository (`actions/checkout`)
  - Installs Deno (`denoland/setup-deno`)
  - Runs `deno lint`
  - Runs `deno fmt --check`
  - Runs `deno check` for type checking
  - Runs `deno test` with `--coverage=cov_profile`
  - Generates an lcov report via `deno coverage --lcov`
  - Uploads coverage via `codecov/codecov-action`
  - Pins every action to a 40-character commit SHA



---

🤖 Processed by: stservice<!-- vibe-worker-issue-51 -->