### PR TITLE
Add Cart Pole balancing example with animated screenshot (Issue #58)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ walkthrough — the per-example README explains the workflow, options, and outpu
 | [🧬 Intelligent Design](intelligent_design/README.md)     | Systematically swap activation functions on hidden neurons to find better squashes than random mutation. | `./intelligent_design/run.sh`   |
 | [🔍 Discovery](discovery/README.md)                       | Cripple a creature by removing a neuron, then use evolutionary search to recover its behaviour.          | `./discovery/run.sh`            |
 | [🔀 Crossover](crossover/README.md)                       | Breed two parents with different architectures into an offspring and (optionally) evolve it further.     | `./crossover/run.sh`            |
+| [🎢 Cart-Pole](cart_pole/README.md)                       | Evolve a controller that balances an inverted pole on a moving cart and render the run as an SVG strip.  | `./cart_pole/run.sh`            |
 | [💡 Suggest Improvements](suggest_improvements/README.md) | Analyse the project and emit categorised improvement suggestions you can file as GitHub issues.          | `./suggest_improvements/run.sh` |
 
 ```mermaid

--- a/cart_pole/README.md
+++ b/cart_pole/README.md
@@ -1,0 +1,84 @@
+# 🎢 Cart-Pole — Balancing an Inverted Pendulum
+
+`cart_pole.ts` evolves a NEAT-AI controller that balances an inverted pole on a moving cart — the
+classic neuroevolution control benchmark. Both the simulator and the evolutionary loop run entirely
+in pure TypeScript, with the only external dependency being NEAT-AI's `Creature.activate` to compute
+each step's action.
+
+![Champion run](../docs/screenshots/cart_pole.svg)
+
+## 🔧 How It Works
+
+```mermaid
+flowchart LR
+    PHYS["🧮 Pure-TS Cart-Pole Physics<br/>(physics.ts)"]
+    INIT["🎲 Random Population<br/>linear policies"]
+    SCORE["📏 Score by Survival Steps<br/>(capped at 500)"]
+    SELECT["🏆 Truncation Selection<br/>top 50% are parents"]
+    MUTATE["🧬 Mutate Weights & Bias"]
+    SOLVED{"Reached MAX_STEPS?"}
+    CHAMP["💾 Save champion.json"]
+    RUN["▶️ Replay Champion"]
+    SVG["🖼️ docs/screenshots/cart_pole.svg"]
+
+    INIT --> SCORE
+    PHYS --> SCORE
+    SCORE --> SELECT
+    SELECT --> MUTATE
+    MUTATE --> SCORE
+    SCORE --> SOLVED
+    SOLVED -- yes --> CHAMP
+    SOLVED -- no, more generations --> SELECT
+    CHAMP --> RUN
+    RUN --> SVG
+
+    style PHYS fill:#4a90d9,stroke:#333,color:#fff
+    style INIT fill:#f5a623,stroke:#333,color:#fff
+    style SCORE fill:#f39c12,stroke:#333,color:#fff
+    style SELECT fill:#e67e22,stroke:#333,color:#fff
+    style MUTATE fill:#e74c3c,stroke:#333,color:#fff
+    style CHAMP fill:#7ed321,stroke:#333,color:#fff
+    style RUN fill:#bd10e0,stroke:#333,color:#fff
+    style SVG fill:#50e3c2,stroke:#333,color:#fff
+```
+
+## 🎯 Inputs and Outputs
+
+| Channel  | Type       | Symbol  | Meaning                                  |
+| -------- | ---------- | ------- | ---------------------------------------- |
+| Input 0  | observable | `x`     | Cart position along the track (metres)   |
+| Input 1  | observable | `v`     | Cart velocity (m/s)                      |
+| Input 2  | observable | `theta` | Pole angle from vertical (radians)       |
+| Input 3  | observable | `omega` | Pole angular velocity (rad/s)            |
+| Output 0 | action     | —       | `>= 0.5` push right, otherwise push left |
+
+The score is the number of timesteps the pole stays within ±12° and the cart stays within ±2.4 m,
+capped at 500 steps. The task is "solved" when the champion reaches the cap.
+
+## 🚀 Running the Example
+
+```bash
+./cart_pole/run.sh
+```
+
+Artefacts:
+
+- `.synthetic-cart-pole/creatures/champion.json` – the fittest controller from the run
+- `docs/screenshots/cart_pole.svg` – an 8-frame strip showing the champion balancing
+
+## 🧠 Tacit Knowledge
+
+A few things that are not obvious from the code alone:
+
+- **Linear is enough.** Cart-pole is solvable by a linear policy `action = sign(w·s + b)` over the
+  four observables. The example uses a four-input, one-output network without hidden neurons. This
+  keeps the search space small (five floats) so a tiny population finds a controller quickly.
+- **Semi-implicit Euler matches OpenAI Gym.** `physics.step` updates velocity before position. This
+  is the same scheme as `CartPole-v1`, so behaviour matches the textbook benchmark to floating-point
+  precision.
+- **Discrete force.** The output is thresholded to ±1 (no zero option). The controller cannot "do
+  nothing"; it must commit to a direction every step.
+- **Reproducibility.** All randomness flows through `common/deterministic_random.ts`. With a fixed
+  seed the same champion is produced on every run.
+- **No Python required.** Despite cart-pole being the canonical OpenAI Gym example, the simulator
+  here is plain TypeScript so the whole project remains "Deno + JSR" with no extra runtime.

--- a/cart_pole/cart_pole.ts
+++ b/cart_pole/cart_pole.ts
@@ -1,0 +1,361 @@
+/**
+ * Cart-Pole Balancing Example
+ *
+ * Evolves a NEAT-AI creature to balance an inverted pole on a moving
+ * cart. The classic neuroevolution control benchmark in pure
+ * TypeScript: the simulator and the evolutionary loop run entirely
+ * in-process, with the only external dependency being NEAT-AI's
+ * `Creature.activate` to compute each step's action.
+ *
+ * Inputs (per timestep): `[x, v, theta, omega]`.
+ * Output: a single scalar — when `>= 0.5` push right, otherwise push left.
+ * Score: the number of timesteps the pole stays upright, capped at
+ * `MAX_STEPS`. The task is "solved" when the champion reaches the cap.
+ */
+import { format } from "@std/fmt/duration";
+import { ensureDirSync } from "@std/fs";
+import { join } from "@std/path";
+import { Creature, type CreatureExport, safeWriteJson } from "@stsoftware/neat-ai";
+
+import { createDeterministicRandom } from "../common/deterministic_random.ts";
+import { setupWorkingDirs } from "../common/working_dirs.ts";
+import { asCreatureExport, type LegacyCreatureJSON } from "../common/legacy_types.ts";
+import { type CartPoleState, encodeState, initialState, isFailed, step } from "./physics.ts";
+import { renderRunSVG } from "./svg.ts";
+
+/** Maximum number of timesteps a single episode is allowed to run. */
+export const MAX_STEPS = 500;
+
+/** Configuration options for {@link evolveCartPoleController}. */
+export interface EvolveOptions {
+  /** Random seed driving population initialisation and mutation. */
+  seed: number;
+  /** Population size for each generation. */
+  populationSize: number;
+  /** Maximum number of generations before giving up. */
+  maxGenerations: number;
+  /** Standard deviation of the weight/bias perturbation noise. */
+  mutationStrength: number;
+  /** Probability that any given gene is perturbed each generation. */
+  mutationRate: number;
+  /** Optional callback invoked once per generation with progress info. */
+  onGeneration?: (info: GenerationInfo) => void;
+}
+
+/** Statistics emitted after each generation. */
+export interface GenerationInfo {
+  generation: number;
+  bestScore: number;
+  meanScore: number;
+}
+
+/** Result of the evolutionary search. */
+export interface EvolveResult {
+  /** The fittest creature found during the run. */
+  champion: Creature;
+  /** Best score reached by the champion. */
+  bestScore: number;
+  /** Number of generations run before stopping. */
+  generations: number;
+  /** True when the champion balanced for the full {@link MAX_STEPS}. */
+  solved: boolean;
+}
+
+/** Sensible defaults for the demonstration runner. */
+export const DEFAULT_EVOLVE_OPTIONS: EvolveOptions = {
+  seed: 12345,
+  populationSize: 30,
+  maxGenerations: 60,
+  mutationStrength: 0.4,
+  mutationRate: 0.5,
+};
+
+/**
+ * Build a small linear network: four inputs feeding directly into a
+ * single LOGISTIC output. With four weights and one bias this is enough
+ * capacity to solve cart-pole as a linear policy and keeps training
+ * tractable for an in-process example.
+ */
+export function buildInitialCreatureJSON(
+  weights: [number, number, number, number],
+  bias: number,
+): LegacyCreatureJSON {
+  return {
+    neurons: [
+      { type: "input", squash: "LOGISTIC", index: 0, uuid: "input-0" },
+      { type: "input", squash: "LOGISTIC", index: 1, uuid: "input-1" },
+      { type: "input", squash: "LOGISTIC", index: 2, uuid: "input-2" },
+      { type: "input", squash: "LOGISTIC", index: 3, uuid: "input-3" },
+      {
+        type: "output",
+        squash: "LOGISTIC",
+        index: 4,
+        bias,
+        uuid: "output-0",
+      },
+    ],
+    synapses: [
+      { from: 0, to: 4, weight: weights[0] },
+      { from: 1, to: 4, weight: weights[1] },
+      { from: 2, to: 4, weight: weights[2] },
+      { from: 3, to: 4, weight: weights[3] },
+    ],
+    input: 4,
+    output: 1,
+  };
+}
+
+/** Sample a value from `[-range, range]` using the supplied PRNG. */
+function uniformSigned(random: () => number, range: number): number {
+  return (random() * 2 - 1) * range;
+}
+
+/**
+ * Construct a random initial creature JSON. Weights are drawn from
+ * `[-1, 1]` and the bias from `[-0.5, 0.5]` — a starting region wide
+ * enough that the seeded population covers both push-left and push-right
+ * tendencies.
+ */
+export function randomCreatureJSON(random: () => number): LegacyCreatureJSON {
+  return buildInitialCreatureJSON(
+    [
+      uniformSigned(random, 1),
+      uniformSigned(random, 1),
+      uniformSigned(random, 1),
+      uniformSigned(random, 1),
+    ],
+    uniformSigned(random, 0.5),
+  );
+}
+
+/**
+ * Decode a creature export into the four input weights and the output
+ * bias. The genome layout is fixed by {@link buildInitialCreatureJSON}.
+ */
+export function genesFromCreatureJSON(
+  json: LegacyCreatureJSON,
+): { weights: [number, number, number, number]; bias: number } {
+  const weights: [number, number, number, number] = [0, 0, 0, 0];
+  for (const synapse of json.synapses) {
+    if (synapse.to === 4 && synapse.from >= 0 && synapse.from <= 3) {
+      weights[synapse.from] = synapse.weight;
+    }
+  }
+  const output = json.neurons.find((n) => n.uuid === "output-0");
+  return { weights, bias: output?.bias ?? 0 };
+}
+
+/**
+ * Mutate a creature genome by perturbing each weight and the bias with
+ * Gaussian-like noise. Each gene is mutated independently with
+ * probability `mutationRate`; noise is drawn uniformly from
+ * `[-mutationStrength, mutationStrength]` (a fast, reproducible
+ * approximation suitable for this small genome).
+ */
+export function mutateCreatureJSON(
+  parent: LegacyCreatureJSON,
+  random: () => number,
+  mutationRate: number,
+  mutationStrength: number,
+): LegacyCreatureJSON {
+  const { weights, bias } = genesFromCreatureJSON(parent);
+  const newWeights = weights.map((w) =>
+    random() < mutationRate ? w + uniformSigned(random, mutationStrength) : w
+  ) as [number, number, number, number];
+  const newBias = random() < mutationRate ? bias + uniformSigned(random, mutationStrength) : bias;
+  return buildInitialCreatureJSON(newWeights, newBias);
+}
+
+/**
+ * Score a creature by running the cart-pole simulator. The episode ends
+ * when the pole or cart leaves the failure thresholds, or after
+ * {@link MAX_STEPS} timesteps. Score equals the number of steps survived.
+ */
+export function scoreController(
+  creature: Creature,
+  maxSteps: number = MAX_STEPS,
+): number {
+  let state: CartPoleState = initialState();
+  for (let stepIdx = 0; stepIdx < maxSteps; stepIdx++) {
+    creature.clearState();
+    const out = creature.activate(encodeState(state));
+    const action = out[0] >= 0.5 ? 1 : -1;
+    state = step(state, action);
+    if (isFailed(state)) {
+      return stepIdx + 1;
+    }
+  }
+  return maxSteps;
+}
+
+/**
+ * Score a hand-crafted "always push toward the pole's tilt" policy.
+ * Used as a sanity check that the simulator is solvable.
+ */
+export function scoreTiltDirectionPolicy(maxSteps: number = MAX_STEPS): number {
+  let state: CartPoleState = initialState();
+  for (let stepIdx = 0; stepIdx < maxSteps; stepIdx++) {
+    const action = state.theta >= 0 ? 1 : -1;
+    state = step(state, action);
+    if (isFailed(state)) {
+      return stepIdx + 1;
+    }
+  }
+  return maxSteps;
+}
+
+/**
+ * Replay a creature's run, recording the cart-pole state at every
+ * timestep up to and including the failing step (if any). Useful for
+ * generating animation frames.
+ */
+export function replayController(
+  creature: Creature,
+  maxSteps: number = MAX_STEPS,
+): CartPoleState[] {
+  const trace: CartPoleState[] = [];
+  let state: CartPoleState = initialState();
+  trace.push(state);
+  for (let stepIdx = 0; stepIdx < maxSteps; stepIdx++) {
+    creature.clearState();
+    const out = creature.activate(encodeState(state));
+    const action = out[0] >= 0.5 ? 1 : -1;
+    state = step(state, action);
+    trace.push(state);
+    if (isFailed(state)) break;
+  }
+  return trace;
+}
+
+/**
+ * Run a generational evolutionary algorithm over creature genomes. The
+ * top half of each generation seeds the next via mutation; elites are
+ * carried over unchanged so the best score is monotonically
+ * non-decreasing.
+ */
+export function evolveCartPoleController(
+  options: EvolveOptions = DEFAULT_EVOLVE_OPTIONS,
+): EvolveResult {
+  const random = createDeterministicRandom(options.seed);
+
+  // Initial population: random linear policies.
+  let population: { json: LegacyCreatureJSON; score: number }[] = [];
+  for (let i = 0; i < options.populationSize; i++) {
+    const json = randomCreatureJSON(random);
+    const creature = Creature.fromJSON(asCreatureExport(json));
+    const score = scoreController(creature);
+    population.push({ json, score });
+  }
+
+  let bestJSON = population[0].json;
+  let bestScore = -1;
+  let solvedAt = -1;
+
+  for (let generation = 0; generation < options.maxGenerations; generation++) {
+    population.sort((a, b) => b.score - a.score);
+    const generationBest = population[0];
+    if (generationBest.score > bestScore) {
+      bestScore = generationBest.score;
+      bestJSON = generationBest.json;
+    }
+
+    const meanScore = population.reduce((acc, p) => acc + p.score, 0) /
+      population.length;
+    options.onGeneration?.({
+      generation,
+      bestScore: generationBest.score,
+      meanScore,
+    });
+
+    if (bestScore >= MAX_STEPS) {
+      solvedAt = generation;
+      break;
+    }
+
+    // Truncation selection: keep top 50% as parents (always at least 1).
+    const parentCount = Math.max(1, Math.floor(options.populationSize / 2));
+    const parents = population.slice(0, parentCount);
+
+    // Build the next generation: keep elites, fill rest with mutated
+    // offspring from random parents.
+    const nextPopulation: { json: LegacyCreatureJSON; score: number }[] = [];
+    nextPopulation.push(parents[0]);
+    while (nextPopulation.length < options.populationSize) {
+      const parent = parents[Math.floor(random() * parents.length)];
+      const childJSON = mutateCreatureJSON(
+        parent.json,
+        random,
+        options.mutationRate,
+        options.mutationStrength,
+      );
+      const childCreature = Creature.fromJSON(asCreatureExport(childJSON));
+      const childScore = scoreController(childCreature);
+      nextPopulation.push({ json: childJSON, score: childScore });
+    }
+
+    population = nextPopulation;
+  }
+
+  const champion = Creature.fromJSON(asCreatureExport(bestJSON));
+  return {
+    champion,
+    bestScore,
+    generations: solvedAt >= 0 ? solvedAt + 1 : options.maxGenerations,
+    solved: bestScore >= MAX_STEPS,
+  };
+}
+
+/** Path to the SVG snapshot the runner emits for the README. */
+export const SCREENSHOT_PATH = "docs/screenshots/cart_pole.svg";
+
+/** Number of evenly-spaced replay frames captured into the SVG strip. */
+export const SVG_FRAME_COUNT = 8;
+
+if (import.meta.main) {
+  const start = Date.now();
+
+  console.log("🎢 Cart-Pole Balancing Example");
+  console.log("");
+
+  const { creaturesDir } = setupWorkingDirs(".synthetic-cart-pole");
+
+  console.log("🧪 Sanity check: hand-crafted tilt-direction policy");
+  const sanityScore = scoreTiltDirectionPolicy();
+  console.log(`   Hand-crafted policy survived ${sanityScore} steps.`);
+
+  console.log("\n🧬 Evolving controller...");
+  const result = evolveCartPoleController({
+    ...DEFAULT_EVOLVE_OPTIONS,
+    onGeneration: ({ generation, bestScore, meanScore }) => {
+      if (generation % 5 === 0 || bestScore >= MAX_STEPS) {
+        console.log(
+          `   Gen ${generation.toString().padStart(3)}  best=${
+            bestScore.toString().padStart(3)
+          }  mean=${meanScore.toFixed(1).padStart(6)}`,
+        );
+      }
+    },
+  });
+
+  console.log(
+    `\n${result.solved ? "✅ Solved" : "⚠️  Did not solve"} ` +
+      `after ${result.generations} generations (best=${result.bestScore}).`,
+  );
+
+  // Save the champion creature.
+  const championPath = join(creaturesDir, "champion.json");
+  const championExport: CreatureExport = result.champion.exportJSON();
+  await safeWriteJson(championPath, championExport);
+  console.log(`💾 Saved champion to ${championPath}`);
+
+  // Render the SVG strip showing the champion balancing.
+  const trace = replayController(result.champion);
+  const svg = renderRunSVG(trace, SVG_FRAME_COUNT);
+  ensureDirSync("docs/screenshots");
+  await Deno.writeTextFile(SCREENSHOT_PATH, svg);
+  console.log(`🖼️  Wrote screenshot ${SCREENSHOT_PATH} (${trace.length} frames captured)`);
+
+  console.log(
+    `\n🏁 Example completed in ${format(Date.now() - start, { ignoreZero: true })}`,
+  );
+}

--- a/cart_pole/cart_pole_test.ts
+++ b/cart_pole/cart_pole_test.ts
@@ -1,0 +1,161 @@
+/**
+ * Unit tests for the cart-pole NEAT controller. "What" tests only —
+ * each test calls a real function, runs the simulator or evolver, and
+ * asserts on the observable outputs (scores, file contents, SVG
+ * structure).
+ */
+import { assert, assertEquals, assertGreater, assertGreaterOrEqual } from "@std/assert";
+import { ensureDirSync, existsSync } from "@std/fs";
+import { join } from "@std/path";
+import { Creature, safeWriteJson } from "@stsoftware/neat-ai";
+
+import { asCreatureExport } from "../common/legacy_types.ts";
+import {
+  buildInitialCreatureJSON,
+  DEFAULT_EVOLVE_OPTIONS,
+  evolveCartPoleController,
+  genesFromCreatureJSON,
+  MAX_STEPS,
+  mutateCreatureJSON,
+  randomCreatureJSON,
+  replayController,
+  scoreController,
+  scoreTiltDirectionPolicy,
+  SVG_FRAME_COUNT,
+} from "./cart_pole.ts";
+import { renderRunSVG } from "./svg.ts";
+import { createDeterministicRandom } from "../common/deterministic_random.ts";
+
+Deno.test("buildInitialCreatureJSON has 4 inputs and 1 output", () => {
+  const json = buildInitialCreatureJSON([0.1, 0.2, 0.3, 0.4], 0.5);
+  assertEquals(json.input, 4);
+  assertEquals(json.output, 1);
+  assertEquals(json.synapses.length, 4);
+});
+
+Deno.test("buildInitialCreatureJSON produces a valid creature", () => {
+  const json = buildInitialCreatureJSON([0.1, 0.2, 0.3, 0.4], 0.5);
+  const creature = Creature.fromJSON(asCreatureExport(json));
+  creature.validate();
+});
+
+Deno.test("genesFromCreatureJSON round-trips the weights and bias", () => {
+  const weights: [number, number, number, number] = [0.11, -0.22, 0.33, -0.44];
+  const bias = 0.55;
+  const json = buildInitialCreatureJSON(weights, bias);
+  const genes = genesFromCreatureJSON(json);
+  assertEquals(genes.weights, weights);
+  assertEquals(genes.bias, bias);
+});
+
+Deno.test("randomCreatureJSON is deterministic for the same seed", () => {
+  const r1 = createDeterministicRandom(99);
+  const r2 = createDeterministicRandom(99);
+  assertEquals(randomCreatureJSON(r1), randomCreatureJSON(r2));
+});
+
+Deno.test("mutateCreatureJSON yields a valid creature", () => {
+  const random = createDeterministicRandom(7);
+  const parent = buildInitialCreatureJSON([0, 0, 0, 0], 0);
+  const child = mutateCreatureJSON(parent, random, 1.0, 0.3);
+  const creature = Creature.fromJSON(asCreatureExport(child));
+  creature.validate();
+});
+
+Deno.test("scoreTiltDirectionPolicy beats a 'do nothing' baseline", () => {
+  // The hand-crafted policy isn't perfect, but it should clearly out-survive
+  // 50 steps — the simulator is solvable with simple feedback.
+  const score = scoreTiltDirectionPolicy(MAX_STEPS);
+  assertGreater(
+    score,
+    50,
+    `tilt-direction policy should survive >50 steps, got ${score}`,
+  );
+});
+
+Deno.test("scoreController returns a value between 0 and MAX_STEPS", () => {
+  const json = buildInitialCreatureJSON([0, 0, 0, 0], 0);
+  const creature = Creature.fromJSON(asCreatureExport(json));
+  const score = scoreController(creature, MAX_STEPS);
+  assertGreaterOrEqual(score, 0);
+  assertGreaterOrEqual(MAX_STEPS, score);
+});
+
+Deno.test(
+  "evolveCartPoleController finds a controller that solves the task with the default seed",
+  async () => {
+    const result = evolveCartPoleController(DEFAULT_EVOLVE_OPTIONS);
+    assertEquals(
+      result.solved,
+      true,
+      `expected the champion to reach MAX_STEPS=${MAX_STEPS}, got ${result.bestScore} ` +
+        `after ${result.generations} generations`,
+    );
+    assertEquals(result.bestScore, MAX_STEPS);
+
+    // Champion must serialise cleanly for downstream consumption.
+    const tmp = await Deno.makeTempDir({ prefix: "cart_pole_test_" });
+    try {
+      const path = join(tmp, "champion.json");
+      await safeWriteJson(path, result.champion.exportJSON());
+      assertEquals(existsSync(path), true);
+    } finally {
+      await Deno.remove(tmp, { recursive: true });
+    }
+  },
+);
+
+Deno.test("replayController returns a non-empty trace with the initial state first", () => {
+  const json = buildInitialCreatureJSON([0, 0, 1, 0], 0);
+  const creature = Creature.fromJSON(asCreatureExport(json));
+  const trace = replayController(creature, 50);
+  assert(trace.length > 0, "trace must not be empty");
+  assertEquals(trace[0].x, 0);
+  assertEquals(trace[0].theta, 0);
+});
+
+Deno.test("renderRunSVG emits an <svg> root with the expected number of frame groups", () => {
+  const json = buildInitialCreatureJSON([0, 0, 1, 0], 0);
+  const creature = Creature.fromJSON(asCreatureExport(json));
+  const trace = replayController(creature, 50);
+  const svg = renderRunSVG(trace, SVG_FRAME_COUNT);
+  assert(svg.startsWith("<svg"), "must start with <svg>");
+  assert(svg.includes("</svg>"), "must contain </svg>");
+  // One <g class="frame" ...> per requested frame.
+  const matches = svg.match(/<g class="frame"/g) ?? [];
+  assertEquals(matches.length, SVG_FRAME_COUNT);
+});
+
+Deno.test("renderRunSVG output renders both cart and pole primitives", () => {
+  const json = buildInitialCreatureJSON([0, 0, 1, 0], 0);
+  const creature = Creature.fromJSON(asCreatureExport(json));
+  const trace = replayController(creature, 30);
+  const svg = renderRunSVG(trace, 4);
+  assert(svg.includes("<rect"), "expected at least one cart rectangle");
+  assert(svg.includes("<line"), "expected at least one pole line");
+});
+
+Deno.test(
+  "running cart_pole.ts via run.sh-style execution emits champion.json and SVG",
+  async () => {
+    // Smoke-test that the SVG rendering path writes a sensible file when
+    // wired up the same way the runner does. We use a temp dir to
+    // avoid polluting the workspace.
+    const tmp = await Deno.makeTempDir({ prefix: "cart_pole_smoke_" });
+    try {
+      ensureDirSync(join(tmp, "screenshots"));
+      const result = evolveCartPoleController(DEFAULT_EVOLVE_OPTIONS);
+      const trace = replayController(result.champion);
+      const svg = renderRunSVG(trace, SVG_FRAME_COUNT);
+      const svgPath = join(tmp, "screenshots", "cart_pole.svg");
+      await Deno.writeTextFile(svgPath, svg);
+      const written = await Deno.readTextFile(svgPath);
+      assert(written.startsWith("<svg"));
+      const championPath = join(tmp, "champion.json");
+      await safeWriteJson(championPath, result.champion.exportJSON());
+      assertEquals(existsSync(championPath), true);
+    } finally {
+      await Deno.remove(tmp, { recursive: true });
+    }
+  },
+);

--- a/cart_pole/physics.ts
+++ b/cart_pole/physics.ts
@@ -1,0 +1,142 @@
+/**
+ * Deterministic 2D cart-pole physics.
+ *
+ * Standard textbook formulation: a frictionless cart of mass `cartMass`
+ * slides along a horizontal track. A pole of mass `poleMass` and
+ * half-length `poleHalfLength` is hinged on top of the cart. A horizontal
+ * force `force` is applied to the cart. Gravity acts downward on the
+ * pole. Equations follow Florian (2007) and are the same as the
+ * OpenAI Gym `CartPole-v1` reference implementation, expressed as pure
+ * functions so simulations are reproducible across runs.
+ *
+ * Coordinate system:
+ *   - `x`: cart position along the track (metres). Positive = right.
+ *   - `v`: cart velocity (metres per second).
+ *   - `theta`: pole angle from the upright vertical (radians). Positive =
+ *     leaning right.
+ *   - `omega`: pole angular velocity (radians per second).
+ */
+
+/** Immutable cart-pole state vector. */
+export interface CartPoleState {
+  /** Cart position along the track (metres). */
+  x: number;
+  /** Cart velocity (metres per second). */
+  v: number;
+  /** Pole angle from vertical (radians). */
+  theta: number;
+  /** Pole angular velocity (radians per second). */
+  omega: number;
+}
+
+/** Physical parameters of the cart-pole system. */
+export interface CartPoleParams {
+  /** Gravitational acceleration (m/s^2). */
+  gravity: number;
+  /** Cart mass (kg). */
+  cartMass: number;
+  /** Pole mass (kg). */
+  poleMass: number;
+  /** Half the pole's length (m). */
+  poleHalfLength: number;
+  /** Magnitude of the applied horizontal force (N). */
+  forceMagnitude: number;
+  /** Simulation time step (seconds). */
+  timeStep: number;
+}
+
+/**
+ * Default physical parameters. These match the canonical CartPole-v1
+ * benchmark used in the neuroevolution literature.
+ */
+export const DEFAULT_PARAMS: CartPoleParams = {
+  gravity: 9.8,
+  cartMass: 1.0,
+  poleMass: 0.1,
+  poleHalfLength: 0.5,
+  forceMagnitude: 10.0,
+  timeStep: 0.02,
+};
+
+/** Threshold beyond which the cart-pole episode is considered failed. */
+export interface CartPoleLimits {
+  /** Maximum absolute pole angle (radians) before failure. */
+  maxAngle: number;
+  /** Maximum absolute cart position (m) before failure. */
+  maxPosition: number;
+}
+
+/** Default failure thresholds: ~12 degrees angle, 2.4 m track half-width. */
+export const DEFAULT_LIMITS: CartPoleLimits = {
+  maxAngle: 12 * Math.PI / 180,
+  maxPosition: 2.4,
+};
+
+/** Initial state with the cart centred and the pole upright. */
+export function initialState(): CartPoleState {
+  return { x: 0, v: 0, theta: 0, omega: 0 };
+}
+
+/**
+ * Advance the cart-pole simulation by one time step using semi-implicit
+ * Euler integration.
+ *
+ * @param state Current state of the system.
+ * @param action Direction of the applied force: -1 pushes left, +1 pushes
+ *               right. Any non-zero numeric value is normalised by sign.
+ * @param params Physical parameters (defaults to {@link DEFAULT_PARAMS}).
+ * @returns The state after one time step. The input state is not mutated.
+ */
+export function step(
+  state: CartPoleState,
+  action: number,
+  params: CartPoleParams = DEFAULT_PARAMS,
+): CartPoleState {
+  const force = (action >= 0 ? 1 : -1) * params.forceMagnitude;
+  const totalMass = params.cartMass + params.poleMass;
+  const polemassLength = params.poleMass * params.poleHalfLength;
+
+  const cosTheta = Math.cos(state.theta);
+  const sinTheta = Math.sin(state.theta);
+
+  // Equations from Florian (2007). The temp term is a partial
+  // acceleration that lets us decouple the two coordinate accelerations.
+  const temp = (force + polemassLength * state.omega * state.omega * sinTheta) /
+    totalMass;
+  const thetaAcc = (params.gravity * sinTheta - cosTheta * temp) /
+    (params.poleHalfLength *
+      (4.0 / 3.0 - (params.poleMass * cosTheta * cosTheta) / totalMass));
+  const xAcc = temp - (polemassLength * thetaAcc * cosTheta) / totalMass;
+
+  // Semi-implicit Euler: update velocity first, then position. This is
+  // the same scheme used by OpenAI Gym for CartPole-v1.
+  const newV = state.v + params.timeStep * xAcc;
+  const newX = state.x + params.timeStep * newV;
+  const newOmega = state.omega + params.timeStep * thetaAcc;
+  const newTheta = state.theta + params.timeStep * newOmega;
+
+  return { x: newX, v: newV, theta: newTheta, omega: newOmega };
+}
+
+/**
+ * Returns true when the state has exceeded the failure thresholds — i.e.
+ * the pole has fallen past the angle limit or the cart has run off the
+ * track.
+ */
+export function isFailed(
+  state: CartPoleState,
+  limits: CartPoleLimits = DEFAULT_LIMITS,
+): boolean {
+  return (
+    Math.abs(state.theta) > limits.maxAngle ||
+    Math.abs(state.x) > limits.maxPosition
+  );
+}
+
+/**
+ * Encode a {@link CartPoleState} as a Float32Array suitable for feeding
+ * to a NEAT-AI creature: `[x, v, theta, omega]`.
+ */
+export function encodeState(state: CartPoleState): Float32Array {
+  return new Float32Array([state.x, state.v, state.theta, state.omega]);
+}

--- a/cart_pole/physics_test.ts
+++ b/cart_pole/physics_test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for the deterministic cart-pole physics module. These are
+ * "what" tests — they verify the observable behaviour of the simulator
+ * (positions, velocities, failure flags) rather than how it is computed.
+ */
+
+import { assert, assertAlmostEquals, assertEquals } from "@std/assert";
+
+import {
+  type CartPoleState,
+  DEFAULT_LIMITS,
+  DEFAULT_PARAMS,
+  encodeState,
+  initialState,
+  isFailed,
+  step,
+} from "./physics.ts";
+
+Deno.test("initialState centres the cart with the pole upright", () => {
+  const s = initialState();
+  assertEquals(s.x, 0);
+  assertEquals(s.v, 0);
+  assertEquals(s.theta, 0);
+  assertEquals(s.omega, 0);
+});
+
+Deno.test("step returns a new state object (input is not mutated)", () => {
+  const s = initialState();
+  const next = step(s, 1);
+  assertEquals(s.x, 0, "input state x should be unchanged");
+  assertEquals(s.v, 0, "input state v should be unchanged");
+  assert(next !== s, "step must return a new state object");
+});
+
+Deno.test("a stationary cart with a vertical pole stays vertical when no force is applied at zero gravity", () => {
+  // Disable gravity so the pole genuinely cannot fall on its own.
+  const params = { ...DEFAULT_PARAMS, gravity: 0, forceMagnitude: 0 };
+  let s: CartPoleState = initialState();
+  for (let i = 0; i < 100; i++) {
+    s = step(s, 0, params);
+  }
+  assertAlmostEquals(s.theta, 0, 1e-9, "pole angle must remain zero");
+  assertAlmostEquals(s.omega, 0, 1e-9, "pole angular velocity must remain zero");
+  assertAlmostEquals(s.x, 0, 1e-9, "cart must not drift");
+});
+
+Deno.test("a positive force accelerates the cart to the right", () => {
+  const s = step(initialState(), 1);
+  assert(s.v > 0, `expected cart velocity > 0, got ${s.v}`);
+  assert(s.x >= 0, `expected non-negative cart position, got ${s.x}`);
+});
+
+Deno.test("a negative force accelerates the cart to the left", () => {
+  const s = step(initialState(), -1);
+  assert(s.v < 0, `expected cart velocity < 0, got ${s.v}`);
+  assert(s.x <= 0, `expected non-positive cart position, got ${s.x}`);
+});
+
+Deno.test("a slightly tilted pole falls without control", () => {
+  // Start with a small tilt; apply zero force every step. The pole
+  // should accelerate away from vertical and trip the failure threshold
+  // within a reasonable number of steps.
+  let s: CartPoleState = { x: 0, v: 0, theta: 0.05, omega: 0 };
+  let failedStep = -1;
+  for (let i = 0; i < 500; i++) {
+    s = step(s, 0);
+    if (isFailed(s)) {
+      failedStep = i;
+      break;
+    }
+  }
+  assert(failedStep >= 0, "pole should fall without control");
+  assert(failedStep < 200, `expected failure before step 200, got ${failedStep}`);
+});
+
+Deno.test("step is deterministic for identical inputs", () => {
+  const s1 = step({ x: 0.1, v: 0.2, theta: 0.05, omega: -0.1 }, 1);
+  const s2 = step({ x: 0.1, v: 0.2, theta: 0.05, omega: -0.1 }, 1);
+  assertEquals(s1, s2);
+});
+
+Deno.test("isFailed flags an over-tilted pole", () => {
+  const tilted: CartPoleState = {
+    x: 0,
+    v: 0,
+    theta: DEFAULT_LIMITS.maxAngle * 1.5,
+    omega: 0,
+  };
+  assertEquals(isFailed(tilted), true);
+});
+
+Deno.test("isFailed flags a cart that has run off the track", () => {
+  const offTrack: CartPoleState = {
+    x: DEFAULT_LIMITS.maxPosition * 1.5,
+    v: 0,
+    theta: 0,
+    omega: 0,
+  };
+  assertEquals(isFailed(offTrack), true);
+});
+
+Deno.test("isFailed returns false near the centre with a vertical pole", () => {
+  assertEquals(isFailed(initialState()), false);
+});
+
+Deno.test("encodeState produces a 4-element Float32Array of [x, v, theta, omega]", () => {
+  const arr = encodeState({ x: 1, v: 2, theta: 0.1, omega: -0.3 });
+  assertEquals(arr.length, 4);
+  assertAlmostEquals(arr[0], 1, 1e-6);
+  assertAlmostEquals(arr[1], 2, 1e-6);
+  assertAlmostEquals(arr[2], 0.1, 1e-6);
+  assertAlmostEquals(arr[3], -0.3, 1e-6);
+});

--- a/cart_pole/run.sh
+++ b/cart_pole/run.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -euo pipefail
+
+# Cart-Pole Balancing Example Runner
+#
+# Evolves a NEAT-AI controller that balances an inverted pole on a
+# moving cart, saves the champion creature, and writes an SVG snapshot
+# of the run to docs/screenshots/cart_pole.svg.
+
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd -P)"
+cd "${REPO_ROOT}"
+
+# Add deno to PATH if not already available
+if ! command -v deno &> /dev/null; then
+  export PATH="$HOME/.deno/bin:$PATH"
+fi
+
+echo "🎢 Cart-Pole Balancing Example"
+echo ""
+
+deno run \
+  --v8-flags=--max-old-space-size=4096 \
+  --allow-read \
+  --allow-write \
+  --allow-env \
+  --allow-net \
+  cart_pole/cart_pole.ts \
+  "$@"
+
+# Re-format the regenerated SVG so subsequent `deno fmt --check` runs
+# stay clean — the renderer emits compact output for readability, and
+# `deno fmt` prefers attributes split across multiple lines.
+if [[ -f "docs/screenshots/cart_pole.svg" ]]; then
+  deno fmt docs/screenshots/cart_pole.svg > /dev/null
+fi

--- a/cart_pole/svg.ts
+++ b/cart_pole/svg.ts
@@ -1,0 +1,96 @@
+/**
+ * SVG rendering helpers for the cart-pole example.
+ *
+ * Produces a single horizontal strip showing several evenly-spaced
+ * frames from a champion's run. The same primitive (one frame group)
+ * is repeated, so the strip stays cheap to generate and easy to read
+ * compared with the rustneat animated GIF that inspired this example.
+ */
+import type { CartPoleState } from "./physics.ts";
+
+/** Width (in SVG user units) used for a single frame in the strip. */
+export const FRAME_WIDTH = 180;
+
+/** Height of one frame, including the headroom for the swinging pole. */
+export const FRAME_HEIGHT = 220;
+
+/** Half-width of the visible track (m), used to map state.x → pixels. */
+const TRACK_HALF_WIDTH = 2.4;
+
+/** Pixel length of the rendered pole. */
+const POLE_PIXELS = 90;
+
+/**
+ * Render a multi-frame SVG strip of a cart-pole run.
+ *
+ * @param trace Sequential states captured during the run.
+ * @param frameCount Number of evenly-spaced frames to draw. A value of
+ *   1 renders only the first state; values greater than `trace.length`
+ *   are clamped to `trace.length`.
+ */
+export function renderRunSVG(
+  trace: CartPoleState[],
+  frameCount: number,
+): string {
+  if (trace.length === 0) {
+    throw new Error("trace must contain at least one state");
+  }
+  const frames = Math.min(Math.max(1, frameCount), trace.length);
+
+  const sampledIndices: number[] = [];
+  if (frames === 1) {
+    sampledIndices.push(0);
+  } else {
+    for (let i = 0; i < frames; i++) {
+      const idx = Math.round((i * (trace.length - 1)) / (frames - 1));
+      sampledIndices.push(idx);
+    }
+  }
+
+  const svgWidth = FRAME_WIDTH * frames;
+  const svgHeight = FRAME_HEIGHT;
+
+  const groups = sampledIndices.map((traceIdx, frameIdx) =>
+    renderFrameGroup(trace[traceIdx], traceIdx, frameIdx)
+  ).join("\n");
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${svgWidth} ${svgHeight}" ` +
+    `width="${svgWidth}" height="${svgHeight}" role="img" ` +
+    `aria-label="Cart-pole champion run, ${frames} frames">\n` +
+    `  <title>Cart-Pole Champion Run</title>\n` +
+    `  <rect width="${svgWidth}" height="${svgHeight}" fill="#fafafa"/>\n` +
+    `${groups}\n` +
+    `</svg>\n`;
+}
+
+/** Render a single cart-pole frame as a `<g>` element. */
+function renderFrameGroup(
+  state: CartPoleState,
+  traceIdx: number,
+  frameIdx: number,
+): string {
+  const xOffset = frameIdx * FRAME_WIDTH;
+  const groundY = FRAME_HEIGHT - 40;
+  const cartCentre = FRAME_WIDTH / 2 +
+    (state.x / TRACK_HALF_WIDTH) * (FRAME_WIDTH / 2 - 30);
+  const cartTop = groundY - 20;
+  const poleTopX = cartCentre + Math.sin(state.theta) * POLE_PIXELS;
+  const poleTopY = cartTop - Math.cos(state.theta) * POLE_PIXELS;
+
+  return [
+    `  <g class="frame" data-frame="${frameIdx}" data-step="${traceIdx}" ` +
+    `transform="translate(${xOffset},0)">`,
+    `    <rect x="0" y="0" width="${FRAME_WIDTH}" height="${FRAME_HEIGHT}" ` +
+    `fill="none" stroke="#cccccc"/>`,
+    `    <line x1="20" y1="${groundY}" x2="${FRAME_WIDTH - 20}" y2="${groundY}" ` +
+    `stroke="#888888" stroke-width="2"/>`,
+    `    <rect x="${cartCentre - 30}" y="${cartTop}" width="60" height="20" ` +
+    `fill="#4a90d9" stroke="#1f4d80"/>`,
+    `    <line x1="${cartCentre.toFixed(2)}" y1="${cartTop}" ` +
+    `x2="${poleTopX.toFixed(2)}" y2="${poleTopY.toFixed(2)}" ` +
+    `stroke="#e74c3c" stroke-width="6" stroke-linecap="round"/>`,
+    `    <circle cx="${cartCentre.toFixed(2)}" cy="${cartTop}" r="4" fill="#1f4d80"/>`,
+    `    <text x="6" y="14" font-family="monospace" font-size="10" fill="#444">step ${traceIdx}</text>`,
+    `  </g>`,
+  ].join("\n");
+}

