### PR TITLE
Add common/data_cache.ts dataset fetch & cache helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,48 @@ benchmark will expose the regression.
 Run `./quality.sh` before merging. It executes linting, formatting, unit tests, and all example
 programs. See [README.md](README.md#-quality-check) for full details.
 
+## 📦 Shared Utilities
+
+The `common/` directory holds helpers that every example may reuse. Reach for these before
+reinventing equivalent logic in a new example.
+
+| Module                           | Purpose                                                       |
+| -------------------------------- | ------------------------------------------------------------- |
+| `common/deterministic_random.ts` | Seeded PRNG for reproducible data generation.                 |
+| `common/synthetic_data.ts`       | Synthetic dataset generation and scoring.                     |
+| `common/working_dirs.ts`         | Standard hidden working-directory layout for examples.        |
+| `common/data_cache.ts`           | Download datasets into hidden directories with on-disk cache. |
+
+### `common/data_cache.ts`
+
+`fetchDataset(opts)` downloads a dataset file into a hidden per-example directory (e.g.
+`.synthetic-mnist/data/train.csv`) and caches it on disk so subsequent runs do not re-download. Pass
+a single URL or an array of mirror URLs and (optionally) a SHA-256 digest:
+
+```ts
+import { fetchDataset } from "../common/data_cache.ts";
+
+await fetchDataset({
+  url: [
+    "https://primary.example.com/mnist/train.csv",
+    "https://mirror.example.com/mnist/train.csv",
+  ],
+  path: ".synthetic-mnist/data/train.csv",
+  sha256: "abc123…",
+});
+```
+
+Behaviour:
+
+- Skips the download when the file already exists (and, when a digest is supplied, when the on-disk
+  digest matches).
+- Streams the response body straight to disk — no in-memory buffering.
+- Verifies the digest after writing; on mismatch the partial file is deleted and the call rejects.
+- Tries each mirror in turn; an HTTP error or network failure on one mirror falls back to the next,
+  and the final error message lists every URL that was tried.
+
+The helper relies on Deno's built-in `fetch` and `crypto.subtle` — no extra dependencies are added.
+
 ## 📂 Project Structure
 
 ```
@@ -76,6 +118,8 @@ common/
   synthetic_data_test.ts           — Unit tests for data generation and scoring
   working_dirs.ts                  — Shared working directory setup
   working_dirs_test.ts             — Unit tests for directory setup
+  data_cache.ts                    — Hidden-directory dataset download with on-disk cache
+  data_cache_test.ts               — Unit tests for the dataset cache
 
 crossover/
   crossover_example.ts             — Example: breed two creatures (crossover)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,6 +95,19 @@ import { generateSyntheticData, scoreCreature } from "../common/synthetic_data.t
 import { setupWorkingDirs } from "../common/working_dirs.ts";
 ```
 
+If your example needs a real-world dataset, do **not** commit the raw data — download it at runtime
+with [`common/data_cache.ts`](AGENTS.md#-shared-utilities) so the repository stays small:
+
+```ts
+import { fetchDataset } from "../common/data_cache.ts";
+
+await fetchDataset({
+  url: "https://example.com/dataset.csv",
+  path: ".my-example/data/dataset.csv",
+  sha256: "abc123…", // optional integrity check
+});
+```
+
 ### 3. 🧪 Write unit tests
 
 Create `my_example/my_example_test.ts` next to the module. Tests must be "what" tests — call real

--- a/common/data_cache.ts
+++ b/common/data_cache.ts
@@ -1,0 +1,163 @@
+/**
+ * Shared dataset cache helper for NEAT-AI examples.
+ *
+ * Examples that train on real-world data (e.g. MNIST, stock prices) should
+ * not bloat the repository with raw datasets. Instead, they call
+ * `fetchDataset` to download the file into a hidden working directory the
+ * first time it is needed, and reuse it on subsequent runs.
+ *
+ * The helper:
+ *   - Skips the download when the file already exists (and, when an
+ *     expected SHA-256 digest is supplied, when the on-disk digest matches).
+ *   - Streams the response body to disk so large files do not need to be
+ *     buffered in memory.
+ *   - Verifies the digest after writing and deletes the partial file on
+ *     mismatch so the next call can retry cleanly.
+ *   - Tries each mirror URL in turn so a 404 or transient network failure
+ *     on one mirror falls back to the next.
+ *
+ * Implementation uses Deno's built-in `fetch` and `crypto.subtle` — no
+ * extra dependencies are required.
+ */
+
+import { ensureDir } from "@std/fs";
+import { dirname } from "@std/path";
+
+/** Options for {@link fetchDataset}. */
+export interface FetchDatasetOptions {
+  /** A single URL or a list of mirror URLs to try in order. */
+  url: string | string[];
+  /**
+   * Destination file path on disk. Parent directories are created
+   * automatically. Examples typically place this under a hidden directory
+   * such as `.synthetic-mnist/data/train.csv`.
+   */
+  path: string;
+  /**
+   * Optional lowercase hex-encoded SHA-256 digest of the expected file
+   * contents. When supplied, the helper verifies the digest after writing
+   * and rejects on mismatch. Cache hits also re-validate against this
+   * digest before being trusted.
+   */
+  sha256?: string;
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await Deno.stat(path);
+    return true;
+  } catch (err) {
+    if (err instanceof Deno.errors.NotFound) {
+      return false;
+    }
+    throw err;
+  }
+}
+
+async function computeSha256(path: string): Promise<string> {
+  const data = await Deno.readFile(path);
+  const hash = await crypto.subtle.digest("SHA-256", data);
+  return Array.from(new Uint8Array(hash))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+async function removeIfPresent(path: string): Promise<void> {
+  try {
+    await Deno.remove(path);
+  } catch (err) {
+    if (!(err instanceof Deno.errors.NotFound)) {
+      throw err;
+    }
+  }
+}
+
+/**
+ * Downloads a dataset file with on-disk caching and optional integrity
+ * verification.
+ *
+ * Returns the destination path on success. Throws an `Error` with a
+ * message that lists every attempted URL when no mirror succeeds, and
+ * a digest-mismatch error (with the partial file removed) when the
+ * downloaded bytes do not match the expected SHA-256.
+ */
+export async function fetchDataset(opts: FetchDatasetOptions): Promise<string> {
+  const { path } = opts;
+  const expectedDigest = opts.sha256?.toLowerCase();
+  const urls = Array.isArray(opts.url) ? opts.url : [opts.url];
+
+  if (urls.length === 0) {
+    throw new Error("fetchDataset: at least one URL must be provided");
+  }
+
+  // Cache hit? Optionally re-validate against the expected digest.
+  if (await fileExists(path)) {
+    if (!expectedDigest) {
+      return path;
+    }
+    const onDisk = await computeSha256(path);
+    if (onDisk === expectedDigest) {
+      return path;
+    }
+    // Stale or corrupt cache entry — remove and re-download.
+    await removeIfPresent(path);
+  }
+
+  await ensureDir(dirname(path));
+
+  const errors: string[] = [];
+  for (const url of urls) {
+    let response: Response;
+    try {
+      response = await fetch(url);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      errors.push(`${url}: ${message}`);
+      continue;
+    }
+
+    if (!response.ok) {
+      // Drain the body so the connection can be released.
+      try {
+        await response.body?.cancel();
+      } catch {
+        // ignore — best-effort cleanup
+      }
+      errors.push(`${url}: HTTP ${response.status} ${response.statusText}`.trim());
+      continue;
+    }
+
+    if (!response.body) {
+      errors.push(`${url}: response has no body`);
+      continue;
+    }
+
+    try {
+      const file = await Deno.open(path, { write: true, create: true, truncate: true });
+      await response.body.pipeTo(file.writable);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      await removeIfPresent(path);
+      errors.push(`${url}: ${message}`);
+      continue;
+    }
+
+    if (expectedDigest) {
+      const actual = await computeSha256(path);
+      if (actual !== expectedDigest) {
+        await removeIfPresent(path);
+        throw new Error(
+          `fetchDataset: digest mismatch for ${url} ` +
+            `(expected ${expectedDigest}, got ${actual})`,
+        );
+      }
+    }
+
+    return path;
+  }
+
+  throw new Error(
+    `fetchDataset: failed to download ${path} from ${urls.length} URL(s):\n` +
+      errors.map((e) => `  - ${e}`).join("\n"),
+  );
+}

--- a/common/data_cache_test.ts
+++ b/common/data_cache_test.ts
@@ -1,0 +1,161 @@
+/**
+ * Unit tests for the shared dataset cache helper.
+ *
+ * These are "what" tests — they verify the observable behaviour of
+ * `fetchDataset` (file contents, request counts, error shape) without
+ * inspecting the implementation.
+ */
+
+import { assertEquals, assertRejects } from "@std/assert";
+import { existsSync } from "@std/fs";
+import { join } from "@std/path";
+
+import { fetchDataset } from "./data_cache.ts";
+
+interface TestServer {
+  port: number;
+  readonly count: number;
+  stop(): Promise<void>;
+}
+
+function startServer(handler: (req: Request) => Response | Promise<Response>): TestServer {
+  const ac = new AbortController();
+  let count = 0;
+  const server = Deno.serve(
+    { port: 0, signal: ac.signal, onListen: () => {} },
+    (req) => {
+      count++;
+      return handler(req);
+    },
+  );
+  return {
+    port: (server.addr as Deno.NetAddr).port,
+    get count() {
+      return count;
+    },
+    async stop() {
+      ac.abort();
+      await server.finished;
+    },
+  };
+}
+
+Deno.test("fetchDataset downloads a file and writes the expected bytes", async () => {
+  const tmp = await Deno.makeTempDir({ prefix: "data_cache_test_" });
+  const expected = new TextEncoder().encode("hello, world");
+  const server = startServer(() => new Response(expected));
+  const dest = join(tmp, "nested", "hello.bin");
+
+  try {
+    const result = await fetchDataset({
+      url: `http://localhost:${server.port}/hello.bin`,
+      path: dest,
+    });
+
+    assertEquals(result, dest, "should return the destination path");
+    assertEquals(existsSync(dest), true, "file should exist on disk");
+    const got = await Deno.readFile(dest);
+    assertEquals(got, expected, "file contents should match the served bytes");
+  } finally {
+    await server.stop();
+    await Deno.remove(tmp, { recursive: true });
+  }
+});
+
+Deno.test("fetchDataset uses the on-disk cache on the second call", async () => {
+  const tmp = await Deno.makeTempDir({ prefix: "data_cache_test_" });
+  const payload = new TextEncoder().encode("cache me");
+  const server = startServer(() => new Response(payload));
+  const dest = join(tmp, "cached.bin");
+
+  try {
+    await fetchDataset({ url: `http://localhost:${server.port}/x`, path: dest });
+    await fetchDataset({ url: `http://localhost:${server.port}/x`, path: dest });
+
+    assertEquals(server.count, 1, "second call must not re-download");
+  } finally {
+    await server.stop();
+    await Deno.remove(tmp, { recursive: true });
+  }
+});
+
+Deno.test("fetchDataset rejects on digest mismatch and removes the partial file", async () => {
+  const tmp = await Deno.makeTempDir({ prefix: "data_cache_test_" });
+  const payload = new TextEncoder().encode("payload that will not match");
+  const server = startServer(() => new Response(payload));
+  const dest = join(tmp, "bad.bin");
+  const wrongDigest = "0".repeat(64);
+
+  try {
+    await assertRejects(
+      () =>
+        fetchDataset({
+          url: `http://localhost:${server.port}/x`,
+          path: dest,
+          sha256: wrongDigest,
+        }),
+      Error,
+      "digest",
+    );
+    assertEquals(existsSync(dest), false, "partial file should be removed on mismatch");
+  } finally {
+    await server.stop();
+    await Deno.remove(tmp, { recursive: true });
+  }
+});
+
+Deno.test("fetchDataset falls back to a mirror when the first URL 404s", async () => {
+  const tmp = await Deno.makeTempDir({ prefix: "data_cache_test_" });
+  const payload = new TextEncoder().encode("from the second mirror");
+  const failing = startServer(() => new Response("not found", { status: 404 }));
+  const working = startServer(() => new Response(payload));
+  const dest = join(tmp, "mirror.bin");
+
+  try {
+    await fetchDataset({
+      url: [
+        `http://localhost:${failing.port}/x`,
+        `http://localhost:${working.port}/x`,
+      ],
+      path: dest,
+    });
+
+    const got = await Deno.readFile(dest);
+    assertEquals(got, payload, "final file should match the working mirror");
+    assertEquals(failing.count, 1, "first mirror should be tried once");
+    assertEquals(working.count, 1, "second mirror should be tried once");
+  } finally {
+    await failing.stop();
+    await working.stop();
+    await Deno.remove(tmp, { recursive: true });
+  }
+});
+
+Deno.test("fetchDataset honours a matching digest as a cache hit", async () => {
+  const tmp = await Deno.makeTempDir({ prefix: "data_cache_test_" });
+  const payload = new TextEncoder().encode("digest-match");
+  const hash = await crypto.subtle.digest("SHA-256", payload);
+  const expectedDigest = Array.from(new Uint8Array(hash))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+  const server = startServer(() => new Response(payload));
+  const dest = join(tmp, "digest.bin");
+
+  try {
+    await fetchDataset({
+      url: `http://localhost:${server.port}/x`,
+      path: dest,
+      sha256: expectedDigest,
+    });
+    await fetchDataset({
+      url: `http://localhost:${server.port}/x`,
+      path: dest,
+      sha256: expectedDigest,
+    });
+
+    assertEquals(server.count, 1, "second call should not re-download when digest matches");
+  } finally {
+    await server.stop();
+    await Deno.remove(tmp, { recursive: true });
+  }
+});

--- a/docs/pr-summary-76.md
+++ b/docs/pr-summary-76.md
@@ -1,0 +1,54 @@
+# Add `common/data_cache.ts` — fetch & cache datasets in hidden directories
+
+## Summary
+
+Adds a shared `fetchDataset` helper so future examples (MNIST, stock market, etc.) can pull
+real-world data at runtime without bloating the repository. The helper downloads into a hidden
+per-example directory, streams the response to disk, optionally verifies a SHA-256 digest, and falls
+back to mirror URLs on HTTP or network failure. Documentation in `AGENTS.md` and `CONTRIBUTING.md`
+now points contributors at the helper. Implementation uses only Deno's built-in `fetch` and
+`crypto.subtle` — no new dependencies.
+
+Closes #76.
+
+## Evidence
+
+- New unit tests in `common/data_cache_test.ts` cover the four "what" scenarios required by the
+  issue plus a digest-cache-hit case:
+  - happy path (download writes the served bytes)
+  - cache hit (second call does not re-download — verified via request counter on a `Deno.serve`
+    test server)
+  - digest mismatch (call rejects, partial file removed)
+  - mirror fallback (first URL 404s, second succeeds)
+  - digest-validated cache hit (matching digest skips re-download)
+- All five tests pass under
+  `deno test --no-check --allow-read --allow-write --allow-env --allow-net`.
+- `./quality.sh` passes — lint, fmt, type check, unit tests (324 total), and every example runner.
+
+```mermaid
+flowchart LR
+    CALL["fetchDataset(url, path, digest?)"]
+    EXISTS{"file exists\nand digest matches?"}
+    DOWNLOAD["fetch + stream to disk"]
+    NEXT["try next mirror"]
+    VERIFY{"computed digest\n== expected?"}
+    READY["✅ file ready"]
+    FAIL["❌ delete partial\nthrow"]
+
+    CALL --> EXISTS
+    EXISTS -- yes --> READY
+    EXISTS -- no --> DOWNLOAD
+    DOWNLOAD -- HTTP/network error --> NEXT
+    NEXT --> DOWNLOAD
+    DOWNLOAD -- ok --> VERIFY
+    VERIFY -- yes --> READY
+    VERIFY -- no --> FAIL
+```
+
+This is a CLI/library change with no UI surface, so no screenshots are attached.
+
+## Test Plan
+
+- [x] `common/data_cache_test.ts` — five Deno tests covering happy path, cache hit, digest mismatch,
+      mirror fallback, and digest-validated cache hit.
+- [x] `./quality.sh` passes locally (lint, fmt, type check, unit tests, every example runner).


### PR DESCRIPTION
# Add `common/data_cache.ts` — fetch & cache datasets in hidden directories

## Summary

Adds a shared `fetchDataset` helper so future examples (MNIST, stock market, etc.) can pull
real-world data at runtime without bloating the repository. The helper downloads into a hidden
per-example directory, streams the response to disk, optionally verifies a SHA-256 digest, and falls
back to mirror URLs on HTTP or network failure. Documentation in `AGENTS.md` and `CONTRIBUTING.md`
now points contributors at the helper. Implementation uses only Deno's built-in `fetch` and
`crypto.subtle` — no new dependencies.

Closes #76.

## Evidence

- New unit tests in `common/data_cache_test.ts` cover the four "what" scenarios required by the
  issue plus a digest-cache-hit case:
  - happy path (download writes the served bytes)
  - cache hit (second call does not re-download — verified via request counter on a `Deno.serve`
    test server)
  - digest mismatch (call rejects, partial file removed)
  - mirror fallback (first URL 404s, second succeeds)
  - digest-validated cache hit (matching digest skips re-download)
- All five tests pass under
  `deno test --no-check --allow-read --allow-write --allow-env --allow-net`.
- `./quality.sh` passes — lint, fmt, type check, unit tests (324 total), and every example runner.

```mermaid
flowchart LR
    CALL["fetchDataset(url, path, digest?)"]
    EXISTS{"file exists\nand digest matches?"}
    DOWNLOAD["fetch + stream to disk"]
    NEXT["try next mirror"]
    VERIFY{"computed digest\n== expected?"}
    READY["✅ file ready"]
    FAIL["❌ delete partial\nthrow"]

    CALL --> EXISTS
    EXISTS -- yes --> READY
    EXISTS -- no --> DOWNLOAD
    DOWNLOAD -- HTTP/network error --> NEXT
    NEXT --> DOWNLOAD
    DOWNLOAD -- ok --> VERIFY
    VERIFY -- yes --> READY
    VERIFY -- no --> FAIL
```

This is a CLI/library change with no UI surface, so no screenshots are attached.

## Test Plan

- [x] `common/data_cache_test.ts` — five Deno tests covering happy path, cache hit, digest mismatch,
      mirror fallback, and digest-validated cache hit.
- [x] `./quality.sh` passes locally (lint, fmt, type check, unit tests, every example runner).



---

🤖 Processed by: stservice<!-- vibe-worker-issue-76 -->