### PR TITLE
Add Snake game example with animated playthrough SVG (Issue #81)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ walkthrough — the per-example README explains the workflow, options, and outpu
 | [🎢 Cart-Pole](cart_pole/README.md)                       | Evolve a controller that balances an inverted pole on a moving cart and render the run as an SVG strip.   | `./cart_pole/run.sh`            |
 | [🚀 Lunar Lander](lunar_lander/README.md)                 | Evolve a controller that lands a 2D lunar lander softly on a marked pad with limited fuel.                | `./lunar_lander/run.sh`         |
 | [🚗 Mountain Car](mountain_car/README.md)                 | Evolve a swing-up controller that drives an under-powered car up a sinusoidal hill to the goal flag.      | `./mountain_car/run.sh`         |
+| [🐍 Snake](snake_game/README.md)                          | Evolve a controller that plays the classic Snake grid game and render the playthrough as an animated SVG. | `./snake_game/run.sh`           |
 | [🧬 Intelligent Design](intelligent_design/README.md)     | Systematically swap activation functions on hidden neurons to find better squashes than random mutation.  | `./intelligent_design/run.sh`   |
 | [🔍 Discovery](discovery/README.md)                       | Cripple a creature by removing a neuron, then use evolutionary search to recover its behaviour.           | `./discovery/run.sh`            |
 | [🔀 Crossover](crossover/README.md)                       | Breed two parents with different architectures into an offspring and (optionally) evolve it further.      | `./crossover/run.sh`            |
@@ -60,6 +61,15 @@ An under-powered car oscillates across a sinusoidal valley and finally crests th
 `x = 0.5`. The car icon animates along the recorded trajectory and changes colour the moment it
 crosses the flag line, with a bottom progress bar marking the playhead.
 
+### 🐍 Snake — animated playthrough
+
+![Snake champion playthrough — an animated SVG of the snake moving across a 12×12 board, growing visibly when it eats food](docs/screenshots/snake_game.svg)
+
+A NEAT-AI controller plays the classic Snake grid game on a 12×12 board. The snake is rendered as a
+chain of rounded rectangles (a yellow head and green body); the food cell pulses via opacity
+animation; the score counter ticks up via SMIL `<set>` overlays whenever the snake eats. A bottom
+playhead progress bar sweeps left-to-right to mark the loop.
+
 ### 📈 Stock Market — direction predictions
 
 ![Stock Market champion test window — an animated S&P 500 close-price line with four-colour ▲/▼ markers showing predicted-vs-realised direction at each bar](docs/screenshots/stock_market.svg)
@@ -87,6 +97,7 @@ flowchart TD
     CART["🎢 Cart-Pole<br/>Balance an inverted pole<br/>on a moving cart"]
     LUNAR["🚀 Lunar Lander<br/>Land softly on a flat<br/>pad with limited fuel"]
     MCAR["🚗 Mountain Car<br/>Swing up an under-powered<br/>car to crest the goal flag"]
+    SNAKE["🐍 Snake<br/>Play the classic Snake<br/>grid game"]
     ID["🧬 Intelligent Design<br/>Optimise activation functions<br/>for hidden neurons"]
     DISC["🔍 Discovery<br/>Recover missing neurons<br/>via evolutionary search"]
     CROSS["🔀 Crossover<br/>Breed two creatures<br/>to produce offspring"]
@@ -99,6 +110,7 @@ flowchart TD
     COMMON --> CART
     COMMON --> LUNAR
     COMMON --> MCAR
+    COMMON --> SNAKE
     COMMON --> ID
     COMMON --> DISC
     COMMON --> CROSS
@@ -112,6 +124,7 @@ flowchart TD
     style CART fill:#9b59b6,stroke:#333,color:#fff
     style LUNAR fill:#1abc9c,stroke:#333,color:#fff
     style MCAR fill:#e67e22,stroke:#333,color:#fff
+    style SNAKE fill:#27ae60,stroke:#333,color:#fff
     style ID fill:#7ed321,stroke:#333,color:#fff
     style DISC fill:#bd10e0,stroke:#333,color:#fff
     style CROSS fill:#e74c3c,stroke:#333,color:#fff
@@ -144,6 +157,7 @@ flowchart BT
         CART["🎢 cart_pole/"]
         LUNAR["🚀 lunar_lander/"]
         MCAR["🚗 mountain_car/"]
+        SNAKE["🐍 snake_game/"]
         ID["🧬 intelligent_design/"]
         DISC["🔍 discovery/"]
         CROSS["🔀 crossover/"]
@@ -157,6 +171,7 @@ flowchart BT
     common --> CART
     common --> LUNAR
     common --> MCAR
+    common --> SNAKE
     common --> ID
     common --> DISC
     common --> CROSS

--- a/docs/pr-summary-81.md
+++ b/docs/pr-summary-81.md
@@ -1,0 +1,83 @@
+# Add Snake Game example with animated playthrough SVG
+
+## Summary
+
+Adds a new `snake_game/` example that evolves a NEAT-AI controller to play the classic Snake grid
+game on a 12×12 board, plus an animated SVG playthrough rendered to
+`docs/screenshots/snake_game.svg`. The example follows the same shape as the other control examples
+(`mountain_car/`, `lunar_lander/`, `cart_pole/`): pure-TypeScript simulator, sensor + action
+encoding, evolutionary loop, animated SVG renderer, "what" tests, and a `run.sh`. Wires into the
+project quality gate (`quality.sh`), the top-level README's Examples table and Screenshots section,
+and the README structure tests. Closes #81.
+
+## Evidence
+
+The change is a CLI / simulation example with no web UI to screenshot. Visual verification comes
+from the committed `docs/screenshots/snake_game.svg`, which is animated SMIL output.
+
+Pipeline (matches the issue diagram):
+
+```mermaid
+flowchart LR
+    GAME["🐍 Snake grid game<br/>(snake.ts)"]
+    SENSE["🛰️ Wall, food &amp; tail sensors<br/>(agent.ts)"]
+    POLICY["🧠 Network → heading"]
+    STEP["⏱️ Move + grow / die"]
+    DONE{"dead or<br/>500 steps?"}
+    SCORE["📏 Food × 100 − penalties"]
+    SVG["🖼️ Animated playthrough SVG"]
+
+    GAME --> SENSE --> POLICY --> STEP --> DONE
+    DONE -- no --> SENSE
+    DONE -- yes --> SCORE --> SVG
+```
+
+Champion run (default seed):
+
+- Champion ate **1 food** in **10 steps** (score = 49.00) after 80 generations.
+- `./quality.sh` passes end-to-end (lint, fmt, type-check, **474 unit tests**, all 11 example
+  runners including the new Snake one).
+
+## Test Plan
+
+New tests added under `snake_game/`:
+
+- `snake_test.ts` — game model:
+  - Happy path: snake placed next to food eats it, length increments, food respawns off-body.
+  - Wall collision ends the episode.
+  - Self collision ends the episode.
+  - 180° reversal request is ignored.
+  - Non-eating move keeps body length constant.
+  - `spawnFood`, `inBounds`, `cellsEqual`, `isReverse` boundary cases.
+  - `newGame` is deterministic for the same seed.
+- `agent_test.ts` — sensor encoding & action decoding:
+  - Encoded vector has exactly `INPUT_COUNT` channels.
+  - Wall distances respect the grid bounds.
+  - Food and tail deltas point in the correct direction.
+  - Length sensor scales with body size.
+  - `headingLeft` / `headingRight` rotate cardinally.
+  - `decodeAction` picks the argmax.
+- `snake_game_test.ts` — evolutionary loop & SVG renderer:
+  - `buildInitialCreatureJSON` shape and validation.
+  - `genesFromCreatureJSON` round-trips weights and biases.
+  - `randomCreatureJSON` deterministic for same seed.
+  - `mutateCreatureJSON` yields a valid creature.
+  - `scoreController` returns a finite score.
+  - **`evolveSnakeController` champion eats at least one food item** (acceptance criterion).
+  - **Reproducibility** — same seed produces a byte-identical champion.
+  - Different seeds produce different champions.
+  - `replayController` emits a non-empty trace starting at the initial state.
+  - `renderRunSVG` emits an `<svg>` root with SMIL animation elements, looping `repeatCount`,
+    snake-head/food/board classes, and rejects an empty trace.
+
+Existing tests updated:
+
+- `readme_structure_test.ts` — `EXAMPLE_DIRS`, `SCREENSHOT_PATHS`, and the required example-name
+  list now include `snake_game` / `snake_game.svg` / "Snake".
+
+Run them locally:
+
+```bash
+deno test --no-check --allow-read --allow-write --allow-env --allow-net snake_game/
+./quality.sh
+```

--- a/docs/screenshots/snake_game.svg
+++ b/docs/screenshots/snake_game.svg
@@ -1,0 +1,395 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 480 520"
+  width="480"
+  height="520"
+  role="img"
+  aria-label="Snake champion playthrough, animated through 11 keyframes"
+>
+  <title>Snake Champion Playthrough (animated)</title>
+  <desc>SMIL-animated SVG: a NEAT-AI controller plays Snake on a 12×12 grid. The snake body grows whenever the head meets food. Loops every 8 seconds.</desc>
+  <rect width="480" height="520" fill="#1a2230" />
+  <g class="board">
+    <rect x="0" y="40" width="32" height="32" fill="#f5f7fa" />
+    <rect x="32" y="40" width="32" height="32" fill="#e3e8ef" />
+    <rect x="64" y="40" width="32" height="32" fill="#f5f7fa" />
+    <rect x="96" y="40" width="32" height="32" fill="#e3e8ef" />
+    <rect x="128" y="40" width="32" height="32" fill="#f5f7fa" />
+    <rect x="160" y="40" width="32" height="32" fill="#e3e8ef" />
+    <rect x="192" y="40" width="32" height="32" fill="#f5f7fa" />
+    <rect x="224" y="40" width="32" height="32" fill="#e3e8ef" />
+    <rect x="256" y="40" width="32" height="32" fill="#f5f7fa" />
+    <rect x="288" y="40" width="32" height="32" fill="#e3e8ef" />
+    <rect x="320" y="40" width="32" height="32" fill="#f5f7fa" />
+    <rect x="352" y="40" width="32" height="32" fill="#e3e8ef" />
+    <rect x="0" y="72" width="32" height="32" fill="#e3e8ef" />
+    <rect x="32" y="72" width="32" height="32" fill="#f5f7fa" />
+    <rect x="64" y="72" width="32" height="32" fill="#e3e8ef" />
+    <rect x="96" y="72" width="32" height="32" fill="#f5f7fa" />
+    <rect x="128" y="72" width="32" height="32" fill="#e3e8ef" />
+    <rect x="160" y="72" width="32" height="32" fill="#f5f7fa" />
+    <rect x="192" y="72" width="32" height="32" fill="#e3e8ef" />
+    <rect x="224" y="72" width="32" height="32" fill="#f5f7fa" />
+    <rect x="256" y="72" width="32" height="32" fill="#e3e8ef" />
+    <rect x="288" y="72" width="32" height="32" fill="#f5f7fa" />
+    <rect x="320" y="72" width="32" height="32" fill="#e3e8ef" />
+    <rect x="352" y="72" width="32" height="32" fill="#f5f7fa" />
+    <rect x="0" y="104" width="32" height="32" fill="#f5f7fa" />
+    <rect x="32" y="104" width="32" height="32" fill="#e3e8ef" />
+    <rect x="64" y="104" width="32" height="32" fill="#f5f7fa" />
+    <rect x="96" y="104" width="32" height="32" fill="#e3e8ef" />
+    <rect x="128" y="104" width="32" height="32" fill="#f5f7fa" />
+    <rect x="160" y="104" width="32" height="32" fill="#e3e8ef" />
+    <rect x="192" y="104" width="32" height="32" fill="#f5f7fa" />
+    <rect x="224" y="104" width="32" height="32" fill="#e3e8ef" />
+    <rect x="256" y="104" width="32" height="32" fill="#f5f7fa" />
+    <rect x="288" y="104" width="32" height="32" fill="#e3e8ef" />
+    <rect x="320" y="104" width="32" height="32" fill="#f5f7fa" />
+    <rect x="352" y="104" width="32" height="32" fill="#e3e8ef" />
+    <rect x="0" y="136" width="32" height="32" fill="#e3e8ef" />
+    <rect x="32" y="136" width="32" height="32" fill="#f5f7fa" />
+    <rect x="64" y="136" width="32" height="32" fill="#e3e8ef" />
+    <rect x="96" y="136" width="32" height="32" fill="#f5f7fa" />
+    <rect x="128" y="136" width="32" height="32" fill="#e3e8ef" />
+    <rect x="160" y="136" width="32" height="32" fill="#f5f7fa" />
+    <rect x="192" y="136" width="32" height="32" fill="#e3e8ef" />
+    <rect x="224" y="136" width="32" height="32" fill="#f5f7fa" />
+    <rect x="256" y="136" width="32" height="32" fill="#e3e8ef" />
+    <rect x="288" y="136" width="32" height="32" fill="#f5f7fa" />
+    <rect x="320" y="136" width="32" height="32" fill="#e3e8ef" />
+    <rect x="352" y="136" width="32" height="32" fill="#f5f7fa" />
+    <rect x="0" y="168" width="32" height="32" fill="#f5f7fa" />
+    <rect x="32" y="168" width="32" height="32" fill="#e3e8ef" />
+    <rect x="64" y="168" width="32" height="32" fill="#f5f7fa" />
+    <rect x="96" y="168" width="32" height="32" fill="#e3e8ef" />
+    <rect x="128" y="168" width="32" height="32" fill="#f5f7fa" />
+    <rect x="160" y="168" width="32" height="32" fill="#e3e8ef" />
+    <rect x="192" y="168" width="32" height="32" fill="#f5f7fa" />
+    <rect x="224" y="168" width="32" height="32" fill="#e3e8ef" />
+    <rect x="256" y="168" width="32" height="32" fill="#f5f7fa" />
+    <rect x="288" y="168" width="32" height="32" fill="#e3e8ef" />
+    <rect x="320" y="168" width="32" height="32" fill="#f5f7fa" />
+    <rect x="352" y="168" width="32" height="32" fill="#e3e8ef" />
+    <rect x="0" y="200" width="32" height="32" fill="#e3e8ef" />
+    <rect x="32" y="200" width="32" height="32" fill="#f5f7fa" />
+    <rect x="64" y="200" width="32" height="32" fill="#e3e8ef" />
+    <rect x="96" y="200" width="32" height="32" fill="#f5f7fa" />
+    <rect x="128" y="200" width="32" height="32" fill="#e3e8ef" />
+    <rect x="160" y="200" width="32" height="32" fill="#f5f7fa" />
+    <rect x="192" y="200" width="32" height="32" fill="#e3e8ef" />
+    <rect x="224" y="200" width="32" height="32" fill="#f5f7fa" />
+    <rect x="256" y="200" width="32" height="32" fill="#e3e8ef" />
+    <rect x="288" y="200" width="32" height="32" fill="#f5f7fa" />
+    <rect x="320" y="200" width="32" height="32" fill="#e3e8ef" />
+    <rect x="352" y="200" width="32" height="32" fill="#f5f7fa" />
+    <rect x="0" y="232" width="32" height="32" fill="#f5f7fa" />
+    <rect x="32" y="232" width="32" height="32" fill="#e3e8ef" />
+    <rect x="64" y="232" width="32" height="32" fill="#f5f7fa" />
+    <rect x="96" y="232" width="32" height="32" fill="#e3e8ef" />
+    <rect x="128" y="232" width="32" height="32" fill="#f5f7fa" />
+    <rect x="160" y="232" width="32" height="32" fill="#e3e8ef" />
+    <rect x="192" y="232" width="32" height="32" fill="#f5f7fa" />
+    <rect x="224" y="232" width="32" height="32" fill="#e3e8ef" />
+    <rect x="256" y="232" width="32" height="32" fill="#f5f7fa" />
+    <rect x="288" y="232" width="32" height="32" fill="#e3e8ef" />
+    <rect x="320" y="232" width="32" height="32" fill="#f5f7fa" />
+    <rect x="352" y="232" width="32" height="32" fill="#e3e8ef" />
+    <rect x="0" y="264" width="32" height="32" fill="#e3e8ef" />
+    <rect x="32" y="264" width="32" height="32" fill="#f5f7fa" />
+    <rect x="64" y="264" width="32" height="32" fill="#e3e8ef" />
+    <rect x="96" y="264" width="32" height="32" fill="#f5f7fa" />
+    <rect x="128" y="264" width="32" height="32" fill="#e3e8ef" />
+    <rect x="160" y="264" width="32" height="32" fill="#f5f7fa" />
+    <rect x="192" y="264" width="32" height="32" fill="#e3e8ef" />
+    <rect x="224" y="264" width="32" height="32" fill="#f5f7fa" />
+    <rect x="256" y="264" width="32" height="32" fill="#e3e8ef" />
+    <rect x="288" y="264" width="32" height="32" fill="#f5f7fa" />
+    <rect x="320" y="264" width="32" height="32" fill="#e3e8ef" />
+    <rect x="352" y="264" width="32" height="32" fill="#f5f7fa" />
+    <rect x="0" y="296" width="32" height="32" fill="#f5f7fa" />
+    <rect x="32" y="296" width="32" height="32" fill="#e3e8ef" />
+    <rect x="64" y="296" width="32" height="32" fill="#f5f7fa" />
+    <rect x="96" y="296" width="32" height="32" fill="#e3e8ef" />
+    <rect x="128" y="296" width="32" height="32" fill="#f5f7fa" />
+    <rect x="160" y="296" width="32" height="32" fill="#e3e8ef" />
+    <rect x="192" y="296" width="32" height="32" fill="#f5f7fa" />
+    <rect x="224" y="296" width="32" height="32" fill="#e3e8ef" />
+    <rect x="256" y="296" width="32" height="32" fill="#f5f7fa" />
+    <rect x="288" y="296" width="32" height="32" fill="#e3e8ef" />
+    <rect x="320" y="296" width="32" height="32" fill="#f5f7fa" />
+    <rect x="352" y="296" width="32" height="32" fill="#e3e8ef" />
+    <rect x="0" y="328" width="32" height="32" fill="#e3e8ef" />
+    <rect x="32" y="328" width="32" height="32" fill="#f5f7fa" />
+    <rect x="64" y="328" width="32" height="32" fill="#e3e8ef" />
+    <rect x="96" y="328" width="32" height="32" fill="#f5f7fa" />
+    <rect x="128" y="328" width="32" height="32" fill="#e3e8ef" />
+    <rect x="160" y="328" width="32" height="32" fill="#f5f7fa" />
+    <rect x="192" y="328" width="32" height="32" fill="#e3e8ef" />
+    <rect x="224" y="328" width="32" height="32" fill="#f5f7fa" />
+    <rect x="256" y="328" width="32" height="32" fill="#e3e8ef" />
+    <rect x="288" y="328" width="32" height="32" fill="#f5f7fa" />
+    <rect x="320" y="328" width="32" height="32" fill="#e3e8ef" />
+    <rect x="352" y="328" width="32" height="32" fill="#f5f7fa" />
+    <rect x="0" y="360" width="32" height="32" fill="#f5f7fa" />
+    <rect x="32" y="360" width="32" height="32" fill="#e3e8ef" />
+    <rect x="64" y="360" width="32" height="32" fill="#f5f7fa" />
+    <rect x="96" y="360" width="32" height="32" fill="#e3e8ef" />
+    <rect x="128" y="360" width="32" height="32" fill="#f5f7fa" />
+    <rect x="160" y="360" width="32" height="32" fill="#e3e8ef" />
+    <rect x="192" y="360" width="32" height="32" fill="#f5f7fa" />
+    <rect x="224" y="360" width="32" height="32" fill="#e3e8ef" />
+    <rect x="256" y="360" width="32" height="32" fill="#f5f7fa" />
+    <rect x="288" y="360" width="32" height="32" fill="#e3e8ef" />
+    <rect x="320" y="360" width="32" height="32" fill="#f5f7fa" />
+    <rect x="352" y="360" width="32" height="32" fill="#e3e8ef" />
+    <rect x="0" y="392" width="32" height="32" fill="#e3e8ef" />
+    <rect x="32" y="392" width="32" height="32" fill="#f5f7fa" />
+    <rect x="64" y="392" width="32" height="32" fill="#e3e8ef" />
+    <rect x="96" y="392" width="32" height="32" fill="#f5f7fa" />
+    <rect x="128" y="392" width="32" height="32" fill="#e3e8ef" />
+    <rect x="160" y="392" width="32" height="32" fill="#f5f7fa" />
+    <rect x="192" y="392" width="32" height="32" fill="#e3e8ef" />
+    <rect x="224" y="392" width="32" height="32" fill="#f5f7fa" />
+    <rect x="256" y="392" width="32" height="32" fill="#e3e8ef" />
+    <rect x="288" y="392" width="32" height="32" fill="#f5f7fa" />
+    <rect x="320" y="392" width="32" height="32" fill="#e3e8ef" />
+    <rect x="352" y="392" width="32" height="32" fill="#f5f7fa" />
+  </g>
+  <rect
+    class="food"
+    x="99"
+    y="395"
+    width="26"
+    height="26"
+    rx="6"
+    ry="6"
+    fill="#e74c3c"
+    stroke="#922b21"
+    stroke-width="1"
+  >
+    <animate
+      attributeName="x"
+      values="99;99;99;99;99;99;99;99;99;99;99"
+      dur="8s"
+      repeatCount="indefinite"
+      calcMode="discrete"
+      fill="freeze"
+    />
+    <animate
+      attributeName="y"
+      values="395;395;395;395;395;395;395;395;395;107;107"
+      dur="8s"
+      repeatCount="indefinite"
+      calcMode="discrete"
+      fill="freeze"
+    />
+    <animate
+      attributeName="opacity"
+      values="1;0.55;1"
+      dur="0.8s"
+      repeatCount="indefinite"
+      calcMode="linear"
+    />
+  </rect>
+  <rect
+    class="snake-head"
+    x="227"
+    y="235"
+    width="26"
+    height="26"
+    rx="6"
+    ry="6"
+    fill="#f1c40f"
+    stroke="#b7950b"
+    stroke-width="1"
+    opacity="1"
+  >
+    <animate
+      attributeName="x"
+      values="227;227;195;163;131;99;99;99;99;99;99"
+      dur="8s"
+      repeatCount="indefinite"
+      calcMode="discrete"
+      fill="freeze"
+    />
+    <animate
+      attributeName="y"
+      values="235;267;267;267;267;267;299;331;363;395;395"
+      dur="8s"
+      repeatCount="indefinite"
+      calcMode="discrete"
+      fill="freeze"
+    />
+    <animate
+      attributeName="opacity"
+      values="1;1;1;1;1;1;1;1;1;1;1"
+      dur="8s"
+      repeatCount="indefinite"
+      calcMode="discrete"
+      fill="freeze"
+    />
+  </rect>
+  <rect
+    class="snake-body"
+    x="195"
+    y="235"
+    width="26"
+    height="26"
+    rx="6"
+    ry="6"
+    fill="#27ae60"
+    stroke="#1e8449"
+    stroke-width="1"
+    opacity="1"
+  >
+    <animate
+      attributeName="x"
+      values="195;227;227;195;163;131;99;99;99;99;99"
+      dur="8s"
+      repeatCount="indefinite"
+      calcMode="discrete"
+      fill="freeze"
+    />
+    <animate
+      attributeName="y"
+      values="235;235;267;267;267;267;267;299;331;363;363"
+      dur="8s"
+      repeatCount="indefinite"
+      calcMode="discrete"
+      fill="freeze"
+    />
+    <animate
+      attributeName="opacity"
+      values="1;1;1;1;1;1;1;1;1;1;1"
+      dur="8s"
+      repeatCount="indefinite"
+      calcMode="discrete"
+      fill="freeze"
+    />
+  </rect>
+  <rect
+    class="snake-body"
+    x="163"
+    y="235"
+    width="26"
+    height="26"
+    rx="6"
+    ry="6"
+    fill="#27ae60"
+    stroke="#1e8449"
+    stroke-width="1"
+    opacity="1"
+  >
+    <animate
+      attributeName="x"
+      values="163;195;227;227;195;163;131;99;99;99;99"
+      dur="8s"
+      repeatCount="indefinite"
+      calcMode="discrete"
+      fill="freeze"
+    />
+    <animate
+      attributeName="y"
+      values="235;235;235;267;267;267;267;267;299;331;331"
+      dur="8s"
+      repeatCount="indefinite"
+      calcMode="discrete"
+      fill="freeze"
+    />
+    <animate
+      attributeName="opacity"
+      values="1;1;1;1;1;1;1;1;1;1;1"
+      dur="8s"
+      repeatCount="indefinite"
+      calcMode="discrete"
+      fill="freeze"
+    />
+  </rect>
+  <rect
+    class="snake-body"
+    x="0"
+    y="0"
+    width="26"
+    height="26"
+    rx="6"
+    ry="6"
+    fill="#27ae60"
+    stroke="#1e8449"
+    stroke-width="1"
+    opacity="0"
+  >
+    <animate
+      attributeName="x"
+      values="227;227;195;163;131;99;99;99;99;99;99"
+      dur="8s"
+      repeatCount="indefinite"
+      calcMode="discrete"
+      fill="freeze"
+    />
+    <animate
+      attributeName="y"
+      values="235;267;267;267;267;267;299;331;363;299;299"
+      dur="8s"
+      repeatCount="indefinite"
+      calcMode="discrete"
+      fill="freeze"
+    />
+    <animate
+      attributeName="opacity"
+      values="0;0;0;0;0;0;0;0;0;1;1"
+      dur="8s"
+      repeatCount="indefinite"
+      calcMode="discrete"
+      fill="freeze"
+    />
+  </rect>
+  <text
+    x="12"
+    y="22"
+    font-family="monospace"
+    font-size="14"
+    fill="#ecf0f1"
+  >🐍 Snake · 1 eaten · 10 steps · died</text>
+  <text
+    class="score"
+    x="468"
+    y="22"
+    text-anchor="end"
+    font-family="monospace"
+    font-size="14"
+    fill="#f1c40f"
+    display="inline"
+  >
+    score 0
+    <set attributeName="display" to="none" begin="7.20s; 15.20s" />
+    <set attributeName="display" to="inline" begin="0s; 8s" />
+  </text>
+  <text
+    class="score"
+    x="468"
+    y="22"
+    text-anchor="end"
+    font-family="monospace"
+    font-size="14"
+    fill="#f1c40f"
+    display="none"
+  >
+    score 100
+    <set attributeName="display" to="inline" begin="7.20s; 15.20s" />
+    <set attributeName="display" to="none" begin="0s; 8s" />
+  </text>
+  <rect class="score-pulse" x="410" y="28" width="58" height="4" rx="2" ry="2" fill="#f1c40f">
+    <animate
+      attributeName="fill"
+      values="#bdc3c7;#bdc3c7;#bdc3c7;#bdc3c7;#bdc3c7;#bdc3c7;#bdc3c7;#bdc3c7;#bdc3c7;#f1c40f;#f1c40f"
+      dur="8s"
+      repeatCount="indefinite"
+      calcMode="discrete"
+      fill="freeze"
+    />
+  </rect>
+  <rect x="12" y="502" width="456" height="4" fill="#34495e" rx="2" />
+  <rect class="progress" x="12" y="502" width="0" height="4" fill="#f1c40f" rx="2">
+    <animate attributeName="width" values="0;456" dur="8s" repeatCount="indefinite" fill="freeze" />
+  </rect>
+</svg>

--- a/quality.sh
+++ b/quality.sh
@@ -106,7 +106,7 @@ fi
 # --- Example Programs ---
 # Clean up any previous synthetic data
 echo "Cleaning up previous runs..."
-rm -rf .synthetic-discovery .synthetic-intelligent-design .synthetic-suggest-improvements .synthetic-crossover .synthetic-cart-pole .synthetic-lunar-lander .synthetic-mountain-car .synthetic-xor .synthetic-stock .synthetic-mnist .discovery
+rm -rf .synthetic-discovery .synthetic-intelligent-design .synthetic-suggest-improvements .synthetic-crossover .synthetic-cart-pole .synthetic-lunar-lander .synthetic-mountain-car .synthetic-snake .synthetic-xor .synthetic-stock .synthetic-mnist .discovery
 echo ""
 
 # Run the Intelligent Design example
@@ -126,6 +126,9 @@ run_example "Lunar Lander Descent Example" "./lunar_lander/run.sh"
 
 # Run the Mountain Car Control example
 run_example "Mountain Car Control Example" "./mountain_car/run.sh"
+
+# Run the Snake Game example
+run_example "Snake Game Example" "./snake_game/run.sh"
 
 # Run the XOR Classification example
 run_example "XOR Classification Example" "./xor_classification/run.sh"

--- a/readme_structure_test.ts
+++ b/readme_structure_test.ts
@@ -19,6 +19,7 @@ const EXAMPLE_DIRS = [
   "lunar_lander",
   "mnist_classification",
   "mountain_car",
+  "snake_game",
   "stock_market",
   "suggest_improvements",
   "xor_classification",
@@ -29,6 +30,7 @@ const SCREENSHOT_PATHS = [
   "docs/screenshots/cart_pole.svg",
   "docs/screenshots/lunar_lander.svg",
   "docs/screenshots/mountain_car.svg",
+  "docs/screenshots/snake_game.svg",
   "docs/screenshots/stock_market.svg",
   "docs/screenshots/mnist_classification.svg",
 ] as const;
@@ -103,6 +105,7 @@ Deno.test("README.md introduces every example by name", () => {
     "XOR",
     "Lunar Lander",
     "Mountain Car",
+    "Snake",
     "Stock Market",
     "MNIST",
   ];

--- a/snake_game/README.md
+++ b/snake_game/README.md
@@ -1,0 +1,97 @@
+# 🐍 Snake — Evolved Controller for the Classic Grid Game
+
+`snake_game.ts` evolves a NEAT-AI controller that plays the classic Snake grid game on a 12×12
+board. The snake starts three segments long, must eat food cells to grow, and dies the moment it
+runs into a wall or its own body. Both the simulator (`snake.ts`) and the evolutionary loop run
+entirely in pure TypeScript; the only external dependency is NEAT-AI's `Creature.activate` to
+compute each step's heading.
+
+![Champion playthrough](../docs/screenshots/snake_game.svg)
+
+## 🔧 How It Works
+
+```mermaid
+flowchart LR
+    GAME["🐍 Snake grid game<br/>(snake.ts)"]
+    SENSE["🛰️ Wall, food &amp; tail sensors<br/>(agent.ts)"]
+    POLICY["🧠 Network → heading"]
+    STEP["⏱️ Move + grow / die"]
+    DONE{"dead or<br/>500 steps?"}
+    SCORE["📏 Food × 100 − penalties"]
+    SVG["🖼️ Animated playthrough SVG"]
+
+    GAME --> SENSE --> POLICY --> STEP --> DONE
+    DONE -- no --> SENSE
+    DONE -- yes --> SCORE --> SVG
+
+    style GAME fill:#27ae60,stroke:#333,color:#fff
+    style SENSE fill:#3498db,stroke:#333,color:#fff
+    style POLICY fill:#9b59b6,stroke:#333,color:#fff
+    style STEP fill:#f39c12,stroke:#333,color:#fff
+    style SCORE fill:#e67e22,stroke:#333,color:#fff
+    style SVG fill:#f1c40f,stroke:#333,color:#000
+```
+
+## 🎯 Inputs and Outputs
+
+The agent observes a small sensor pack (8 channels — well below the issue's 12-input budget):
+
+| Channel  | Type       | Symbol        | Meaning                                             |
+| -------- | ---------- | ------------- | --------------------------------------------------- |
+| Input 0  | observable | `wallForward` | Cells of free space ahead, normalised by `gridSize` |
+| Input 1  | observable | `wallLeft`    | Cells of free space to the snake's left             |
+| Input 2  | observable | `wallRight`   | Cells of free space to the snake's right            |
+| Input 3  | observable | `foodDx`      | `(food.x − head.x) / gridSize` (signed)             |
+| Input 4  | observable | `foodDy`      | `(food.y − head.y) / gridSize` (signed)             |
+| Input 5  | observable | `tailDx`      | `(tail.x − head.x) / gridSize` (signed)             |
+| Input 6  | observable | `tailDy`      | `(tail.y − head.y) / gridSize` (signed)             |
+| Input 7  | observable | `length`      | `body.length / (gridSize × gridSize)`               |
+| Output 0 | action     | —             | Logistic activation; argmax → heading **Up**        |
+| Output 1 | action     | —             | Logistic activation; argmax → heading **Right**     |
+| Output 2 | action     | —             | Logistic activation; argmax → heading **Down**      |
+| Output 3 | action     | —             | Logistic activation; argmax → heading **Left**      |
+
+Each tick the controller chooses one of four headings; a 180° reversal request is rejected and the
+snake keeps its previous heading. Episodes end when the snake collides with a wall or its own body,
+or when the 500-step cap is reached.
+
+## 📏 Scoring
+
+```text
+score = (food eaten × 100) − (steps × 0.1) − (50 if died else 0)
+```
+
+Eating one food gives +100, easily out-weighing the per-step penalty so survival without eating
+cannot beat eating quickly. The 50-point death penalty rewards staying alive when food is genuinely
+out of reach.
+
+## 🚀 Running the Example
+
+```bash
+./snake_game/run.sh
+```
+
+Artefacts:
+
+- `.synthetic-snake/creatures/champion.json` – the fittest controller from the run
+- `docs/screenshots/snake_game.svg` – animated SVG of the champion's playthrough
+
+## 🧠 Tacit Knowledge
+
+A few things that are not obvious from the code alone:
+
+- **Linear policy is enough.** Eight inputs and four logistic outputs (32 weights, 4 biases) is a
+  small enough search space that a 60-creature population finds a food-seeking controller in tens of
+  generations. There is no hidden layer.
+- **Argmax discretisation.** The four outputs are passed through logistics and then `argmax` — the
+  controller commits to one of four headings every step. Ties favour lower indices but in practice
+  the logistic outputs differ enough that ties are vanishingly rare.
+- **180° reversals are rejected.** Snake gameplay requires this so the snake cannot trivially
+  collide with its own neck. Asking the controller to reverse simply leaves the heading unchanged.
+- **Tail moves before collision check.** When the snake does not eat, the tail cell is freed before
+  the head's new cell is checked for body overlap — so the snake can chase its own tail safely,
+  matching classic Snake semantics.
+- **Reproducibility.** All randomness flows through `common/deterministic_random.ts`. With a fixed
+  seed the same champion is produced on every run.
+- **Per-episode seed is shared.** Every creature in a generation faces the same initial state and
+  the same food sequence (given equivalent decisions), so fitness comparisons are fair.

--- a/snake_game/agent.ts
+++ b/snake_game/agent.ts
@@ -1,0 +1,130 @@
+/**
+ * Snake-game agent: sensor encoding and action decoding.
+ *
+ * The controller observes the world through a small sensor pack of
+ * eight floating-point values (well below the issue's 12-input
+ * budget). Outputs are four logistic activations — one per heading —
+ * and the agent commits to the argmax over those scores every tick.
+ *
+ * Sensor channels (all clamped to friendly numerical ranges):
+ *   0. Wall distance forward — cells of free space in front of the
+ *      head along the current heading, normalised by `gridSize`.
+ *   1. Wall distance to the snake's left.
+ *   2. Wall distance to the snake's right.
+ *   3. Food Δx — `(food.x − head.x) / gridSize` (signed).
+ *   4. Food Δy — `(food.y − head.y) / gridSize` (signed).
+ *   5. Tail Δx — `(tail.x − head.x) / gridSize` (signed).
+ *   6. Tail Δy — `(tail.y − head.y) / gridSize` (signed).
+ *   7. Length — `body.length / (gridSize · gridSize)`.
+ */
+import { Heading, HEADING_DELTAS, type SnakeState } from "./snake.ts";
+
+/** Number of sensor inputs fed to the controller. */
+export const INPUT_COUNT = 8;
+
+/** Number of action outputs (one per heading). */
+export const OUTPUT_COUNT = 4;
+
+/** Headings in argmax order for {@link decodeAction}. */
+export const ACTION_HEADINGS: ReadonlyArray<Heading> = [
+  Heading.Up,
+  Heading.Right,
+  Heading.Down,
+  Heading.Left,
+];
+
+/**
+ * Compute the integer wall distance from `(x, y)` along `(dx, dy)` —
+ * how many free cells the snake could move forward before hitting the
+ * grid boundary or its own body. Used for the three "vision" sensors.
+ */
+function wallDistance(
+  state: SnakeState,
+  startX: number,
+  startY: number,
+  dx: number,
+  dy: number,
+): number {
+  // Build a set of body cells (excluding the head) so the distance
+  // counts the snake as a wall.
+  const blocked = new Set<string>();
+  for (let i = 1; i < state.body.length; i++) {
+    blocked.add(`${state.body[i].x},${state.body[i].y}`);
+  }
+  let distance = 0;
+  let x = startX + dx;
+  let y = startY + dy;
+  while (x >= 0 && y >= 0 && x < state.gridSize && y < state.gridSize) {
+    if (blocked.has(`${x},${y}`)) break;
+    distance += 1;
+    x += dx;
+    y += dy;
+  }
+  return distance;
+}
+
+/** Heading 90° to the snake's left of `current`. */
+export function headingLeft(current: Heading): Heading {
+  return ((current + 3) % 4) as Heading;
+}
+
+/** Heading 90° to the snake's right of `current`. */
+export function headingRight(current: Heading): Heading {
+  return ((current + 1) % 4) as Heading;
+}
+
+/**
+ * Encode a {@link SnakeState} as a Float32Array of {@link INPUT_COUNT}
+ * sensor values. Values are normalised so the network sees inputs in
+ * a comparable range regardless of grid size.
+ */
+export function encodeState(state: SnakeState): Float32Array {
+  const head = state.body[0];
+  const tail = state.body[state.body.length - 1];
+  const grid = state.gridSize;
+
+  const forward = HEADING_DELTAS[state.heading];
+  const left = HEADING_DELTAS[headingLeft(state.heading)];
+  const right = HEADING_DELTAS[headingRight(state.heading)];
+
+  const wallForward = wallDistance(state, head.x, head.y, forward[0], forward[1]) / grid;
+  const wallLeft = wallDistance(state, head.x, head.y, left[0], left[1]) / grid;
+  const wallRight = wallDistance(state, head.x, head.y, right[0], right[1]) / grid;
+
+  const foodDx = (state.food.x - head.x) / grid;
+  const foodDy = (state.food.y - head.y) / grid;
+
+  const tailDx = (tail.x - head.x) / grid;
+  const tailDy = (tail.y - head.y) / grid;
+
+  const lengthSensor = state.body.length / (grid * grid);
+
+  return new Float32Array([
+    wallForward,
+    wallLeft,
+    wallRight,
+    foodDx,
+    foodDy,
+    tailDx,
+    tailDy,
+    lengthSensor,
+  ]);
+}
+
+/**
+ * Convert the four logistic outputs into the chosen {@link Heading}
+ * by argmax. Ties favour lower indices (Up, then Right, then Down,
+ * then Left); the tie-breaker is irrelevant for evolutionary search
+ * but keeps the mapping deterministic.
+ */
+export function decodeAction(outputs: ArrayLike<number>): Heading {
+  let bestIdx = 0;
+  let best = outputs[0];
+  for (let i = 1; i < OUTPUT_COUNT; i++) {
+    if (outputs[i] > best) {
+      best = outputs[i];
+      bestIdx = i;
+    }
+  }
+  return ACTION_HEADINGS[bestIdx];
+}

--- a/snake_game/agent_test.ts
+++ b/snake_game/agent_test.ts
@@ -1,0 +1,91 @@
+/**
+ * Unit tests for the Snake-game agent (sensor encoding & action
+ * decoding). "What" tests only — call the encoder with known states,
+ * inspect the resulting Float32Array, and assert on the values.
+ */
+import { assert, assertAlmostEquals, assertEquals } from "@std/assert";
+import {
+  ACTION_HEADINGS,
+  decodeAction,
+  encodeState,
+  headingLeft,
+  headingRight,
+  INPUT_COUNT,
+  OUTPUT_COUNT,
+} from "./agent.ts";
+import { Heading, type SnakeState } from "./snake.ts";
+
+function makeState(overrides: Partial<SnakeState> = {}): SnakeState {
+  return {
+    gridSize: 12,
+    body: [{ x: 6, y: 6 }, { x: 5, y: 6 }, { x: 4, y: 6 }],
+    heading: Heading.Right,
+    food: { x: 8, y: 6 },
+    dead: false,
+    eaten: 0,
+    steps: 0,
+    ...overrides,
+  };
+}
+
+Deno.test("encodeState produces exactly INPUT_COUNT values", () => {
+  const state = makeState();
+  const out = encodeState(state);
+  assertEquals(out.length, INPUT_COUNT);
+});
+
+Deno.test("encodeState wall distances respect the grid bounds", () => {
+  // Head at (11, 0) heading right — the right wall is one step away.
+  const state = makeState({
+    body: [{ x: 11, y: 0 }, { x: 10, y: 0 }, { x: 9, y: 0 }],
+    heading: Heading.Right,
+  });
+  const out = encodeState(state);
+  // Wall forward = 0 cells of free space.
+  assertEquals(out[0], 0);
+});
+
+Deno.test("encodeState food delta points toward the food", () => {
+  const state = makeState({
+    body: [{ x: 5, y: 5 }, { x: 4, y: 5 }, { x: 3, y: 5 }],
+    food: { x: 8, y: 5 },
+  });
+  const out = encodeState(state);
+  // foodDx = (8 - 5) / 12 = 0.25
+  assertAlmostEquals(out[3], 0.25, 1e-6);
+  // foodDy = 0
+  assertAlmostEquals(out[4], 0, 1e-6);
+});
+
+Deno.test("encodeState tail delta points back toward the tail", () => {
+  const state = makeState({
+    body: [{ x: 5, y: 5 }, { x: 4, y: 5 }, { x: 3, y: 5 }],
+  });
+  const out = encodeState(state);
+  // tailDx = (3 - 5) / 12 = -2/12
+  assertAlmostEquals(out[5], -2 / 12, 1e-6);
+  assertAlmostEquals(out[6], 0, 1e-6);
+});
+
+Deno.test("encodeState length sensor scales with body size", () => {
+  const a = encodeState(makeState({ body: [{ x: 5, y: 5 }] }));
+  const b = encodeState(makeState({
+    body: [{ x: 5, y: 5 }, { x: 4, y: 5 }, { x: 3, y: 5 }, { x: 2, y: 5 }],
+  }));
+  assert(b[7] > a[7], "length sensor should grow with body size");
+});
+
+Deno.test("headingLeft/Right rotate cardinally", () => {
+  assertEquals(headingLeft(Heading.Up), Heading.Left);
+  assertEquals(headingRight(Heading.Up), Heading.Right);
+  assertEquals(headingLeft(Heading.Right), Heading.Up);
+  assertEquals(headingRight(Heading.Right), Heading.Down);
+});
+
+Deno.test("decodeAction picks the argmax over the four outputs", () => {
+  for (let i = 0; i < OUTPUT_COUNT; i++) {
+    const outputs = [0.1, 0.1, 0.1, 0.1];
+    outputs[i] = 0.9;
+    assertEquals(decodeAction(outputs), ACTION_HEADINGS[i]);
+  }
+});

--- a/snake_game/run.sh
+++ b/snake_game/run.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -euo pipefail
+
+# Snake Game Example Runner
+#
+# Evolves a NEAT-AI controller that plays the classic Snake grid game,
+# saves the champion creature, and writes an animated SVG of the
+# champion's playthrough to docs/screenshots/snake_game.svg.
+
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd -P)"
+cd "${REPO_ROOT}"
+
+# Add deno to PATH if not already available
+if ! command -v deno &> /dev/null; then
+  export PATH="$HOME/.deno/bin:$PATH"
+fi
+
+echo "🐍 Snake Game Example"
+echo ""
+
+deno run \
+  --v8-flags=--max-old-space-size=4096 \
+  --allow-read \
+  --allow-write \
+  --allow-env \
+  --allow-net \
+  snake_game/snake_game.ts \
+  "$@"
+
+# Re-format the regenerated SVG so subsequent `deno fmt --check` runs
+# stay clean — the renderer emits compact output for readability, and
+# `deno fmt` prefers attributes split across multiple lines.
+if [[ -f "docs/screenshots/snake_game.svg" ]]; then
+  deno fmt docs/screenshots/snake_game.svg > /dev/null
+fi

--- a/snake_game/snake.ts
+++ b/snake_game/snake.ts
@@ -1,0 +1,252 @@
+/**
+ * Deterministic Snake game model.
+ *
+ * A pure-TypeScript port of the classic grid-based Snake game. The
+ * snake occupies a fixed-size square grid and advances one cell per
+ * tick along its current heading. Eating food grows the snake by one
+ * segment; running into a wall or its own body ends the episode.
+ *
+ * Coordinate system:
+ *   - `(x, y)` are integer cell coordinates with `(0, 0)` in the
+ *     top-left corner. `x` increases rightward, `y` increases downward
+ *     (matching SVG conventions, so the renderer is trivial).
+ *   - Headings are encoded as one of `Heading.Up`, `Heading.Right`,
+ *     `Heading.Down`, `Heading.Left`.
+ *
+ * Update rules:
+ *   - The snake's body is an array of cells; index 0 is the head.
+ *   - Each tick the head advances one cell along the new heading. A
+ *     180° reversal request is rejected and the previous heading is
+ *     used instead, matching the canonical Snake gameplay.
+ *   - If the new head cell holds food, the snake grows by one segment
+ *     (the tail is not removed) and a new food cell is spawned via the
+ *     seeded PRNG. Otherwise the tail is removed so the body length
+ *     stays constant.
+ *   - The episode ends when the head is outside the grid or collides
+ *     with another body cell.
+ *
+ * Pure functions only — no globals, no hidden timers — so two runs
+ * with the same seed produce byte-identical traces.
+ */
+
+/** Cardinal headings the snake can move in. Values match `[Δx, Δy]`. */
+export enum Heading {
+  Up = 0,
+  Right = 1,
+  Down = 2,
+  Left = 3,
+}
+
+/** Translation vector for a heading: `[Δx, Δy]`. */
+export const HEADING_DELTAS: ReadonlyArray<readonly [number, number]> = [
+  [0, -1],
+  [1, 0],
+  [0, 1],
+  [-1, 0],
+];
+
+/** A single grid cell. */
+export interface Cell {
+  x: number;
+  y: number;
+}
+
+/** Immutable snapshot of a Snake game state. */
+export interface SnakeState {
+  /** Side-length of the square grid (in cells). */
+  gridSize: number;
+  /** Snake body, head at index 0, tail at the last index. */
+  body: ReadonlyArray<Cell>;
+  /** Current heading. */
+  heading: Heading;
+  /** Cell holding food (always strictly inside the grid). */
+  food: Cell;
+  /** True once the snake has died (wall or self collision). */
+  dead: boolean;
+  /** Number of food items eaten this episode. */
+  eaten: number;
+  /** Number of ticks executed since `initialState`. */
+  steps: number;
+}
+
+/** Default grid side length — 12×12 keeps episodes short and visible. */
+export const DEFAULT_GRID_SIZE = 12;
+
+/** Default initial snake length. */
+export const DEFAULT_INITIAL_LENGTH = 3;
+
+/**
+ * Build the initial Snake state. The snake is centred horizontally
+ * with its head pointing right, so a small linear tail trails behind
+ * it (centre column, three cells wide). Food is placed at a fixed
+ * deterministic location for the very first tick; subsequent food
+ * spawns flow through the supplied `random()` PRNG.
+ */
+export function initialState(
+  gridSize: number = DEFAULT_GRID_SIZE,
+  initialLength: number = DEFAULT_INITIAL_LENGTH,
+): SnakeState {
+  if (gridSize < 4) {
+    throw new Error(`gridSize must be at least 4, got ${gridSize}`);
+  }
+  if (initialLength < 1 || initialLength >= gridSize) {
+    throw new Error(
+      `initialLength must be in [1, gridSize), got ${initialLength}`,
+    );
+  }
+  const midY = Math.floor(gridSize / 2);
+  const headX = Math.floor(gridSize / 2) + Math.floor(initialLength / 2);
+  const body: Cell[] = [];
+  for (let i = 0; i < initialLength; i++) {
+    body.push({ x: headX - i, y: midY });
+  }
+  // Default food cell: a deterministic location well clear of the
+  // snake so the first tick has a meaningful gradient. Placed three
+  // rows below the snake.
+  const food: Cell = { x: Math.floor(gridSize / 2), y: midY + 3 };
+  return {
+    gridSize,
+    body,
+    heading: Heading.Right,
+    food,
+    dead: false,
+    eaten: 0,
+    steps: 0,
+  };
+}
+
+/**
+ * Returns true when `a` and `b` cover the same grid cell.
+ */
+export function cellsEqual(a: Cell, b: Cell): boolean {
+  return a.x === b.x && a.y === b.y;
+}
+
+/**
+ * Returns true when `cell` is on the grid (`0 <= x, y < gridSize`).
+ */
+export function inBounds(cell: Cell, gridSize: number): boolean {
+  return cell.x >= 0 && cell.y >= 0 && cell.x < gridSize && cell.y < gridSize;
+}
+
+/**
+ * Test whether the candidate heading would reverse the snake's
+ * current direction (a 180° turn). Snake gameplay rejects this so
+ * the snake cannot collide with its own neck.
+ */
+export function isReverse(current: Heading, candidate: Heading): boolean {
+  return ((current + 2) % 4) === candidate;
+}
+
+/**
+ * Pick a fresh food cell uniformly at random from cells not occupied
+ * by the snake body. Falls back to the first free cell scanned in
+ * row-major order if the random pick lands on the snake (this can
+ * only happen when the grid is densely covered, e.g. snake fills more
+ * than half of it). When the grid has no free cells the existing
+ * food position is reused — the calling code never reaches this
+ * branch in practice because filling the grid means the snake won.
+ */
+export function spawnFood(
+  state: Pick<SnakeState, "gridSize" | "body">,
+  random: () => number,
+): Cell {
+  const { gridSize, body } = state;
+  const occupied = new Set<string>();
+  for (const cell of body) occupied.add(`${cell.x},${cell.y}`);
+
+  // Try a random pick first.
+  for (let attempt = 0; attempt < 32; attempt++) {
+    const x = Math.floor(random() * gridSize);
+    const y = Math.floor(random() * gridSize);
+    if (!occupied.has(`${x},${y}`)) {
+      return { x, y };
+    }
+  }
+  // Deterministic fallback — scan the grid in row-major order.
+  for (let y = 0; y < gridSize; y++) {
+    for (let x = 0; x < gridSize; x++) {
+      if (!occupied.has(`${x},${y}`)) {
+        return { x, y };
+      }
+    }
+  }
+  // Snake fills the entire grid: keep food where it was. The caller
+  // would treat this as a "won the game" terminal state.
+  return { x: body[0].x, y: body[0].y };
+}
+
+/**
+ * Advance the simulation by one tick.
+ *
+ * @param state    Current state. Treated as immutable.
+ * @param desired  Heading the agent wants to take. If it would reverse
+ *                 the current heading the request is ignored and the
+ *                 snake keeps moving in `state.heading`.
+ * @param random   Seeded PRNG used when food needs to respawn.
+ * @returns The state after one tick. The input is not mutated.
+ */
+export function step(
+  state: SnakeState,
+  desired: Heading,
+  random: () => number,
+): SnakeState {
+  if (state.dead) return state;
+
+  const heading = isReverse(state.heading, desired) ? state.heading : desired;
+  const [dx, dy] = HEADING_DELTAS[heading];
+  const head = state.body[0];
+  const newHead: Cell = { x: head.x + dx, y: head.y + dy };
+
+  // Wall collision.
+  if (!inBounds(newHead, state.gridSize)) {
+    return { ...state, heading, dead: true, steps: state.steps + 1 };
+  }
+
+  const ate = cellsEqual(newHead, state.food);
+  // Build the next body. If we did not eat, drop the tail before
+  // collision-checking — the cell the tail is leaving becomes free
+  // again so a snake can chase its own tail safely.
+  const nextBody: Cell[] = [newHead, ...state.body];
+  if (!ate) nextBody.pop();
+
+  // Self collision: the head matches any other body cell.
+  for (let i = 1; i < nextBody.length; i++) {
+    if (cellsEqual(newHead, nextBody[i])) {
+      return { ...state, heading, dead: true, steps: state.steps + 1 };
+    }
+  }
+
+  let food = state.food;
+  let eaten = state.eaten;
+  if (ate) {
+    eaten += 1;
+    food = spawnFood({ gridSize: state.gridSize, body: nextBody }, random);
+  }
+
+  return {
+    gridSize: state.gridSize,
+    body: nextBody,
+    heading,
+    food,
+    dead: false,
+    eaten,
+    steps: state.steps + 1,
+  };
+}
+
+/**
+ * Build the initial state and place food via `random()` so episodes
+ * are reproducible from a single seed (the default `initialState`
+ * uses a deterministic placeholder food cell so the very first call
+ * needs no PRNG).
+ */
+export function newGame(
+  random: () => number,
+  gridSize: number = DEFAULT_GRID_SIZE,
+  initialLength: number = DEFAULT_INITIAL_LENGTH,
+): SnakeState {
+  const state = initialState(gridSize, initialLength);
+  const food = spawnFood(state, random);
+  return { ...state, food };
+}

--- a/snake_game/snake_game.ts
+++ b/snake_game/snake_game.ts
@@ -1,0 +1,374 @@
+/**
+ * Snake Game Example.
+ *
+ * Evolves a NEAT-AI controller to play the classic Snake grid game.
+ * Each agent observes a small sensor pack (wall distances, food
+ * direction, tail direction, length — see `agent.ts`) and emits four
+ * logistic activations, one per heading; the argmax becomes the next
+ * heading. The simulator (`snake.ts`), evolutionary loop, and
+ * animated SVG renderer (`svg.ts`) all run in pure TypeScript; the
+ * only external dependency is NEAT-AI's `Creature.activate`.
+ *
+ * Score = `food × FOOD_REWARD − stepCount × STEP_PENALTY` minus a
+ * one-off `DEATH_PENALTY` if the snake collided with a wall or
+ * itself. Survival without eating cannot out-score eating quickly,
+ * because the per-step penalty only adds up over time.
+ */
+import { format } from "@std/fmt/duration";
+import { ensureDirSync } from "@std/fs";
+import { join } from "@std/path";
+import { Creature, type CreatureExport, safeWriteJson } from "@stsoftware/neat-ai";
+
+import { createDeterministicRandom } from "../common/deterministic_random.ts";
+import { setupWorkingDirs } from "../common/working_dirs.ts";
+import { asCreatureExport, type LegacyCreatureJSON } from "../common/legacy_types.ts";
+import { decodeAction, encodeState, INPUT_COUNT, OUTPUT_COUNT } from "./agent.ts";
+import { newGame, type SnakeState, step } from "./snake.ts";
+import { renderRunSVG } from "./svg.ts";
+
+/** Index of the first output neuron. */
+const FIRST_OUTPUT_INDEX = INPUT_COUNT;
+
+/** Hard cap on the number of ticks a single episode is allowed. */
+export const MAX_STEPS = 500;
+
+/** Score reward per food item eaten. */
+export const FOOD_REWARD = 100;
+
+/** Per-step penalty applied at the end of the episode. */
+export const STEP_PENALTY = 0.1;
+
+/** Flat penalty applied when the snake dies (wall or self collision). */
+export const DEATH_PENALTY = 50;
+
+/** Configuration options for {@link evolveSnakeController}. */
+export interface EvolveOptions {
+  seed: number;
+  populationSize: number;
+  maxGenerations: number;
+  mutationStrength: number;
+  mutationRate: number;
+  /** Hard cap on episode length. Defaults to {@link MAX_STEPS}. */
+  maxSteps?: number;
+  onGeneration?: (info: GenerationInfo) => void;
+}
+
+/** Statistics emitted after each generation. */
+export interface GenerationInfo {
+  generation: number;
+  bestScore: number;
+  meanScore: number;
+  bestEaten: number;
+}
+
+/** Result of the evolutionary search. */
+export interface EvolveResult {
+  champion: Creature;
+  bestScore: number;
+  generations: number;
+  championEaten: number;
+  championSteps: number;
+}
+
+/** Sensible defaults for the demonstration runner. */
+export const DEFAULT_EVOLVE_OPTIONS: EvolveOptions = {
+  seed: 12345,
+  populationSize: 60,
+  maxGenerations: 80,
+  mutationStrength: 0.6,
+  mutationRate: 0.5,
+};
+
+/**
+ * Build a small linear network: eight inputs feeding directly into
+ * four LOGISTIC outputs (one per heading). 32 weights and 4 biases is
+ * a compact search space that captures simple "head toward food while
+ * avoiding walls" policies without inflating evolution time.
+ */
+export function buildInitialCreatureJSON(
+  weights: number[],
+  biases: [number, number, number, number],
+): LegacyCreatureJSON {
+  if (weights.length !== INPUT_COUNT * OUTPUT_COUNT) {
+    throw new Error(
+      `weights must contain exactly ${INPUT_COUNT * OUTPUT_COUNT} entries, ` +
+        `got ${weights.length}`,
+    );
+  }
+  const neurons: LegacyCreatureJSON["neurons"] = [];
+  for (let i = 0; i < INPUT_COUNT; i++) {
+    neurons.push({ type: "input", squash: "LOGISTIC", index: i, uuid: `input-${i}` });
+  }
+  for (let o = 0; o < OUTPUT_COUNT; o++) {
+    neurons.push({
+      type: "output",
+      squash: "LOGISTIC",
+      index: FIRST_OUTPUT_INDEX + o,
+      bias: biases[o],
+      uuid: `output-${o}`,
+    });
+  }
+  const synapses: LegacyCreatureJSON["synapses"] = [];
+  for (let o = 0; o < OUTPUT_COUNT; o++) {
+    for (let i = 0; i < INPUT_COUNT; i++) {
+      synapses.push({
+        from: i,
+        to: FIRST_OUTPUT_INDEX + o,
+        weight: weights[o * INPUT_COUNT + i],
+      });
+    }
+  }
+  return { neurons, synapses, input: INPUT_COUNT, output: OUTPUT_COUNT };
+}
+
+/** Sample a value from `[-range, range]` using the supplied PRNG. */
+function uniformSigned(random: () => number, range: number): number {
+  return (random() * 2 - 1) * range;
+}
+
+/** Random initial creature: weights in `[-1, 1]`, biases in `[-0.5, 0.5]`. */
+export function randomCreatureJSON(random: () => number): LegacyCreatureJSON {
+  const weights: number[] = [];
+  for (let i = 0; i < INPUT_COUNT * OUTPUT_COUNT; i++) {
+    weights.push(uniformSigned(random, 1));
+  }
+  const biases: [number, number, number, number] = [
+    uniformSigned(random, 0.5),
+    uniformSigned(random, 0.5),
+    uniformSigned(random, 0.5),
+    uniformSigned(random, 0.5),
+  ];
+  return buildInitialCreatureJSON(weights, biases);
+}
+
+/** Decode a creature export back into its weights and biases. */
+export function genesFromCreatureJSON(
+  json: LegacyCreatureJSON,
+): { weights: number[]; biases: [number, number, number, number] } {
+  const weights = new Array(INPUT_COUNT * OUTPUT_COUNT).fill(0);
+  for (const synapse of json.synapses) {
+    const o = synapse.to - FIRST_OUTPUT_INDEX;
+    if (o >= 0 && o < OUTPUT_COUNT && synapse.from >= 0 && synapse.from < INPUT_COUNT) {
+      weights[o * INPUT_COUNT + synapse.from] = synapse.weight;
+    }
+  }
+  const biases: [number, number, number, number] = [0, 0, 0, 0];
+  for (let o = 0; o < OUTPUT_COUNT; o++) {
+    const neuron = json.neurons.find((n) => n.uuid === `output-${o}`);
+    biases[o] = neuron?.bias ?? 0;
+  }
+  return { weights, biases };
+}
+
+/** Mutate each gene independently with probability `mutationRate`. */
+export function mutateCreatureJSON(
+  parent: LegacyCreatureJSON,
+  random: () => number,
+  mutationRate: number,
+  mutationStrength: number,
+): LegacyCreatureJSON {
+  const { weights, biases } = genesFromCreatureJSON(parent);
+  const newWeights = weights.map((w) =>
+    random() < mutationRate ? w + uniformSigned(random, mutationStrength) : w
+  );
+  const newBiases = biases.map((b) =>
+    random() < mutationRate ? b + uniformSigned(random, mutationStrength) : b
+  ) as [number, number, number, number];
+  return buildInitialCreatureJSON(newWeights, newBiases);
+}
+
+/** Outcome of a single scoring episode. */
+export interface EpisodeResult {
+  score: number;
+  eaten: number;
+  steps: number;
+  died: boolean;
+  finalState: SnakeState;
+}
+
+/**
+ * Play one episode and score the controller. The same per-episode
+ * seed is used for every controller in a generation so the comparison
+ * is fair (same initial state, same food sequence on equivalent
+ * decisions).
+ */
+export function scoreController(
+  creature: Creature,
+  episodeSeed: number,
+  maxSteps: number = MAX_STEPS,
+): EpisodeResult {
+  const episodeRandom = createDeterministicRandom(episodeSeed);
+  let state = newGame(episodeRandom);
+  for (let i = 0; i < maxSteps; i++) {
+    creature.clearState();
+    const out = creature.activate(encodeState(state));
+    const action = decodeAction(out);
+    state = step(state, action, episodeRandom);
+    if (state.dead) break;
+  }
+  const score = state.eaten * FOOD_REWARD - state.steps * STEP_PENALTY -
+    (state.dead ? DEATH_PENALTY : 0);
+  return {
+    score,
+    eaten: state.eaten,
+    steps: state.steps,
+    died: state.dead,
+    finalState: state,
+  };
+}
+
+/**
+ * Replay a creature's run from the same initial state, returning the
+ * full state trace (one entry per tick, including the initial state)
+ * suitable for the SVG renderer.
+ */
+export function replayController(
+  creature: Creature,
+  episodeSeed: number,
+  maxSteps: number = MAX_STEPS,
+): SnakeState[] {
+  const episodeRandom = createDeterministicRandom(episodeSeed);
+  let state = newGame(episodeRandom);
+  const trace: SnakeState[] = [state];
+  for (let i = 0; i < maxSteps; i++) {
+    creature.clearState();
+    const out = creature.activate(encodeState(state));
+    const action = decodeAction(out);
+    state = step(state, action, episodeRandom);
+    trace.push(state);
+    if (state.dead) break;
+  }
+  return trace;
+}
+
+/**
+ * Run a generational evolutionary algorithm. Truncation selection
+ * keeps the top half as parents; the elite carries over so the best
+ * score is monotonically non-decreasing.
+ */
+export function evolveSnakeController(
+  options: EvolveOptions = DEFAULT_EVOLVE_OPTIONS,
+): EvolveResult {
+  const random = createDeterministicRandom(options.seed);
+  const maxSteps = options.maxSteps ?? MAX_STEPS;
+  // Pick a fixed episode seed for the whole run so every creature
+  // faces the same initial conditions.
+  const episodeSeed = options.seed ^ 0x5eed;
+
+  let population: Array<{
+    json: LegacyCreatureJSON;
+    score: number;
+    eaten: number;
+    steps: number;
+  }> = [];
+  for (let i = 0; i < options.populationSize; i++) {
+    const json = randomCreatureJSON(random);
+    const creature = Creature.fromJSON(asCreatureExport(json));
+    const r = scoreController(creature, episodeSeed, maxSteps);
+    population.push({ json, score: r.score, eaten: r.eaten, steps: r.steps });
+  }
+
+  let bestJSON = population[0].json;
+  let bestScore = -Infinity;
+  let bestEaten = 0;
+  let bestSteps = 0;
+
+  for (let generation = 0; generation < options.maxGenerations; generation++) {
+    population.sort((a, b) => b.score - a.score);
+    const generationBest = population[0];
+    if (generationBest.score > bestScore) {
+      bestScore = generationBest.score;
+      bestJSON = generationBest.json;
+      bestEaten = generationBest.eaten;
+      bestSteps = generationBest.steps;
+    }
+
+    const meanScore = population.reduce((acc, p) => acc + p.score, 0) /
+      population.length;
+    options.onGeneration?.({
+      generation,
+      bestScore: generationBest.score,
+      meanScore,
+      bestEaten: generationBest.eaten,
+    });
+
+    const parentCount = Math.max(1, Math.floor(options.populationSize / 2));
+    const parents = population.slice(0, parentCount);
+
+    const next: typeof population = [];
+    next.push(parents[0]); // elite
+    while (next.length < options.populationSize) {
+      const parent = parents[Math.floor(random() * parents.length)];
+      const childJSON = mutateCreatureJSON(
+        parent.json,
+        random,
+        options.mutationRate,
+        options.mutationStrength,
+      );
+      const childCreature = Creature.fromJSON(asCreatureExport(childJSON));
+      const r = scoreController(childCreature, episodeSeed, maxSteps);
+      next.push({ json: childJSON, score: r.score, eaten: r.eaten, steps: r.steps });
+    }
+    population = next;
+  }
+
+  const champion = Creature.fromJSON(asCreatureExport(bestJSON));
+  return {
+    champion,
+    bestScore,
+    generations: options.maxGenerations,
+    championEaten: bestEaten,
+    championSteps: bestSteps,
+  };
+}
+
+/** Path to the SVG snapshot the runner emits for the README. */
+export const SCREENSHOT_PATH = "docs/screenshots/snake_game.svg";
+
+if (import.meta.main) {
+  const start = Date.now();
+
+  console.log("🐍 Snake Game Example");
+  console.log("");
+
+  const { creaturesDir } = setupWorkingDirs(".synthetic-snake");
+
+  console.log("🧬 Evolving controller...");
+  const result = evolveSnakeController({
+    ...DEFAULT_EVOLVE_OPTIONS,
+    onGeneration: ({ generation, bestScore, meanScore, bestEaten }) => {
+      if (generation % 5 === 0) {
+        console.log(
+          `   Gen ${generation.toString().padStart(3)}  ` +
+            `best=${bestScore.toFixed(1).padStart(8)}  ` +
+            `mean=${meanScore.toFixed(1).padStart(8)}  ` +
+            `eaten=${bestEaten}`,
+        );
+      }
+    },
+  });
+
+  const verdictIcon = result.championEaten > 0 ? "✅" : "⚠️";
+  console.log(
+    `\n${verdictIcon} Champion ate ${result.championEaten} food in ${result.championSteps} steps ` +
+      `(score=${result.bestScore.toFixed(2)}, generations=${result.generations}).`,
+  );
+
+  // Save the champion creature.
+  const championPath = join(creaturesDir, "champion.json");
+  const championExport: CreatureExport = result.champion.exportJSON();
+  await safeWriteJson(championPath, championExport);
+  console.log(`💾 Saved champion to ${championPath}`);
+
+  // Render the animated SVG showing the champion's playthrough.
+  const episodeSeed = DEFAULT_EVOLVE_OPTIONS.seed ^ 0x5eed;
+  const trace = replayController(result.champion, episodeSeed);
+  const svg = renderRunSVG(trace);
+  ensureDirSync("docs/screenshots");
+  await Deno.writeTextFile(SCREENSHOT_PATH, svg);
+  console.log(`🖼️  Wrote screenshot ${SCREENSHOT_PATH} (${trace.length} frames captured)`);
+
+  console.log(
+    `\n🏁 Example completed in ${format(Date.now() - start, { ignoreZero: true })}`,
+  );
+}

--- a/snake_game/snake_game_test.ts
+++ b/snake_game/snake_game_test.ts
@@ -1,0 +1,172 @@
+/**
+ * Unit tests for the Snake-game NEAT controller. "What" tests only —
+ * each test calls a real function, runs the simulator or evolver, and
+ * asserts on the observable outputs.
+ */
+import { assert, assertEquals, assertGreaterOrEqual, assertNotEquals } from "@std/assert";
+import { existsSync } from "@std/fs";
+import { join } from "@std/path";
+import { Creature, safeWriteJson } from "@stsoftware/neat-ai";
+
+import { asCreatureExport } from "../common/legacy_types.ts";
+import { createDeterministicRandom } from "../common/deterministic_random.ts";
+import {
+  buildInitialCreatureJSON,
+  DEFAULT_EVOLVE_OPTIONS,
+  evolveSnakeController,
+  genesFromCreatureJSON,
+  mutateCreatureJSON,
+  randomCreatureJSON,
+  replayController,
+  scoreController,
+} from "./snake_game.ts";
+import { renderRunSVG } from "./svg.ts";
+import { INPUT_COUNT, OUTPUT_COUNT } from "./agent.ts";
+
+Deno.test("buildInitialCreatureJSON has 8 inputs and 4 outputs", () => {
+  const weights = new Array(INPUT_COUNT * OUTPUT_COUNT).fill(0);
+  const json = buildInitialCreatureJSON(weights, [0, 0, 0, 0]);
+  assertEquals(json.input, INPUT_COUNT);
+  assertEquals(json.output, OUTPUT_COUNT);
+  assertEquals(json.synapses.length, INPUT_COUNT * OUTPUT_COUNT);
+});
+
+Deno.test("buildInitialCreatureJSON produces a valid creature", () => {
+  const weights = new Array(INPUT_COUNT * OUTPUT_COUNT).fill(0.1);
+  const json = buildInitialCreatureJSON(weights, [0.1, 0.2, 0.3, 0.4]);
+  const creature = Creature.fromJSON(asCreatureExport(json));
+  creature.validate();
+});
+
+Deno.test("buildInitialCreatureJSON rejects wrong-sized weight vectors", () => {
+  let threw = false;
+  try {
+    buildInitialCreatureJSON([1, 2, 3], [0, 0, 0, 0]);
+  } catch {
+    threw = true;
+  }
+  assertEquals(threw, true);
+});
+
+Deno.test("genesFromCreatureJSON round-trips weights and biases", () => {
+  const weights: number[] = [];
+  for (let i = 0; i < INPUT_COUNT * OUTPUT_COUNT; i++) weights.push(i * 0.01);
+  const biases: [number, number, number, number] = [0.1, -0.2, 0.3, -0.4];
+  const json = buildInitialCreatureJSON(weights, biases);
+  const genes = genesFromCreatureJSON(json);
+  assertEquals(genes.weights, weights);
+  assertEquals(genes.biases, biases);
+});
+
+Deno.test("randomCreatureJSON is deterministic for the same seed", () => {
+  const a = randomCreatureJSON(createDeterministicRandom(99));
+  const b = randomCreatureJSON(createDeterministicRandom(99));
+  assertEquals(JSON.stringify(a), JSON.stringify(b));
+});
+
+Deno.test("mutateCreatureJSON yields a valid creature", () => {
+  const random = createDeterministicRandom(7);
+  const weights = new Array(INPUT_COUNT * OUTPUT_COUNT).fill(0);
+  const parent = buildInitialCreatureJSON(weights, [0, 0, 0, 0]);
+  const child = mutateCreatureJSON(parent, random, 1.0, 0.3);
+  const creature = Creature.fromJSON(asCreatureExport(child));
+  creature.validate();
+});
+
+Deno.test("scoreController returns a finite score for an arbitrary creature", () => {
+  const weights = new Array(INPUT_COUNT * OUTPUT_COUNT).fill(0);
+  const json = buildInitialCreatureJSON(weights, [0, 0, 0, 0]);
+  const creature = Creature.fromJSON(asCreatureExport(json));
+  const result = scoreController(creature, 1234, 100);
+  assert(Number.isFinite(result.score), `expected finite score, got ${result.score}`);
+  assertGreaterOrEqual(result.steps, 1);
+});
+
+Deno.test("evolveSnakeController champion eats at least one food item", async () => {
+  const result = evolveSnakeController(DEFAULT_EVOLVE_OPTIONS);
+  assertGreaterOrEqual(
+    result.championEaten,
+    1,
+    `expected the champion to eat at least one food, got ${result.championEaten}`,
+  );
+  // Champion must serialise cleanly for downstream consumption.
+  const tmp = await Deno.makeTempDir({ prefix: "snake_test_" });
+  try {
+    const path = join(tmp, "champion.json");
+    await safeWriteJson(path, result.champion.exportJSON());
+    assertEquals(existsSync(path), true);
+  } finally {
+    await Deno.remove(tmp, { recursive: true });
+  }
+});
+
+Deno.test("evolveSnakeController is reproducible — fixed seed, identical champion", () => {
+  const a = evolveSnakeController(DEFAULT_EVOLVE_OPTIONS);
+  const b = evolveSnakeController(DEFAULT_EVOLVE_OPTIONS);
+  const aJson = JSON.stringify(a.champion.exportJSON());
+  const bJson = JSON.stringify(b.champion.exportJSON());
+  assertEquals(aJson, bJson, "champions from the same seed must serialise identically");
+  assertEquals(a.bestScore, b.bestScore);
+  assertEquals(a.championEaten, b.championEaten);
+});
+
+Deno.test("evolveSnakeController with different seeds produces different champions", () => {
+  const a = evolveSnakeController({ ...DEFAULT_EVOLVE_OPTIONS, seed: 1, maxGenerations: 8 });
+  const b = evolveSnakeController({ ...DEFAULT_EVOLVE_OPTIONS, seed: 2, maxGenerations: 8 });
+  const aJson = JSON.stringify(a.champion.exportJSON());
+  const bJson = JSON.stringify(b.champion.exportJSON());
+  assertNotEquals(aJson, bJson);
+});
+
+Deno.test("replayController returns a non-empty trace starting at the initial state", () => {
+  const weights = new Array(INPUT_COUNT * OUTPUT_COUNT).fill(0);
+  const json = buildInitialCreatureJSON(weights, [0, 0, 0, 0]);
+  const creature = Creature.fromJSON(asCreatureExport(json));
+  const trace = replayController(creature, 4242, 50);
+  assert(trace.length > 0);
+  assertEquals(trace[0].steps, 0);
+});
+
+Deno.test("renderRunSVG emits an <svg> root with SMIL animation elements", () => {
+  const weights = new Array(INPUT_COUNT * OUTPUT_COUNT).fill(0);
+  const json = buildInitialCreatureJSON(weights, [0, 0, 0, 0]);
+  const creature = Creature.fromJSON(asCreatureExport(json));
+  const trace = replayController(creature, 4242, 30);
+  const svg = renderRunSVG(trace);
+  assert(svg.startsWith("<svg"), "must start with <svg>");
+  assert(svg.includes("</svg>"), "must contain </svg>");
+  const animateMatches = svg.match(/<animate /g) ?? [];
+  // Many animate nodes — food x/y/opacity, score colour, progress bar,
+  // and one trio per snake segment.
+  assertGreaterOrEqual(animateMatches.length, 6);
+});
+
+Deno.test("renderRunSVG repeats the animation indefinitely", () => {
+  const weights = new Array(INPUT_COUNT * OUTPUT_COUNT).fill(0);
+  const json = buildInitialCreatureJSON(weights, [0, 0, 0, 0]);
+  const creature = Creature.fromJSON(asCreatureExport(json));
+  const trace = replayController(creature, 4242, 30);
+  const svg = renderRunSVG(trace);
+  assert(svg.includes('repeatCount="indefinite"'));
+});
+
+Deno.test("renderRunSVG draws the snake head and food cells", () => {
+  const weights = new Array(INPUT_COUNT * OUTPUT_COUNT).fill(0);
+  const json = buildInitialCreatureJSON(weights, [0, 0, 0, 0]);
+  const creature = Creature.fromJSON(asCreatureExport(json));
+  const trace = replayController(creature, 4242, 30);
+  const svg = renderRunSVG(trace);
+  assert(svg.includes('class="snake-head"'), "expected the snake head element");
+  assert(svg.includes('class="food"'), "expected the food element");
+  assert(svg.includes('class="board"'), "expected the checker board background");
+});
+
+Deno.test("renderRunSVG rejects an empty trace", () => {
+  let threw = false;
+  try {
+    renderRunSVG([]);
+  } catch {
+    threw = true;
+  }
+  assertEquals(threw, true);
+});

--- a/snake_game/snake_test.ts
+++ b/snake_game/snake_test.ts
@@ -1,0 +1,162 @@
+/**
+ * Unit tests for the deterministic Snake game model.
+ *
+ * "What" tests only — each test calls a real function, runs the
+ * simulator, and asserts on observable output (state values, death
+ * flags, length progression).
+ */
+import { assert, assertEquals } from "@std/assert";
+import { createDeterministicRandom } from "../common/deterministic_random.ts";
+import {
+  cellsEqual,
+  Heading,
+  inBounds,
+  initialState,
+  isReverse,
+  newGame,
+  spawnFood,
+  step,
+} from "./snake.ts";
+
+Deno.test("initialState builds a snake of the requested length", () => {
+  const s = initialState(12, 4);
+  assertEquals(s.body.length, 4);
+  assertEquals(s.gridSize, 12);
+  assertEquals(s.heading, Heading.Right);
+  assertEquals(s.eaten, 0);
+  assertEquals(s.steps, 0);
+  assertEquals(s.dead, false);
+});
+
+Deno.test("initialState rejects too-small grids", () => {
+  let threw = false;
+  try {
+    initialState(2, 3);
+  } catch {
+    threw = true;
+  }
+  assertEquals(threw, true);
+});
+
+Deno.test("isReverse detects 180° turns", () => {
+  assertEquals(isReverse(Heading.Up, Heading.Down), true);
+  assertEquals(isReverse(Heading.Down, Heading.Up), true);
+  assertEquals(isReverse(Heading.Left, Heading.Right), true);
+  assertEquals(isReverse(Heading.Right, Heading.Left), true);
+  assertEquals(isReverse(Heading.Up, Heading.Right), false);
+  assertEquals(isReverse(Heading.Up, Heading.Up), false);
+});
+
+Deno.test("cellsEqual matches identical cells", () => {
+  assertEquals(cellsEqual({ x: 1, y: 2 }, { x: 1, y: 2 }), true);
+  assertEquals(cellsEqual({ x: 1, y: 2 }, { x: 1, y: 3 }), false);
+});
+
+Deno.test("inBounds rejects cells outside the grid", () => {
+  assertEquals(inBounds({ x: 0, y: 0 }, 5), true);
+  assertEquals(inBounds({ x: 4, y: 4 }, 5), true);
+  assertEquals(inBounds({ x: -1, y: 0 }, 5), false);
+  assertEquals(inBounds({ x: 5, y: 0 }, 5), false);
+  assertEquals(inBounds({ x: 0, y: 5 }, 5), false);
+});
+
+Deno.test("step — happy path: snake placed next to food eats it and grows", () => {
+  // Place food directly in front of the head so the next move eats.
+  const random = createDeterministicRandom(1);
+  const base = initialState(12, 3);
+  const head = base.body[0];
+  const food = { x: head.x + 1, y: head.y };
+  const state = { ...base, food };
+  const next = step(state, Heading.Right, random);
+  assertEquals(next.dead, false);
+  assertEquals(next.eaten, 1, "expected eaten to increment after eating food");
+  assertEquals(next.body.length, base.body.length + 1, "snake should grow by one segment");
+  assertEquals(next.body[0].x, head.x + 1);
+  // New food cell should not occupy a body cell.
+  for (const cell of next.body) {
+    assert(
+      !cellsEqual(cell, next.food),
+      "new food must not overlap any body cell",
+    );
+  }
+});
+
+Deno.test("step — wall collision ends the episode", () => {
+  const random = createDeterministicRandom(2);
+  const base = initialState(12, 3);
+  // Move snake to the right wall.
+  const head = { x: base.gridSize - 1, y: base.body[0].y };
+  const body = [head, { x: head.x - 1, y: head.y }, { x: head.x - 2, y: head.y }];
+  const state = { ...base, body, heading: Heading.Right };
+  const next = step(state, Heading.Right, random);
+  assertEquals(next.dead, true, "expected death after running into the wall");
+  assertEquals(next.eaten, 0);
+});
+
+Deno.test("step — self collision ends the episode", () => {
+  const random = createDeterministicRandom(3);
+  // Construct a snake long enough to collide with itself in one turn.
+  // Body shape (heading right, about to turn down then back into itself):
+  //   tail at (5, 5), body at (6, 5), (7, 5), (7, 6), (6, 6); head at (5, 6).
+  // Asking the head to go up onto (5, 5) would collide with the tail —
+  // but the tail moves first. To force a collision we put the head
+  // adjacent to a non-tail body cell.
+  const body = [
+    { x: 6, y: 6 }, // head
+    { x: 7, y: 6 },
+    { x: 7, y: 5 },
+    { x: 6, y: 5 },
+    { x: 5, y: 5 },
+  ];
+  const state = {
+    gridSize: 12,
+    body,
+    heading: Heading.Left,
+    food: { x: 0, y: 0 },
+    dead: false,
+    eaten: 0,
+    steps: 0,
+  };
+  // Move up: head would go to (6, 5) which is currently a body cell
+  // and remains one after the tail moves.
+  const next = step(state, Heading.Up, random);
+  assertEquals(next.dead, true, "expected death after running into own body");
+});
+
+Deno.test("step — 180° reversal request is ignored", () => {
+  const random = createDeterministicRandom(4);
+  const base = initialState(12, 3);
+  // Snake heading right; ask it to go left (a reversal).
+  const next = step({ ...base }, Heading.Left, random);
+  // The snake should keep heading right, not crash into its neck.
+  assertEquals(next.heading, Heading.Right);
+  assertEquals(next.dead, false);
+});
+
+Deno.test("step — non-eating move keeps body length constant", () => {
+  const random = createDeterministicRandom(5);
+  const base = initialState(12, 3);
+  // Set food well away so it is definitely not eaten.
+  const state = { ...base, food: { x: 0, y: 0 } };
+  const next = step(state, Heading.Right, random);
+  assertEquals(next.body.length, base.body.length);
+});
+
+Deno.test("spawnFood places food on a cell not occupied by the snake", () => {
+  const random = createDeterministicRandom(42);
+  const state = initialState(12, 5);
+  for (let i = 0; i < 20; i++) {
+    const food = spawnFood(state, random);
+    assert(food.x >= 0 && food.x < state.gridSize);
+    assert(food.y >= 0 && food.y < state.gridSize);
+    for (const cell of state.body) {
+      assert(!cellsEqual(food, cell), "food must not overlap snake body");
+    }
+  }
+});
+
+Deno.test("newGame is deterministic for the same seed", () => {
+  const a = newGame(createDeterministicRandom(7), 12, 3);
+  const b = newGame(createDeterministicRandom(7), 12, 3);
+  assertEquals(JSON.stringify(a), JSON.stringify(b));
+});

--- a/snake_game/svg.ts
+++ b/snake_game/svg.ts
@@ -1,0 +1,314 @@
+/**
+ * SVG rendering helpers for the Snake-game example.
+ *
+ * Produces a single animated SVG of the champion's playthrough. The
+ * board is drawn as a checker-pattern grid; the snake's body is
+ * rendered as a chain of rounded rectangles (head distinct from
+ * body); the food cell pulses via opacity animation. Each segment's
+ * `x` and `y` attributes are animated through SMIL keyframe lists
+ * derived from the recorded trace, so the snake visibly grows as it
+ * eats food.
+ *
+ * Limits to keep the file compact:
+ *   - Frames are sub-sampled to {@link MAX_KEYFRAMES} entries.
+ *   - The snake is rendered up to {@link MAX_SEGMENTS} segments; if it
+ *     grows longer (rare, given grid-12 and 500-step caps) extra
+ *     segments are simply not drawn.
+ */
+import type { Cell, SnakeState } from "./snake.ts";
+
+/** SVG canvas width in user units. */
+export const SVG_WIDTH = 480;
+
+/** SVG canvas height in user units. */
+export const SVG_HEIGHT = 520;
+
+/** Pixel size of each grid cell. */
+const CELL_SIZE = 32;
+
+/** Pixel inset for body squares so they look slightly inset in their cell. */
+const SEGMENT_INSET = 3;
+
+/** Top margin reserved for the title row and score. */
+const MARGIN_TOP = 40;
+
+/** Total animation duration (seconds) for one full replay loop. */
+export const ANIMATION_DURATION_SECONDS = 8;
+
+/** Maximum number of trajectory keyframes baked into the SMIL value lists. */
+export const MAX_KEYFRAMES = 120;
+
+/** Maximum number of snake segments rendered. */
+export const MAX_SEGMENTS = 64;
+
+/** Colour used for the snake's head. */
+const HEAD_COLOUR = "#f1c40f";
+
+/** Colour used for the snake's body. */
+const BODY_COLOUR = "#27ae60";
+
+/** Alternating fill colours for the checker pattern. */
+const CHECKER_LIGHT = "#f5f7fa";
+const CHECKER_DARK = "#e3e8ef";
+
+/** Food cell colour. */
+const FOOD_COLOUR = "#e74c3c";
+
+/** Convert a cell coordinate to its SVG-x position. */
+function cellX(x: number): number {
+  return x * CELL_SIZE;
+}
+
+/** Convert a cell coordinate to its SVG-y position. */
+function cellY(y: number): number {
+  return MARGIN_TOP + y * CELL_SIZE;
+}
+
+/**
+ * Sub-sample the trace down to at most {@link MAX_KEYFRAMES} entries.
+ * The first and final entries are always retained so a SMIL-disabled
+ * preview shows a sensible static frame and the score counter ends on
+ * the correct value.
+ */
+function sampleTrace(trace: SnakeState[]): SnakeState[] {
+  if (trace.length <= MAX_KEYFRAMES) return trace.slice();
+  const stride = Math.ceil(trace.length / MAX_KEYFRAMES);
+  const samples: SnakeState[] = [];
+  for (let i = 0; i < trace.length; i += stride) samples.push(trace[i]);
+  if (samples[samples.length - 1] !== trace[trace.length - 1]) {
+    samples.push(trace[trace.length - 1]);
+  }
+  return samples;
+}
+
+/** Return the cell occupied by segment `i` in `state`, or `undefined`. */
+function segmentCell(state: SnakeState, i: number): Cell | undefined {
+  return state.body[i];
+}
+
+/**
+ * Render the champion's playthrough as an animated SVG. The trace
+ * must contain at least one state. The first state is taken as the
+ * static base pose so SMIL-disabled viewers see a sensible frame.
+ */
+export function renderRunSVG(trace: SnakeState[]): string {
+  if (trace.length === 0) {
+    throw new Error("trace must contain at least one state");
+  }
+
+  const samples = sampleTrace(trace);
+  const first = samples[0];
+  const final = samples[samples.length - 1];
+  const gridSize = first.gridSize;
+  const animDur = `${ANIMATION_DURATION_SECONDS}s`;
+  // SMIL `repeatCount="indefinite"` for looping, `calcMode="discrete"`
+  // so segments snap from cell to cell rather than slide through the
+  // grid lines (matches the discrete game step semantics).
+  const animationCommon = `dur="${animDur}" repeatCount="indefinite" ` +
+    `calcMode="discrete" fill="freeze"`;
+
+  const lines: string[] = [];
+
+  lines.push(
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${SVG_WIDTH} ${SVG_HEIGHT}" ` +
+      `width="${SVG_WIDTH}" height="${SVG_HEIGHT}" role="img" ` +
+      `aria-label="Snake champion playthrough, animated through ${samples.length} keyframes">`,
+  );
+  lines.push(`  <title>Snake Champion Playthrough (animated)</title>`);
+  lines.push(
+    `  <desc>SMIL-animated SVG: a NEAT-AI controller plays Snake on a ${gridSize}×${gridSize} ` +
+      `grid. The snake body grows whenever the head meets food. Loops every ` +
+      `${ANIMATION_DURATION_SECONDS} seconds.</desc>`,
+  );
+  lines.push(`  <rect width="${SVG_WIDTH}" height="${SVG_HEIGHT}" fill="#1a2230"/>`);
+
+  // Checker board background.
+  lines.push(`  <g class="board">`);
+  for (let y = 0; y < gridSize; y++) {
+    for (let x = 0; x < gridSize; x++) {
+      const fill = (x + y) % 2 === 0 ? CHECKER_LIGHT : CHECKER_DARK;
+      lines.push(
+        `    <rect x="${cellX(x)}" y="${cellY(y)}" ` +
+          `width="${CELL_SIZE}" height="${CELL_SIZE}" fill="${fill}"/>`,
+      );
+    }
+  }
+  lines.push(`  </g>`);
+
+  // Animated food cell — moves to a new keyframe each tick and pulses
+  // via opacity animation.
+  const foodXValues = samples.map((s) => (cellX(s.food.x) + SEGMENT_INSET).toFixed(0)).join(";");
+  const foodYValues = samples.map((s) => (cellY(s.food.y) + SEGMENT_INSET).toFixed(0)).join(";");
+  lines.push(
+    `  <rect class="food" x="${(cellX(first.food.x) + SEGMENT_INSET).toFixed(0)}" ` +
+      `y="${(cellY(first.food.y) + SEGMENT_INSET).toFixed(0)}" ` +
+      `width="${CELL_SIZE - 2 * SEGMENT_INSET}" height="${CELL_SIZE - 2 * SEGMENT_INSET}" ` +
+      `rx="6" ry="6" fill="${FOOD_COLOUR}" stroke="#922b21" stroke-width="1">`,
+  );
+  lines.push(`    <animate attributeName="x" values="${foodXValues}" ${animationCommon}/>`);
+  lines.push(`    <animate attributeName="y" values="${foodYValues}" ${animationCommon}/>`);
+  lines.push(
+    `    <animate attributeName="opacity" values="1;0.55;1" ` +
+      `dur="0.8s" repeatCount="indefinite" calcMode="linear"/>`,
+  );
+  lines.push(`  </rect>`);
+
+  // Snake segments — render up to MAX_SEGMENTS; each animates its
+  // `x`, `y`, and `opacity` via SMIL value lists.
+  const maxObservedLength = Math.min(
+    MAX_SEGMENTS,
+    samples.reduce((m, s) => Math.max(m, s.body.length), 0),
+  );
+
+  for (let i = 0; i < maxObservedLength; i++) {
+    // For each keyframe, emit the (x, y) for segment i if present, or
+    // the head's position with opacity 0 if the segment does not yet
+    // exist (so it pops into being when the snake grows).
+    const xValues: string[] = [];
+    const yValues: string[] = [];
+    const opValues: string[] = [];
+    let initialX = 0;
+    let initialY = 0;
+    let initialOp = 0;
+    for (let k = 0; k < samples.length; k++) {
+      const seg = segmentCell(samples[k], i);
+      if (seg !== undefined) {
+        const sx = cellX(seg.x) + SEGMENT_INSET;
+        const sy = cellY(seg.y) + SEGMENT_INSET;
+        xValues.push(sx.toFixed(0));
+        yValues.push(sy.toFixed(0));
+        opValues.push("1");
+        if (k === 0) {
+          initialX = sx;
+          initialY = sy;
+          initialOp = 1;
+        }
+      } else {
+        // Segment not yet grown: hide off-grid.
+        const head = samples[k].body[0] ?? samples[k].body[samples[k].body.length - 1];
+        const sx = cellX(head.x) + SEGMENT_INSET;
+        const sy = cellY(head.y) + SEGMENT_INSET;
+        xValues.push(sx.toFixed(0));
+        yValues.push(sy.toFixed(0));
+        opValues.push("0");
+      }
+    }
+    const fill = i === 0 ? HEAD_COLOUR : BODY_COLOUR;
+    const stroke = i === 0 ? "#b7950b" : "#1e8449";
+    const className = i === 0 ? "snake-head" : "snake-body";
+    lines.push(
+      `  <rect class="${className}" x="${initialX.toFixed(0)}" y="${initialY.toFixed(0)}" ` +
+        `width="${CELL_SIZE - 2 * SEGMENT_INSET}" height="${CELL_SIZE - 2 * SEGMENT_INSET}" ` +
+        `rx="6" ry="6" fill="${fill}" stroke="${stroke}" stroke-width="1" ` +
+        `opacity="${initialOp}">`,
+    );
+    lines.push(`    <animate attributeName="x" values="${xValues.join(";")}" ${animationCommon}/>`);
+    lines.push(`    <animate attributeName="y" values="${yValues.join(";")}" ${animationCommon}/>`);
+    lines.push(
+      `    <animate attributeName="opacity" values="${opValues.join(";")}" ${animationCommon}/>`,
+    );
+    lines.push(`  </rect>`);
+  }
+
+  // Title row: example label and final summary (static).
+  lines.push(
+    `  <text x="12" y="22" font-family="monospace" font-size="14" fill="#ecf0f1">` +
+      `🐍 Snake · ${final.eaten} eaten · ${final.steps} steps · ` +
+      `${final.dead ? "died" : "alive"}</text>`,
+  );
+
+  // Animated score counter. We emit one <text> overlay per distinct
+  // score level reached during the playthrough: the first is visible
+  // from `t=0`, each subsequent overlay flips to visible via a SMIL
+  // `<set attributeName="display">` element timed to the moment the
+  // snake eats. Combined, the overlays produce a counter that bumps
+  // up live in step with the playthrough.
+  const distinctScores: { eaten: number; tickIndex: number }[] = [];
+  let lastEaten = -1;
+  for (let i = 0; i < samples.length; i++) {
+    if (samples[i].eaten !== lastEaten) {
+      distinctScores.push({ eaten: samples[i].eaten, tickIndex: i });
+      lastEaten = samples[i].eaten;
+    }
+  }
+  const totalTicks = Math.max(1, samples.length - 1);
+  for (let idx = 0; idx < distinctScores.length; idx++) {
+    const { eaten, tickIndex } = distinctScores[idx];
+    const score = eaten * 100;
+    const beginSeconds = (tickIndex / totalTicks) * ANIMATION_DURATION_SECONDS;
+    // The first overlay starts visible; subsequent overlays start
+    // hidden and become visible at their `begin` time. When the
+    // animation loops we hide them again at `t=0` so the counter
+    // resets cleanly.
+    const initialDisplay = idx === 0 ? "inline" : "none";
+    lines.push(
+      `  <text class="score" x="${SVG_WIDTH - 12}" y="22" text-anchor="end" ` +
+        `font-family="monospace" font-size="14" fill="#f1c40f" ` +
+        `display="${initialDisplay}">` +
+        `score ${score}`,
+    );
+    if (idx > 0) {
+      // Show this overlay at the appropriate moment in every loop.
+      lines.push(
+        `    <set attributeName="display" to="inline" ` +
+          `begin="${beginSeconds.toFixed(2)}s; ${
+            (beginSeconds + ANIMATION_DURATION_SECONDS)
+              .toFixed(2)
+          }s" />`,
+      );
+      // Hide it at the start of each loop so the counter resets.
+      lines.push(
+        `    <set attributeName="display" to="none" ` +
+          `begin="0s; ${ANIMATION_DURATION_SECONDS}s" />`,
+      );
+    } else if (distinctScores.length > 1) {
+      // The first overlay must hide once a higher score appears.
+      const nextBegin = (distinctScores[1].tickIndex / totalTicks) * ANIMATION_DURATION_SECONDS;
+      lines.push(
+        `    <set attributeName="display" to="none" ` +
+          `begin="${nextBegin.toFixed(2)}s; ${
+            (nextBegin + ANIMATION_DURATION_SECONDS).toFixed(2)
+          }s" />`,
+      );
+      lines.push(
+        `    <set attributeName="display" to="inline" ` +
+          `begin="0s; ${ANIMATION_DURATION_SECONDS}s" />`,
+      );
+    }
+    lines.push(`  </text>`);
+  }
+
+  // Score-pulse playhead under the counter — colour-shifts whenever
+  // the snake has eaten anything, just for visual flourish.
+  const colourValues = samples.map((s) => (s.eaten > 0 ? HEAD_COLOUR : "#bdc3c7")).join(";");
+  lines.push(
+    `  <rect class="score-pulse" x="${SVG_WIDTH - 70}" y="28" width="58" height="4" ` +
+      `rx="2" ry="2" fill="${HEAD_COLOUR}">`,
+  );
+  lines.push(
+    `    <animate attributeName="fill" values="${colourValues}" ${animationCommon}/>`,
+  );
+  lines.push(`  </rect>`);
+
+  // Bottom playhead progress bar.
+  const progressBarY = SVG_HEIGHT - 18;
+  const progressBarLeft = 12;
+  const progressBarWidth = SVG_WIDTH - 24;
+  lines.push(
+    `  <rect x="${progressBarLeft}" y="${progressBarY}" ` +
+      `width="${progressBarWidth}" height="4" fill="#34495e" rx="2"/>`,
+  );
+  lines.push(
+    `  <rect class="progress" x="${progressBarLeft}" y="${progressBarY}" ` +
+      `width="0" height="4" fill="#f1c40f" rx="2">`,
+  );
+  lines.push(
+    `    <animate attributeName="width" values="0;${progressBarWidth}" ` +
+      `dur="${animDur}" repeatCount="indefinite" fill="freeze"/>`,
+  );
+  lines.push(`  </rect>`);
+
+  lines.push(`</svg>`);
+  lines.push("");
+  return lines.join("\n");
+}


### PR DESCRIPTION
# Add Snake Game example with animated playthrough SVG

## Summary

Adds a new `snake_game/` example that evolves a NEAT-AI controller to play the classic Snake grid
game on a 12×12 board, plus an animated SVG playthrough rendered to
`docs/screenshots/snake_game.svg`. The example follows the same shape as the other control examples
(`mountain_car/`, `lunar_lander/`, `cart_pole/`): pure-TypeScript simulator, sensor + action
encoding, evolutionary loop, animated SVG renderer, "what" tests, and a `run.sh`. Wires into the
project quality gate (`quality.sh`), the top-level README's Examples table and Screenshots section,
and the README structure tests. Closes #81.

## Evidence

The change is a CLI / simulation example with no web UI to screenshot. Visual verification comes
from the committed `docs/screenshots/snake_game.svg`, which is animated SMIL output.

Pipeline (matches the issue diagram):

```mermaid
flowchart LR
    GAME["🐍 Snake grid game<br/>(snake.ts)"]
    SENSE["🛰️ Wall, food &amp; tail sensors<br/>(agent.ts)"]
    POLICY["🧠 Network → heading"]
    STEP["⏱️ Move + grow / die"]
    DONE{"dead or<br/>500 steps?"}
    SCORE["📏 Food × 100 − penalties"]
    SVG["🖼️ Animated playthrough SVG"]

    GAME --> SENSE --> POLICY --> STEP --> DONE
    DONE -- no --> SENSE
    DONE -- yes --> SCORE --> SVG
```

Champion run (default seed):

- Champion ate **1 food** in **10 steps** (score = 49.00) after 80 generations.
- `./quality.sh` passes end-to-end (lint, fmt, type-check, **474 unit tests**, all 11 example
  runners including the new Snake one).

## Test Plan

New tests added under `snake_game/`:

- `snake_test.ts` — game model:
  - Happy path: snake placed next to food eats it, length increments, food respawns off-body.
  - Wall collision ends the episode.
  - Self collision ends the episode.
  - 180° reversal request is ignored.
  - Non-eating move keeps body length constant.
  - `spawnFood`, `inBounds`, `cellsEqual`, `isReverse` boundary cases.
  - `newGame` is deterministic for the same seed.
- `agent_test.ts` — sensor encoding & action decoding:
  - Encoded vector has exactly `INPUT_COUNT` channels.
  - Wall distances respect the grid bounds.
  - Food and tail deltas point in the correct direction.
  - Length sensor scales with body size.
  - `headingLeft` / `headingRight` rotate cardinally.
  - `decodeAction` picks the argmax.
- `snake_game_test.ts` — evolutionary loop & SVG renderer:
  - `buildInitialCreatureJSON` shape and validation.
  - `genesFromCreatureJSON` round-trips weights and biases.
  - `randomCreatureJSON` deterministic for same seed.
  - `mutateCreatureJSON` yields a valid creature.
  - `scoreController` returns a finite score.
  - **`evolveSnakeController` champion eats at least one food item** (acceptance criterion).
  - **Reproducibility** — same seed produces a byte-identical champion.
  - Different seeds produce different champions.
  - `replayController` emits a non-empty trace starting at the initial state.
  - `renderRunSVG` emits an `<svg>` root with SMIL animation elements, looping `repeatCount`,
    snake-head/food/board classes, and rejects an empty trace.

Existing tests updated:

- `readme_structure_test.ts` — `EXAMPLE_DIRS`, `SCREENSHOT_PATHS`, and the required example-name
  list now include `snake_game` / `snake_game.svg` / "Snake".

Run them locally:

```bash
deno test --no-check --allow-read --allow-write --allow-env --allow-net snake_game/
./quality.sh
```



---

🤖 Processed by: stservice<!-- vibe-worker-issue-81 -->