--- a/docs/archive_test.ts
+++ b/docs/archive_test.ts
@@ -40,6 +40,7 @@ Deno.test("No PR summary files remain in docs/ root", () => {
       if (entry.name === "pr-summary-36.md") continue;
       if (entry.name === "pr-summary-37.md") continue;
       if (entry.name === "pr-summary-38.md") continue;
+      if (entry.name === "pr-summary-58.md") continue;
       throw new Error(
         `Found unexpected PR summary file in docs/ root: ${entry.name}`,
       );

--- a/docs/pr-summary-58.md
+++ b/docs/pr-summary-58.md
@@ -1,0 +1,79 @@
+## Summary
+
+Adds a new self-contained `cart_pole/` example that evolves a NEAT-AI controller to balance an
+inverted pole on a moving cart, then renders a multi-frame SVG snapshot of the champion's run for
+the README. Closes #58.
+
+The example is intentionally simple — a pure-TypeScript cart-pole simulator (Florian 2007 / OpenAI
+Gym `CartPole-v1`), a four-input/one-output linear NEAT creature, and a hand-rolled generational
+evolutionary loop that uses the existing `common/deterministic_random.ts` PRNG for reproducibility.
+With the default seed the controller reaches the maximum 500 timesteps in a single generation, so
+`./cart_pole/run.sh` finishes in well under a second.
+
+## Evidence
+
+```mermaid
+flowchart LR
+    PHYS["🧮 Pure-TS Cart-Pole Physics"]
+    EVO["🧬 NEAT Evolution<br/>(linear policy)"]
+    CHAMP["🏆 Champion Controller<br/>champion.json"]
+    RUN["▶️ Replay run<br/>capture frames"]
+    SVG["🖼️ docs/screenshots/<br/>cart_pole.svg"]
+    PHYS --> EVO
+    EVO --> CHAMP
+    CHAMP --> RUN
+    RUN --> SVG
+```
+
+The committed `docs/screenshots/cart_pole.svg` (8 evenly-spaced frames) shows the champion balancing
+across the full 500-step run.
+
+Cart-Pole is a backend/CLI example with no web UI to screenshot; verification is via tests and the
+end-to-end runner output below:
+
+```text
+🎢 Cart-Pole Balancing Example
+🧪 Sanity check: hand-crafted tilt-direction policy
+   Hand-crafted policy survived 90 steps.
+
+🧬 Evolving controller...
+   Gen   0  best=500  mean=  39.5
+
+✅ Solved after 1 generations (best=500).
+💾 Saved champion to .synthetic-cart-pole/creatures/champion.json
+🖼️  Wrote screenshot docs/screenshots/cart_pole.svg (501 frames captured)
+🏁 Example completed in 16ms
+```
+
+## Test Plan
+
+New test files (all under `cart_pole/`) — every assertion calls real functions and checks observable
+behaviour:
+
+- `cart_pole/physics_test.ts` — 11 tests covering `initialState`, `step`, `isFailed`, and
+  `encodeState`. Verifies that a stationary cart with a vertical pole stays vertical at zero
+  gravity, that positive/negative force accelerates the cart in the expected direction, that an
+  uncontrolled tilted pole falls within ~200 steps, and that failure thresholds are flagged
+  correctly.
+- `cart_pole/cart_pole_test.ts` — 12 tests covering genome construction, mutation, scoring,
+  evolution, replay, and SVG output. Includes the issue's required hand-crafted "always push toward
+  pole-tilt direction" sanity check (>50 steps) and asserts that `evolveCartPoleController` reaches
+  `MAX_STEPS` with the default seed and that `renderRunSVG` emits the requested number of frame
+  groups.
+
+Existing tests updated to recognise the new example:
+
+- `readme_structure_test.ts` — adds `cart_pole` to `EXAMPLE_DIRS` and "Cart-Pole" to the README name
+  list.
+- `docs/archive_test.ts` — allows `pr-summary-58.md` in the docs root.
+
+Wiring:
+
+- `quality.sh` runs `./cart_pole/run.sh` after the existing examples and cleans
+  `.synthetic-cart-pole/`.
+- `cart_pole/run.sh` re-formats the regenerated SVG via `deno fmt` so subsequent `deno fmt --check`
+  runs stay clean.
+
+The pre-existing `quality.sh` failures (Deno type-check errors in `intelligent_design/` and a WASM
+network-permission error in the crossover/discovery tests) are unrelated to this change — they
+reproduce on the unmodified `Develop` branch.

--- a/docs/screenshots/cart_pole.svg
+++ b/docs/screenshots/cart_pole.svg
@@ -1,0 +1,139 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 1440 220"
+  width="1440"
+  height="220"
+  role="img"
+  aria-label="Cart-pole champion run, 8 frames"
+>
+  <title>Cart-Pole Champion Run</title>
+  <rect width="1440" height="220" fill="#fafafa" />
+  <g class="frame" data-frame="0" data-step="0" transform="translate(0,0)">
+    <rect x="0" y="0" width="180" height="220" fill="none" stroke="#cccccc" />
+    <line x1="20" y1="180" x2="160" y2="180" stroke="#888888" stroke-width="2" />
+    <rect x="60" y="160" width="60" height="20" fill="#4a90d9" stroke="#1f4d80" />
+    <line
+      x1="90.00"
+      y1="160"
+      x2="90.00"
+      y2="70.00"
+      stroke="#e74c3c"
+      stroke-width="6"
+      stroke-linecap="round"
+    />
+    <circle cx="90.00" cy="160" r="4" fill="#1f4d80" />
+    <text x="6" y="14" font-family="monospace" font-size="10" fill="#444">step 0</text>
+  </g>
+  <g class="frame" data-frame="1" data-step="71" transform="translate(180,0)">
+    <rect x="0" y="0" width="180" height="220" fill="none" stroke="#cccccc" />
+    <line x1="20" y1="180" x2="160" y2="180" stroke="#888888" stroke-width="2" />
+    <rect x="55.47505512423814" y="160" width="60" height="20" fill="#4a90d9" stroke="#1f4d80" />
+    <line
+      x1="85.48"
+      y1="160"
+      x2="83.85"
+      y2="70.01"
+      stroke="#e74c3c"
+      stroke-width="6"
+      stroke-linecap="round"
+    />
+    <circle cx="85.48" cy="160" r="4" fill="#1f4d80" />
+    <text x="6" y="14" font-family="monospace" font-size="10" fill="#444">step 71</text>
+  </g>
+  <g class="frame" data-frame="2" data-step="143" transform="translate(360,0)">
+    <rect x="0" y="0" width="180" height="220" fill="none" stroke="#cccccc" />
+    <line x1="20" y1="180" x2="160" y2="180" stroke="#888888" stroke-width="2" />
+    <rect x="48.91502516180928" y="160" width="60" height="20" fill="#4a90d9" stroke="#1f4d80" />
+    <line
+      x1="78.92"
+      y1="160"
+      x2="78.44"
+      y2="70.00"
+      stroke="#e74c3c"
+      stroke-width="6"
+      stroke-linecap="round"
+    />
+    <circle cx="78.92" cy="160" r="4" fill="#1f4d80" />
+    <text x="6" y="14" font-family="monospace" font-size="10" fill="#444">step 143</text>
+  </g>
+  <g class="frame" data-frame="3" data-step="214" transform="translate(540,0)">
+    <rect x="0" y="0" width="180" height="220" fill="none" stroke="#cccccc" />
+    <line x1="20" y1="180" x2="160" y2="180" stroke="#888888" stroke-width="2" />
+    <rect x="42.09143379100519" y="160" width="60" height="20" fill="#4a90d9" stroke="#1f4d80" />
+    <line
+      x1="72.09"
+      y1="160"
+      x2="72.04"
+      y2="70.00"
+      stroke="#e74c3c"
+      stroke-width="6"
+      stroke-linecap="round"
+    />
+    <circle cx="72.09" cy="160" r="4" fill="#1f4d80" />
+    <text x="6" y="14" font-family="monospace" font-size="10" fill="#444">step 214</text>
+  </g>
+  <g class="frame" data-frame="4" data-step="286" transform="translate(720,0)">
+    <rect x="0" y="0" width="180" height="220" fill="none" stroke="#cccccc" />
+    <line x1="20" y1="180" x2="160" y2="180" stroke="#888888" stroke-width="2" />
+    <rect x="34.63387649650247" y="160" width="60" height="20" fill="#4a90d9" stroke="#1f4d80" />
+    <line
+      x1="64.63"
+      y1="160"
+      x2="64.81"
+      y2="70.00"
+      stroke="#e74c3c"
+      stroke-width="6"
+      stroke-linecap="round"
+    />
+    <circle cx="64.63" cy="160" r="4" fill="#1f4d80" />
+    <text x="6" y="14" font-family="monospace" font-size="10" fill="#444">step 286</text>
+  </g>
+  <g class="frame" data-frame="5" data-step="357" transform="translate(900,0)">
+    <rect x="0" y="0" width="180" height="220" fill="none" stroke="#cccccc" />
+    <line x1="20" y1="180" x2="160" y2="180" stroke="#888888" stroke-width="2" />
+    <rect x="26.823017091931987" y="160" width="60" height="20" fill="#4a90d9" stroke="#1f4d80" />
+    <line
+      x1="56.82"
+      y1="160"
+      x2="56.42"
+      y2="70.00"
+      stroke="#e74c3c"
+      stroke-width="6"
+      stroke-linecap="round"
+    />
+    <circle cx="56.82" cy="160" r="4" fill="#1f4d80" />
+    <text x="6" y="14" font-family="monospace" font-size="10" fill="#444">step 357</text>
+  </g>
+  <g class="frame" data-frame="6" data-step="429" transform="translate(1080,0)">
+    <rect x="0" y="0" width="180" height="220" fill="none" stroke="#cccccc" />
+    <line x1="20" y1="180" x2="160" y2="180" stroke="#888888" stroke-width="2" />
+    <rect x="18.096686322390433" y="160" width="60" height="20" fill="#4a90d9" stroke="#1f4d80" />
+    <line
+      x1="48.10"
+      y1="160"
+      x2="47.60"
+      y2="70.00"
+      stroke="#e74c3c"
+      stroke-width="6"
+      stroke-linecap="round"
+    />
+    <circle cx="48.10" cy="160" r="4" fill="#1f4d80" />
+    <text x="6" y="14" font-family="monospace" font-size="10" fill="#444">step 429</text>
+  </g>
+  <g class="frame" data-frame="7" data-step="500" transform="translate(1260,0)">
+    <rect x="0" y="0" width="180" height="220" fill="none" stroke="#cccccc" />
+    <line x1="20" y1="180" x2="160" y2="180" stroke="#888888" stroke-width="2" />
+    <rect x="8.568582417224675" y="160" width="60" height="20" fill="#4a90d9" stroke="#1f4d80" />
+    <line
+      x1="38.57"
+      y1="160"
+      x2="36.68"
+      y2="70.02"
+      stroke="#e74c3c"
+      stroke-width="6"
+      stroke-linecap="round"
+    />
+    <circle cx="38.57" cy="160" r="4" fill="#1f4d80" />
+    <text x="6" y="14" font-family="monospace" font-size="10" fill="#444">step 500</text>
+  </g>
+</svg>

--- a/quality.sh
+++ b/quality.sh
@@ -106,7 +106,7 @@ fi
 # --- Example Programs ---
 # Clean up any previous synthetic data
 echo "Cleaning up previous runs..."
-rm -rf .synthetic-discovery .synthetic-intelligent-design .synthetic-suggest-improvements .synthetic-crossover .discovery
+rm -rf .synthetic-discovery .synthetic-intelligent-design .synthetic-suggest-improvements .synthetic-crossover .synthetic-cart-pole .discovery
 echo ""
 
 # Run the Intelligent Design example
@@ -117,6 +117,9 @@ run_example "Discovery Example" "./discovery/run.sh"
 
 # Run the Crossover (Breeding) example
 run_example "Crossover (Breeding) Example" "./crossover/run.sh"
+
+# Run the Cart-Pole Balancing example
+run_example "Cart-Pole Balancing Example" "./cart_pole/run.sh"
 
 # Run the Suggest Improvements example
 run_example "Suggest Improvements" "./suggest_improvements/run.sh"

--- a/readme_structure_test.ts
+++ b/readme_structure_test.ts
@@ -12,6 +12,7 @@ import { assertEquals, assertStringIncludes } from "@std/assert";
 const README_PATH = "README.md";
 
 const EXAMPLE_DIRS = [
+  "cart_pole",
   "crossover",
   "discovery",
   "intelligent_design",
@@ -83,6 +84,7 @@ Deno.test("README.md introduces every example by name", () => {
     "Intelligent Design",
     "Discovery",
     "Crossover",
+    "Cart-Pole",
     "Suggest Improvements",
   ];
   for (const name of required) {


### PR DESCRIPTION
## Summary

Adds a new self-contained `cart_pole/` example that evolves a NEAT-AI controller to balance an
inverted pole on a moving cart, then renders a multi-frame SVG snapshot of the champion's run for
the README. Closes #58.

The example is intentionally simple — a pure-TypeScript cart-pole simulator (Florian 2007 / OpenAI
Gym `CartPole-v1`), a four-input/one-output linear NEAT creature, and a hand-rolled generational
evolutionary loop that uses the existing `common/deterministic_random.ts` PRNG for reproducibility.
With the default seed the controller reaches the maximum 500 timesteps in a single generation, so
`./cart_pole/run.sh` finishes in well under a second.

## Evidence

```mermaid
flowchart LR
    PHYS["🧮 Pure-TS Cart-Pole Physics"]
    EVO["🧬 NEAT Evolution<br/>(linear policy)"]
    CHAMP["🏆 Champion Controller<br/>champion.json"]
    RUN["▶️ Replay run<br/>capture frames"]
    SVG["🖼️ docs/screenshots/<br/>cart_pole.svg"]
    PHYS --> EVO
    EVO --> CHAMP
    CHAMP --> RUN
    RUN --> SVG
```

The committed `docs/screenshots/cart_pole.svg` (8 evenly-spaced frames) shows the champion balancing
across the full 500-step run.

Cart-Pole is a backend/CLI example with no web UI to screenshot; verification is via tests and the
end-to-end runner output below:

```text
🎢 Cart-Pole Balancing Example
🧪 Sanity check: hand-crafted tilt-direction policy
   Hand-crafted policy survived 90 steps.

🧬 Evolving controller...
   Gen   0  best=500  mean=  39.5

✅ Solved after 1 generations (best=500).
💾 Saved champion to .synthetic-cart-pole/creatures/champion.json
🖼️  Wrote screenshot docs/screenshots/cart_pole.svg (501 frames captured)
🏁 Example completed in 16ms
```

## Test Plan

New test files (all under `cart_pole/`) — every assertion calls real functions and checks observable
behaviour:

- `cart_pole/physics_test.ts` — 11 tests covering `initialState`, `step`, `isFailed`, and
  `encodeState`. Verifies that a stationary cart with a vertical pole stays vertical at zero
  gravity, that positive/negative force accelerates the cart in the expected direction, that an
  uncontrolled tilted pole falls within ~200 steps, and that failure thresholds are flagged
  correctly.
- `cart_pole/cart_pole_test.ts` — 12 tests covering genome construction, mutation, scoring,
  evolution, replay, and SVG output. Includes the issue's required hand-crafted "always push toward
  pole-tilt direction" sanity check (>50 steps) and asserts that `evolveCartPoleController` reaches
  `MAX_STEPS` with the default seed and that `renderRunSVG` emits the requested number of frame
  groups.

Existing tests updated to recognise the new example:

- `readme_structure_test.ts` — adds `cart_pole` to `EXAMPLE_DIRS` and "Cart-Pole" to the README name
  list.
- `docs/archive_test.ts` — allows `pr-summary-58.md` in the docs root.

Wiring:

- `quality.sh` runs `./cart_pole/run.sh` after the existing examples and cleans
  `.synthetic-cart-pole/`.
- `cart_pole/run.sh` re-formats the regenerated SVG via `deno fmt` so subsequent `deno fmt --check`
  runs stay clean.

The pre-existing `quality.sh` failures (Deno type-check errors in `intelligent_design/` and a WASM
network-permission error in the crossover/discovery tests) are unrelated to this change — they
reproduce on the unmodified `Develop` branch.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-58 -->