### PR TITLE
Add maze navigation example with animated path-tracing SVG (Issue #79)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ walkthrough — the per-example README explains the workflow, options, and outpu
 | [🚀 Lunar Lander](lunar_lander/README.md)                 | Evolve a controller that lands a 2D lunar lander softly on a marked pad with limited fuel.                | `./lunar_lander/run.sh`         |
 | [🚗 Mountain Car](mountain_car/README.md)                 | Evolve a swing-up controller that drives an under-powered car up a sinusoidal hill to the goal flag.      | `./mountain_car/run.sh`         |
 | [🐍 Snake](snake_game/README.md)                          | Evolve a controller that plays the classic Snake grid game and render the playthrough as an animated SVG. | `./snake_game/run.sh`           |
+| [🗺️ Maze Navigation](maze_navigation/README.md)           | Evolve an agent to navigate a fixed grid maze from start to goal using local wall + heading sensors.      | `./maze_navigation/run.sh`      |
 | [🧬 Intelligent Design](intelligent_design/README.md)     | Systematically swap activation functions on hidden neurons to find better squashes than random mutation.  | `./intelligent_design/run.sh`   |
 | [🔍 Discovery](discovery/README.md)                       | Cripple a creature by removing a neuron, then use evolutionary search to recover its behaviour.           | `./discovery/run.sh`            |
 | [🔀 Crossover](crossover/README.md)                       | Breed two parents with different architectures into an offspring and (optionally) evolve it further.      | `./crossover/run.sh`            |
@@ -69,6 +70,16 @@ A NEAT-AI controller plays the classic Snake grid game on a 12×12 board. The sn
 chain of rounded rectangles (a yellow head and green body); the food cell pulses via opacity
 animation; the score counter ticks up via SMIL `<set>` overlays whenever the snake eats. A bottom
 playhead progress bar sweeps left-to-right to mark the loop.
+
+### 🗺️ Maze Navigation — agent traverses the maze
+
+![Maze Navigation champion run — an animated SVG of a circle moving along a dotted footprint trail through a 12×12 grid maze from the start cell to a pulsing goal cell](docs/screenshots/maze_navigation.svg)
+
+A NEAT-AI agent navigates a fixed 12×12 grid maze using only local sensors: four wall-distance
+readings (N/E/S/W) and a packed unit-vector heading-to-goal. The agent renders as a circle that
+animates along the recorded trajectory; a dotted breadcrumb polyline traces the path so the run
+remains readable after the loop ends; the goal cell pulses via opacity animation when the agent
+arrives.
 
 ### 📈 Stock Market — direction predictions
 

--- a/docs/archive_test.ts
+++ b/docs/archive_test.ts
@@ -55,7 +55,9 @@ Deno.test("No PR summary files remain in docs/ root", () => {
       if (entry.name === "pr-summary-76.md") continue;
       if (entry.name === "pr-summary-77.md") continue;
       if (entry.name === "pr-summary-78.md") continue;
+      if (entry.name === "pr-summary-79.md") continue;
       if (entry.name === "pr-summary-80.md") continue;
+      if (entry.name === "pr-summary-81.md") continue;
       throw new Error(
         `Found unexpected PR summary file in docs/ root: ${entry.name}`,
       );

--- a/docs/pr-summary-79.md
+++ b/docs/pr-summary-79.md
@@ -1,0 +1,64 @@
+# Maze Navigation Example
+
+## Summary
+
+Adds a new `maze_navigation/` example that evolves a NEAT-AI agent to navigate a fixed 12×12 grid
+maze from a start cell to a goal cell using local sensor inputs (four wall distances plus a packed
+heading-to-goal). The example mirrors the structure of `snake_game/`: a pure-TypeScript simulator
+(`maze.ts`), a sensor/action module (`agent.ts`), an evolutionary loop with truncation selection
+(`maze_navigation.ts`), and an animated SVG renderer (`svg.ts`) that traces the agent's footsteps
+through the maze with a dotted breadcrumb polyline and a pulsing goal cell. Closes #79.
+
+## Evidence
+
+The example is a CLI / SVG-rendering task with no web interface — evidence is the deterministic
+champion run plus the unit tests.
+
+```mermaid
+flowchart LR
+    MAZE["🗺️ Static grid maze<br/>(maze.ts)"]
+    SENSE["🛰️ Wall + heading sensors<br/>(agent.ts)"]
+    POLICY["🧠 Network → cardinal action"]
+    STEP["🚶 Step or block on wall"]
+    DONE{"goal reached<br/>or 200-step cap?"}
+    SCORE["📏 Score = f(distance, steps)"]
+    SVG["🖼️ Animated maze SVG"]
+
+    MAZE --> SENSE --> POLICY --> STEP --> DONE
+    DONE -- no --> SENSE
+    DONE -- yes --> SCORE --> SVG
+```
+
+Champion run output (deterministic seed `42`, 80-creature population, 60 generations):
+
+```
+✅ Champion reached the goal in 18 steps (final distance 0, score=0.982, generations=60).
+```
+
+The agent solves the L-shaped corridor in the optimal 18 steps (9 east + 9 south).
+
+`./quality.sh` passes end-to-end including the new `maze_navigation` example, all 39 maze-navigation
+unit tests, and the README structure / mermaid / archive tests.
+
+The animated SVG embedded in the top README is committed at `docs/screenshots/maze_navigation.svg`.
+
+## Test Plan
+
+- New unit tests in `maze_navigation/maze_test.ts` (17 tests) cover:
+  - Parsing string-art layouts (happy path + rejecting malformed layouts).
+  - Bounds, wall, and Manhattan helpers.
+  - Step semantics: happy path, walls block, `Stay` no-op, frozen-once-reached.
+  - **Walls block movement** — moving into a wall leaves the agent's position unchanged.
+  - **Sensor reading** — at a known cell the four wall distances match a hand-computed table.
+  - `wallDistance` cap behaviour.
+- New unit tests in `maze_navigation/agent_test.ts` (7 tests) cover sensor encoding, heading-to-goal
+  unit vector, argmax decoding, and the rule that `Stay` is never emitted.
+- New unit tests in `maze_navigation/maze_navigation_test.ts` (15 tests) cover creature
+  construction, gene round-tripping, mutation, scoring, evolution, replay, SVG rendering, and
+  **reproducibility** (fixed seed → byte-identical champions).
+- Updated `readme_structure_test.ts` to include `maze_navigation` in `EXAMPLE_DIRS`,
+  `SCREENSHOT_PATHS`, and the required-name list — all existing structural tests continue to pass.
+- Wired the example into `quality.sh` (added `run_example` line and `.synthetic-maze` cleanup); the
+  full pipeline (`./quality.sh`) passes.
+- Updated `docs/archive_test.ts` allowlist to include `pr-summary-79.md` (this PR) and
+  `pr-summary-81.md` (a pre-existing miss from PR #81 that was breaking the test).

--- a/docs/screenshots/maze_navigation.svg
+++ b/docs/screenshots/maze_navigation.svg
@@ -1,0 +1,362 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 408 452"
+  width="408"
+  height="452"
+  role="img"
+  aria-label="Maze navigation champion run, animated through 19 keyframes"
+>
+  <title>Maze Navigation Champion Run (animated)</title>
+  <desc>SMIL-animated SVG: a NEAT-AI agent navigates a 12×12 grid maze from start (S) to goal (G). The agent's footsteps are traced as a dotted polyline. Loops every 8 seconds.</desc>
+  <rect width="408" height="452" fill="#2c3e50" />
+  <g class="floor">
+    <rect x="12" y="40" width="32" height="32" fill="#f5e9d3" />
+    <rect x="44" y="40" width="32" height="32" fill="#f0dfb8" />
+    <rect x="76" y="40" width="32" height="32" fill="#f5e9d3" />
+    <rect x="108" y="40" width="32" height="32" fill="#f0dfb8" />
+    <rect x="140" y="40" width="32" height="32" fill="#f5e9d3" />
+    <rect x="172" y="40" width="32" height="32" fill="#f0dfb8" />
+    <rect x="204" y="40" width="32" height="32" fill="#f5e9d3" />
+    <rect x="236" y="40" width="32" height="32" fill="#f0dfb8" />
+    <rect x="268" y="40" width="32" height="32" fill="#f5e9d3" />
+    <rect x="300" y="40" width="32" height="32" fill="#f0dfb8" />
+    <rect x="332" y="40" width="32" height="32" fill="#f5e9d3" />
+    <rect x="364" y="40" width="32" height="32" fill="#f0dfb8" />
+    <rect x="12" y="72" width="32" height="32" fill="#f0dfb8" />
+    <rect x="44" y="72" width="32" height="32" fill="#f5e9d3" />
+    <rect x="76" y="72" width="32" height="32" fill="#f0dfb8" />
+    <rect x="108" y="72" width="32" height="32" fill="#f5e9d3" />
+    <rect x="140" y="72" width="32" height="32" fill="#f0dfb8" />
+    <rect x="172" y="72" width="32" height="32" fill="#f5e9d3" />
+    <rect x="204" y="72" width="32" height="32" fill="#f0dfb8" />
+    <rect x="236" y="72" width="32" height="32" fill="#f5e9d3" />
+    <rect x="268" y="72" width="32" height="32" fill="#f0dfb8" />
+    <rect x="300" y="72" width="32" height="32" fill="#f5e9d3" />
+    <rect x="332" y="72" width="32" height="32" fill="#f0dfb8" />
+    <rect x="364" y="72" width="32" height="32" fill="#f5e9d3" />
+    <rect x="12" y="104" width="32" height="32" fill="#f5e9d3" />
+    <rect x="44" y="104" width="32" height="32" fill="#f0dfb8" />
+    <rect x="76" y="104" width="32" height="32" fill="#f5e9d3" />
+    <rect x="108" y="104" width="32" height="32" fill="#f0dfb8" />
+    <rect x="140" y="104" width="32" height="32" fill="#f5e9d3" />
+    <rect x="172" y="104" width="32" height="32" fill="#f0dfb8" />
+    <rect x="204" y="104" width="32" height="32" fill="#f5e9d3" />
+    <rect x="236" y="104" width="32" height="32" fill="#f0dfb8" />
+    <rect x="268" y="104" width="32" height="32" fill="#f5e9d3" />
+    <rect x="300" y="104" width="32" height="32" fill="#f0dfb8" />
+    <rect x="332" y="104" width="32" height="32" fill="#f5e9d3" />
+    <rect x="364" y="104" width="32" height="32" fill="#f0dfb8" />
+    <rect x="12" y="136" width="32" height="32" fill="#f0dfb8" />
+    <rect x="44" y="136" width="32" height="32" fill="#f5e9d3" />
+    <rect x="76" y="136" width="32" height="32" fill="#f0dfb8" />
+    <rect x="108" y="136" width="32" height="32" fill="#f5e9d3" />
+    <rect x="140" y="136" width="32" height="32" fill="#f0dfb8" />
+    <rect x="172" y="136" width="32" height="32" fill="#f5e9d3" />
+    <rect x="204" y="136" width="32" height="32" fill="#f0dfb8" />
+    <rect x="236" y="136" width="32" height="32" fill="#f5e9d3" />
+    <rect x="268" y="136" width="32" height="32" fill="#f0dfb8" />
+    <rect x="300" y="136" width="32" height="32" fill="#f5e9d3" />
+    <rect x="332" y="136" width="32" height="32" fill="#f0dfb8" />
+    <rect x="364" y="136" width="32" height="32" fill="#f5e9d3" />
+    <rect x="12" y="168" width="32" height="32" fill="#f5e9d3" />
+    <rect x="44" y="168" width="32" height="32" fill="#f0dfb8" />
+    <rect x="76" y="168" width="32" height="32" fill="#f5e9d3" />
+    <rect x="108" y="168" width="32" height="32" fill="#f0dfb8" />
+    <rect x="140" y="168" width="32" height="32" fill="#f5e9d3" />
+    <rect x="172" y="168" width="32" height="32" fill="#f0dfb8" />
+    <rect x="204" y="168" width="32" height="32" fill="#f5e9d3" />
+    <rect x="236" y="168" width="32" height="32" fill="#f0dfb8" />
+    <rect x="268" y="168" width="32" height="32" fill="#f5e9d3" />
+    <rect x="300" y="168" width="32" height="32" fill="#f0dfb8" />
+    <rect x="332" y="168" width="32" height="32" fill="#f5e9d3" />
+    <rect x="364" y="168" width="32" height="32" fill="#f0dfb8" />
+    <rect x="12" y="200" width="32" height="32" fill="#f0dfb8" />
+    <rect x="44" y="200" width="32" height="32" fill="#f5e9d3" />
+    <rect x="76" y="200" width="32" height="32" fill="#f0dfb8" />
+    <rect x="108" y="200" width="32" height="32" fill="#f5e9d3" />
+    <rect x="140" y="200" width="32" height="32" fill="#f0dfb8" />
+    <rect x="172" y="200" width="32" height="32" fill="#f5e9d3" />
+    <rect x="204" y="200" width="32" height="32" fill="#f0dfb8" />
+    <rect x="236" y="200" width="32" height="32" fill="#f5e9d3" />
+    <rect x="268" y="200" width="32" height="32" fill="#f0dfb8" />
+    <rect x="300" y="200" width="32" height="32" fill="#f5e9d3" />
+    <rect x="332" y="200" width="32" height="32" fill="#f0dfb8" />
+    <rect x="364" y="200" width="32" height="32" fill="#f5e9d3" />
+    <rect x="12" y="232" width="32" height="32" fill="#f5e9d3" />
+    <rect x="44" y="232" width="32" height="32" fill="#f0dfb8" />
+    <rect x="76" y="232" width="32" height="32" fill="#f5e9d3" />
+    <rect x="108" y="232" width="32" height="32" fill="#f0dfb8" />
+    <rect x="140" y="232" width="32" height="32" fill="#f5e9d3" />
+    <rect x="172" y="232" width="32" height="32" fill="#f0dfb8" />
+    <rect x="204" y="232" width="32" height="32" fill="#f5e9d3" />
+    <rect x="236" y="232" width="32" height="32" fill="#f0dfb8" />
+    <rect x="268" y="232" width="32" height="32" fill="#f5e9d3" />
+    <rect x="300" y="232" width="32" height="32" fill="#f0dfb8" />
+    <rect x="332" y="232" width="32" height="32" fill="#f5e9d3" />
+    <rect x="364" y="232" width="32" height="32" fill="#f0dfb8" />
+    <rect x="12" y="264" width="32" height="32" fill="#f0dfb8" />
+    <rect x="44" y="264" width="32" height="32" fill="#f5e9d3" />
+    <rect x="76" y="264" width="32" height="32" fill="#f0dfb8" />
+    <rect x="108" y="264" width="32" height="32" fill="#f5e9d3" />
+    <rect x="140" y="264" width="32" height="32" fill="#f0dfb8" />
+    <rect x="172" y="264" width="32" height="32" fill="#f5e9d3" />
+    <rect x="204" y="264" width="32" height="32" fill="#f0dfb8" />
+    <rect x="236" y="264" width="32" height="32" fill="#f5e9d3" />
+    <rect x="268" y="264" width="32" height="32" fill="#f0dfb8" />
+    <rect x="300" y="264" width="32" height="32" fill="#f5e9d3" />
+    <rect x="332" y="264" width="32" height="32" fill="#f0dfb8" />
+    <rect x="364" y="264" width="32" height="32" fill="#f5e9d3" />
+    <rect x="12" y="296" width="32" height="32" fill="#f5e9d3" />
+    <rect x="44" y="296" width="32" height="32" fill="#f0dfb8" />
+    <rect x="76" y="296" width="32" height="32" fill="#f5e9d3" />
+    <rect x="108" y="296" width="32" height="32" fill="#f0dfb8" />
+    <rect x="140" y="296" width="32" height="32" fill="#f5e9d3" />
+    <rect x="172" y="296" width="32" height="32" fill="#f0dfb8" />
+    <rect x="204" y="296" width="32" height="32" fill="#f5e9d3" />
+    <rect x="236" y="296" width="32" height="32" fill="#f0dfb8" />
+    <rect x="268" y="296" width="32" height="32" fill="#f5e9d3" />
+    <rect x="300" y="296" width="32" height="32" fill="#f0dfb8" />
+    <rect x="332" y="296" width="32" height="32" fill="#f5e9d3" />
+    <rect x="364" y="296" width="32" height="32" fill="#f0dfb8" />
+    <rect x="12" y="328" width="32" height="32" fill="#f0dfb8" />
+    <rect x="44" y="328" width="32" height="32" fill="#f5e9d3" />
+    <rect x="76" y="328" width="32" height="32" fill="#f0dfb8" />
+    <rect x="108" y="328" width="32" height="32" fill="#f5e9d3" />
+    <rect x="140" y="328" width="32" height="32" fill="#f0dfb8" />
+    <rect x="172" y="328" width="32" height="32" fill="#f5e9d3" />
+    <rect x="204" y="328" width="32" height="32" fill="#f0dfb8" />
+    <rect x="236" y="328" width="32" height="32" fill="#f5e9d3" />
+    <rect x="268" y="328" width="32" height="32" fill="#f0dfb8" />
+    <rect x="300" y="328" width="32" height="32" fill="#f5e9d3" />
+    <rect x="332" y="328" width="32" height="32" fill="#f0dfb8" />
+    <rect x="364" y="328" width="32" height="32" fill="#f5e9d3" />
+    <rect x="12" y="360" width="32" height="32" fill="#f5e9d3" />
+    <rect x="44" y="360" width="32" height="32" fill="#f0dfb8" />
+    <rect x="76" y="360" width="32" height="32" fill="#f5e9d3" />
+    <rect x="108" y="360" width="32" height="32" fill="#f0dfb8" />
+    <rect x="140" y="360" width="32" height="32" fill="#f5e9d3" />
+    <rect x="172" y="360" width="32" height="32" fill="#f0dfb8" />
+    <rect x="204" y="360" width="32" height="32" fill="#f5e9d3" />
+    <rect x="236" y="360" width="32" height="32" fill="#f0dfb8" />
+    <rect x="268" y="360" width="32" height="32" fill="#f5e9d3" />
+    <rect x="300" y="360" width="32" height="32" fill="#f0dfb8" />
+    <rect x="332" y="360" width="32" height="32" fill="#f5e9d3" />
+    <rect x="364" y="360" width="32" height="32" fill="#f0dfb8" />
+    <rect x="12" y="392" width="32" height="32" fill="#f0dfb8" />
+    <rect x="44" y="392" width="32" height="32" fill="#f5e9d3" />
+    <rect x="76" y="392" width="32" height="32" fill="#f0dfb8" />
+    <rect x="108" y="392" width="32" height="32" fill="#f5e9d3" />
+    <rect x="140" y="392" width="32" height="32" fill="#f0dfb8" />
+    <rect x="172" y="392" width="32" height="32" fill="#f5e9d3" />
+    <rect x="204" y="392" width="32" height="32" fill="#f0dfb8" />
+    <rect x="236" y="392" width="32" height="32" fill="#f5e9d3" />
+    <rect x="268" y="392" width="32" height="32" fill="#f0dfb8" />
+    <rect x="300" y="392" width="32" height="32" fill="#f5e9d3" />
+    <rect x="332" y="392" width="32" height="32" fill="#f0dfb8" />
+    <rect x="364" y="392" width="32" height="32" fill="#f5e9d3" />
+  </g>
+  <rect class="start" x="44" y="72" width="32" height="32" fill="#7ed6df" opacity="0.55" />
+  <text
+    x="60"
+    y="93"
+    text-anchor="middle"
+    font-family="monospace"
+    font-size="14"
+    font-weight="bold"
+    fill="#1a2230"
+  >S</text>
+  <rect class="goal" x="332" y="360" width="32" height="32" fill="#e056fd" opacity="0.65" />
+  <rect class="goal-pulse" x="332" y="360" width="32" height="32" fill="#e056fd" opacity="0">
+    <animate
+      attributeName="opacity"
+      values="0;0.85;0"
+      dur="0.9s"
+      repeatCount="indefinite"
+      calcMode="linear"
+    />
+  </rect>
+  <text
+    x="348"
+    y="381"
+    text-anchor="middle"
+    font-family="monospace"
+    font-size="14"
+    font-weight="bold"
+    fill="#1a2230"
+  >G</text>
+  <g class="walls">
+    <rect x="12" y="40" width="32" height="32" fill="#1f2933" />
+    <rect x="44" y="40" width="32" height="32" fill="#1f2933" />
+    <rect x="76" y="40" width="32" height="32" fill="#1f2933" />
+    <rect x="108" y="40" width="32" height="32" fill="#1f2933" />
+    <rect x="140" y="40" width="32" height="32" fill="#1f2933" />
+    <rect x="172" y="40" width="32" height="32" fill="#1f2933" />
+    <rect x="204" y="40" width="32" height="32" fill="#1f2933" />
+    <rect x="236" y="40" width="32" height="32" fill="#1f2933" />
+    <rect x="268" y="40" width="32" height="32" fill="#1f2933" />
+    <rect x="300" y="40" width="32" height="32" fill="#1f2933" />
+    <rect x="332" y="40" width="32" height="32" fill="#1f2933" />
+    <rect x="364" y="40" width="32" height="32" fill="#1f2933" />
+    <rect x="12" y="72" width="32" height="32" fill="#1f2933" />
+    <rect x="364" y="72" width="32" height="32" fill="#1f2933" />
+    <rect x="12" y="104" width="32" height="32" fill="#1f2933" />
+    <rect x="44" y="104" width="32" height="32" fill="#1f2933" />
+    <rect x="76" y="104" width="32" height="32" fill="#1f2933" />
+    <rect x="108" y="104" width="32" height="32" fill="#1f2933" />
+    <rect x="140" y="104" width="32" height="32" fill="#1f2933" />
+    <rect x="172" y="104" width="32" height="32" fill="#1f2933" />
+    <rect x="204" y="104" width="32" height="32" fill="#1f2933" />
+    <rect x="236" y="104" width="32" height="32" fill="#1f2933" />
+    <rect x="268" y="104" width="32" height="32" fill="#1f2933" />
+    <rect x="300" y="104" width="32" height="32" fill="#1f2933" />
+    <rect x="364" y="104" width="32" height="32" fill="#1f2933" />
+    <rect x="12" y="136" width="32" height="32" fill="#1f2933" />
+    <rect x="44" y="136" width="32" height="32" fill="#1f2933" />
+    <rect x="76" y="136" width="32" height="32" fill="#1f2933" />
+    <rect x="108" y="136" width="32" height="32" fill="#1f2933" />
+    <rect x="140" y="136" width="32" height="32" fill="#1f2933" />
+    <rect x="172" y="136" width="32" height="32" fill="#1f2933" />
+    <rect x="204" y="136" width="32" height="32" fill="#1f2933" />
+    <rect x="236" y="136" width="32" height="32" fill="#1f2933" />
+    <rect x="268" y="136" width="32" height="32" fill="#1f2933" />
+    <rect x="300" y="136" width="32" height="32" fill="#1f2933" />
+    <rect x="364" y="136" width="32" height="32" fill="#1f2933" />
+    <rect x="12" y="168" width="32" height="32" fill="#1f2933" />
+    <rect x="44" y="168" width="32" height="32" fill="#1f2933" />
+    <rect x="76" y="168" width="32" height="32" fill="#1f2933" />
+    <rect x="108" y="168" width="32" height="32" fill="#1f2933" />
+    <rect x="140" y="168" width="32" height="32" fill="#1f2933" />
+    <rect x="172" y="168" width="32" height="32" fill="#1f2933" />
+    <rect x="204" y="168" width="32" height="32" fill="#1f2933" />
+    <rect x="236" y="168" width="32" height="32" fill="#1f2933" />
+    <rect x="268" y="168" width="32" height="32" fill="#1f2933" />
+    <rect x="300" y="168" width="32" height="32" fill="#1f2933" />
+    <rect x="364" y="168" width="32" height="32" fill="#1f2933" />
+    <rect x="12" y="200" width="32" height="32" fill="#1f2933" />
+    <rect x="44" y="200" width="32" height="32" fill="#1f2933" />
+    <rect x="76" y="200" width="32" height="32" fill="#1f2933" />
+    <rect x="108" y="200" width="32" height="32" fill="#1f2933" />
+    <rect x="140" y="200" width="32" height="32" fill="#1f2933" />
+    <rect x="172" y="200" width="32" height="32" fill="#1f2933" />
+    <rect x="204" y="200" width="32" height="32" fill="#1f2933" />
+    <rect x="236" y="200" width="32" height="32" fill="#1f2933" />
+    <rect x="268" y="200" width="32" height="32" fill="#1f2933" />
+    <rect x="300" y="200" width="32" height="32" fill="#1f2933" />
+    <rect x="364" y="200" width="32" height="32" fill="#1f2933" />
+    <rect x="12" y="232" width="32" height="32" fill="#1f2933" />
+    <rect x="44" y="232" width="32" height="32" fill="#1f2933" />
+    <rect x="76" y="232" width="32" height="32" fill="#1f2933" />
+    <rect x="108" y="232" width="32" height="32" fill="#1f2933" />
+    <rect x="140" y="232" width="32" height="32" fill="#1f2933" />
+    <rect x="172" y="232" width="32" height="32" fill="#1f2933" />
+    <rect x="204" y="232" width="32" height="32" fill="#1f2933" />
+    <rect x="236" y="232" width="32" height="32" fill="#1f2933" />
+    <rect x="268" y="232" width="32" height="32" fill="#1f2933" />
+    <rect x="300" y="232" width="32" height="32" fill="#1f2933" />
+    <rect x="364" y="232" width="32" height="32" fill="#1f2933" />
+    <rect x="12" y="264" width="32" height="32" fill="#1f2933" />
+    <rect x="44" y="264" width="32" height="32" fill="#1f2933" />
+    <rect x="76" y="264" width="32" height="32" fill="#1f2933" />
+    <rect x="108" y="264" width="32" height="32" fill="#1f2933" />
+    <rect x="140" y="264" width="32" height="32" fill="#1f2933" />
+    <rect x="172" y="264" width="32" height="32" fill="#1f2933" />
+    <rect x="204" y="264" width="32" height="32" fill="#1f2933" />
+    <rect x="236" y="264" width="32" height="32" fill="#1f2933" />
+    <rect x="268" y="264" width="32" height="32" fill="#1f2933" />
+    <rect x="300" y="264" width="32" height="32" fill="#1f2933" />
+    <rect x="364" y="264" width="32" height="32" fill="#1f2933" />
+    <rect x="12" y="296" width="32" height="32" fill="#1f2933" />
+    <rect x="44" y="296" width="32" height="32" fill="#1f2933" />
+    <rect x="76" y="296" width="32" height="32" fill="#1f2933" />
+    <rect x="108" y="296" width="32" height="32" fill="#1f2933" />
+    <rect x="140" y="296" width="32" height="32" fill="#1f2933" />
+    <rect x="172" y="296" width="32" height="32" fill="#1f2933" />
+    <rect x="204" y="296" width="32" height="32" fill="#1f2933" />
+    <rect x="236" y="296" width="32" height="32" fill="#1f2933" />
+    <rect x="268" y="296" width="32" height="32" fill="#1f2933" />
+    <rect x="300" y="296" width="32" height="32" fill="#1f2933" />
+    <rect x="364" y="296" width="32" height="32" fill="#1f2933" />
+    <rect x="12" y="328" width="32" height="32" fill="#1f2933" />
+    <rect x="44" y="328" width="32" height="32" fill="#1f2933" />
+    <rect x="76" y="328" width="32" height="32" fill="#1f2933" />
+    <rect x="108" y="328" width="32" height="32" fill="#1f2933" />
+    <rect x="140" y="328" width="32" height="32" fill="#1f2933" />
+    <rect x="172" y="328" width="32" height="32" fill="#1f2933" />
+    <rect x="204" y="328" width="32" height="32" fill="#1f2933" />
+    <rect x="236" y="328" width="32" height="32" fill="#1f2933" />
+    <rect x="268" y="328" width="32" height="32" fill="#1f2933" />
+    <rect x="300" y="328" width="32" height="32" fill="#1f2933" />
+    <rect x="364" y="328" width="32" height="32" fill="#1f2933" />
+    <rect x="12" y="360" width="32" height="32" fill="#1f2933" />
+    <rect x="44" y="360" width="32" height="32" fill="#1f2933" />
+    <rect x="76" y="360" width="32" height="32" fill="#1f2933" />
+    <rect x="108" y="360" width="32" height="32" fill="#1f2933" />
+    <rect x="140" y="360" width="32" height="32" fill="#1f2933" />
+    <rect x="172" y="360" width="32" height="32" fill="#1f2933" />
+    <rect x="204" y="360" width="32" height="32" fill="#1f2933" />
+    <rect x="236" y="360" width="32" height="32" fill="#1f2933" />
+    <rect x="268" y="360" width="32" height="32" fill="#1f2933" />
+    <rect x="300" y="360" width="32" height="32" fill="#1f2933" />
+    <rect x="364" y="360" width="32" height="32" fill="#1f2933" />
+    <rect x="12" y="392" width="32" height="32" fill="#1f2933" />
+    <rect x="44" y="392" width="32" height="32" fill="#1f2933" />
+    <rect x="76" y="392" width="32" height="32" fill="#1f2933" />
+    <rect x="108" y="392" width="32" height="32" fill="#1f2933" />
+    <rect x="140" y="392" width="32" height="32" fill="#1f2933" />
+    <rect x="172" y="392" width="32" height="32" fill="#1f2933" />
+    <rect x="204" y="392" width="32" height="32" fill="#1f2933" />
+    <rect x="236" y="392" width="32" height="32" fill="#1f2933" />
+    <rect x="268" y="392" width="32" height="32" fill="#1f2933" />
+    <rect x="300" y="392" width="32" height="32" fill="#1f2933" />
+    <rect x="332" y="392" width="32" height="32" fill="#1f2933" />
+    <rect x="364" y="392" width="32" height="32" fill="#1f2933" />
+  </g>
+  <polyline
+    class="footprint"
+    points="60,88 92,88 124,88 156,88 188,88 220,88 252,88 284,88 316,88 348,88 348,120 348,152 348,184 348,216 348,248 348,280 348,312 348,344 348,376"
+    fill="none"
+    stroke="#ff7f50"
+    stroke-width="3"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    stroke-dasharray="2 6"
+    opacity="0.85"
+  />
+  <circle
+    class="agent"
+    cx="60"
+    cy="88"
+    r="10.666666666666666"
+    fill="#ff7f50"
+    stroke="#a04030"
+    stroke-width="2"
+  >
+    <animate
+      attributeName="cx"
+      values="60;92;124;156;188;220;252;284;316;348;348;348;348;348;348;348;348;348;348"
+      dur="8s"
+      repeatCount="indefinite"
+      calcMode="discrete"
+      fill="freeze"
+    />
+    <animate
+      attributeName="cy"
+      values="88;88;88;88;88;88;88;88;88;88;120;152;184;216;248;280;312;344;376"
+      dur="8s"
+      repeatCount="indefinite"
+      calcMode="discrete"
+      fill="freeze"
+    />
+  </circle>
+  <text
+    x="12"
+    y="22"
+    font-family="monospace"
+    font-size="14"
+    fill="#ecf0f1"
+  >🗺️ Maze · 18 steps · reached goal</text>
+  <rect x="12" y="434" width="384" height="4" fill="#34495e" rx="2" />
+  <rect class="progress" x="12" y="434" width="0" height="4" fill="#ff7f50" rx="2">
+    <animate attributeName="width" values="0;384" dur="8s" repeatCount="indefinite" fill="freeze" />
+  </rect>
+</svg>

--- a/maze_navigation/README.md
+++ b/maze_navigation/README.md
@@ -1,0 +1,113 @@
+# 🗺️ Maze Navigation — Evolved Agent for a Grid Maze
+
+`maze_navigation.ts` evolves a NEAT-AI controller that navigates a fixed 12×12 grid maze from a
+start cell to a goal cell using only local sensor inputs (wall distances plus a packed
+heading-to-goal). The simulator (`maze.ts`), evolutionary loop, and animated SVG renderer (`svg.ts`)
+all run in pure TypeScript; the only external dependency is NEAT-AI's `Creature.activate` to compute
+each step's action.
+
+![Champion run](../docs/screenshots/maze_navigation.svg)
+
+## 🔧 How It Works
+
+```mermaid
+flowchart LR
+    MAZE["🗺️ Static grid maze<br/>(maze.ts)"]
+    SENSE["🛰️ Wall + heading sensors<br/>(agent.ts)"]
+    POLICY["🧠 Network → cardinal action"]
+    STEP["🚶 Step or block on wall"]
+    DONE{"goal reached<br/>or 200-step cap?"}
+    SCORE["📏 Score = f(distance, steps)"]
+    SVG["🖼️ Animated maze SVG"]
+
+    MAZE --> SENSE --> POLICY --> STEP --> DONE
+    DONE -- no --> SENSE
+    DONE -- yes --> SCORE --> SVG
+
+    style MAZE fill:#27ae60,stroke:#333,color:#fff
+    style SENSE fill:#3498db,stroke:#333,color:#fff
+    style POLICY fill:#9b59b6,stroke:#333,color:#fff
+    style STEP fill:#f39c12,stroke:#333,color:#fff
+    style SCORE fill:#e67e22,stroke:#333,color:#fff
+    style SVG fill:#f1c40f,stroke:#333,color:#000
+```
+
+## 🗺️ Maze Layout
+
+The default maze is encoded as a string-art template — `S` marks the start, `G` the goal, `#` walls
+and `.` open cells. The path is an L-shape: nine cells east along the top row, then nine cells south
+down the rightmost open column.
+
+```text
+############
+#S.........#
+##########.#
+##########.#
+##########.#
+##########.#
+##########.#
+##########.#
+##########.#
+##########.#
+##########G#
+############
+```
+
+## 🎯 Inputs and Outputs
+
+The agent observes a small sensor pack (5 channels):
+
+| Channel  | Type       | Symbol    | Meaning                                             |
+| -------- | ---------- | --------- | --------------------------------------------------- |
+| Input 0  | observable | `wallN`   | Free cells to the north, capped at 6, normalised    |
+| Input 1  | observable | `wallE`   | Free cells to the east                              |
+| Input 2  | observable | `wallS`   | Free cells to the south                             |
+| Input 3  | observable | `wallW`   | Free cells to the west                              |
+| Input 4  | observable | `heading` | Packed unit-vector heading-to-goal: `(ux + uy) / 2` |
+| Output 0 | action     | —         | Logistic activation; argmax → action **North**      |
+| Output 1 | action     | —         | Logistic activation; argmax → action **East**       |
+| Output 2 | action     | —         | Logistic activation; argmax → action **South**      |
+| Output 3 | action     | —         | Logistic activation; argmax → action **West**       |
+
+Each tick the controller chooses one of the four cardinal moves; if the destination is a wall or
+off-grid the agent stays put. Episodes end when the agent reaches the goal or the 200-step cap
+fires.
+
+## 📏 Scoring
+
+```text
+score = 1 / (1 + manhattan_to_goal_at_terminal_step) − step_count × 0.001
+```
+
+Reaching the goal scores `1 − steps × 0.001` — a max of about 0.8 for a quick run. A controller that
+gets stuck three cells from the goal scores `0.25` minus the step penalty, so the gradient toward
+the goal is preserved even before the agent first arrives.
+
+## 🚀 Running the Example
+
+```bash
+./maze_navigation/run.sh
+```
+
+Artefacts:
+
+- `.synthetic-maze/creatures/champion.json` – the fittest controller from the run
+- `.synthetic-maze/output/trajectory.json` – the champion's step-by-step trajectory log
+- `docs/screenshots/maze_navigation.svg` – animated SVG of the champion's run
+
+## 🧠 Tacit Knowledge
+
+A few things that are not obvious from the code alone:
+
+- **Linear policy is enough on the L-shape.** Five inputs and four logistic outputs (20 weights, 4
+  biases) is a small enough search space that an 80-creature population finds a goal-reaching
+  controller in tens of generations. There is no hidden layer — the wall-distance sensors carry
+  enough information for the network to learn "head where there is space".
+- **Argmax discretisation.** The four outputs are passed through logistics and then `argmax` — the
+  controller commits to one of four cardinal moves every step. The `Stay` action is never emitted.
+- **Walls block, they do not kill.** Bumping into a wall leaves the agent's position unchanged but
+  still consumes a tick, so prolonged wall-bumping erodes the score via the per-step penalty.
+- **Reproducibility.** All randomness flows through `common/deterministic_random.ts`. With a fixed
+  seed the same champion is produced on every run.
+- **Same maze every time.** The maze is encoded as a string-art template, parsed once at start-up,
+  and reused by every controller in the population — fitness comparisons are fair.

--- a/maze_navigation/agent.ts
+++ b/maze_navigation/agent.ts
@@ -1,0 +1,96 @@
+/**
+ * Maze-navigation agent: sensor encoding and action decoding.
+ *
+ * The controller observes the world through a small sensor pack of
+ * five floating-point values:
+ *
+ *   0. Wall distance North — capped at {@link SENSOR_CAP} cells, then
+ *      normalised to `[0, 1]` by dividing by `SENSOR_CAP`.
+ *   1. Wall distance East.
+ *   2. Wall distance South.
+ *   3. Wall distance West.
+ *   4. Heading-to-goal — a single packed value:
+ *      `(unitX + unitY) / 2` — both components added together so a
+ *      single channel encodes the direction towards the goal in the
+ *      `[-1, 1]` range. (See {@link encodeState} for the full vector
+ *      form passed to the network — five logical sensor channels.)
+ *
+ * The issue asks for "5 inputs: distances to wall on N/E/S/W (in
+ * cells, capped) and a unit-vector heading-to-goal (2 components
+ * packed)". We pack the unit vector into the fifth input by averaging
+ * its components — sufficient for a small linear policy to recover
+ * direction without inflating the input count.
+ *
+ * Outputs are four logistic activations — one per cardinal action —
+ * and the agent commits to the argmax over those scores every tick.
+ */
+import { Action, type Maze, type MazeState, wallDistance } from "./maze.ts";
+
+/** Number of sensor inputs fed to the controller. */
+export const INPUT_COUNT = 5;
+
+/** Number of action outputs (one per cardinal action — Stay is not emitted). */
+export const OUTPUT_COUNT = 4;
+
+/** Cap on the wall-distance sensor — keeps the input range bounded. */
+export const SENSOR_CAP = 6;
+
+/** Actions in argmax order for {@link decodeAction}. */
+export const ACTION_ORDER: ReadonlyArray<Action> = [
+  Action.North,
+  Action.East,
+  Action.South,
+  Action.West,
+];
+
+/**
+ * Compute the unit vector from `position` toward the maze's goal.
+ * Returns `[0, 0]` when the agent is already on the goal.
+ */
+export function headingToGoal(
+  maze: Maze,
+  position: { x: number; y: number },
+): [number, number] {
+  const dx = maze.goal.x - position.x;
+  const dy = maze.goal.y - position.y;
+  const mag = Math.hypot(dx, dy);
+  if (mag === 0) return [0, 0];
+  return [dx / mag, dy / mag];
+}
+
+/**
+ * Encode a {@link MazeState} as a Float32Array of {@link INPUT_COUNT}
+ * sensor values. Values are normalised so the network sees inputs in
+ * a comparable range regardless of maze size.
+ */
+export function encodeState(state: MazeState): Float32Array {
+  const { maze, position } = state;
+  const cap = SENSOR_CAP;
+  const wallN = wallDistance(maze, position.x, position.y, 0, -1, cap) / cap;
+  const wallE = wallDistance(maze, position.x, position.y, 1, 0, cap) / cap;
+  const wallS = wallDistance(maze, position.x, position.y, 0, 1, cap) / cap;
+  const wallW = wallDistance(maze, position.x, position.y, -1, 0, cap) / cap;
+  const [hx, hy] = headingToGoal(maze, position);
+  // Pack the two heading components into a single scalar in [-1, 1]
+  // by averaging — keeps the input count at five as the issue asks.
+  const headingPacked = (hx + hy) / 2;
+  return new Float32Array([wallN, wallE, wallS, wallW, headingPacked]);
+}
+
+/**
+ * Convert the four logistic outputs into the chosen {@link Action} by
+ * argmax. Ties favour lower indices (North, then East, then South,
+ * then West); the tie-breaker is irrelevant for evolutionary search
+ * but keeps the mapping deterministic.
+ */
+export function decodeAction(outputs: ArrayLike<number>): Action {
+  let bestIdx = 0;
+  let best = outputs[0];
+  for (let i = 1; i < OUTPUT_COUNT; i++) {
+    if (outputs[i] > best) {
+      best = outputs[i];
+      bestIdx = i;
+    }
+  }
+  return ACTION_ORDER[bestIdx];
+}

--- a/maze_navigation/agent_test.ts
+++ b/maze_navigation/agent_test.ts
@@ -1,0 +1,108 @@
+/**
+ * Unit tests for the maze-navigation agent (sensor encoding & action
+ * decoding). "What" tests only — call the encoder with known states,
+ * inspect the resulting Float32Array, and assert on the values.
+ */
+import { assert, assertAlmostEquals, assertEquals } from "@std/assert";
+import {
+  ACTION_ORDER,
+  decodeAction,
+  encodeState,
+  headingToGoal,
+  INPUT_COUNT,
+  OUTPUT_COUNT,
+  SENSOR_CAP,
+} from "./agent.ts";
+import { Action, initialState, parseMaze } from "./maze.ts";
+
+Deno.test("encodeState produces exactly INPUT_COUNT values", () => {
+  const maze = parseMaze([
+    "#####",
+    "#S.G#",
+    "#####",
+  ]);
+  const state = initialState(maze);
+  const out = encodeState(state);
+  assertEquals(out.length, INPUT_COUNT);
+});
+
+Deno.test("encodeState — sensor reading at a known cell matches a hand-computed table", () => {
+  // Layout:
+  //   #####
+  //   #...#
+  //   #.#.#
+  //   #S.G#
+  //   #####
+  // Agent starts at (1, 3). Wall distances:
+  //   north — (1,2) is `.`, (1,1) is `.`, (1,0) is `#` → 2
+  //   east  — (2,3) is `.`, (3,3) is `G` (free), (4,3) is `#` → 2
+  //   south — (1,4) is `#` → 0
+  //   west  — (0,3) is `#` → 0
+  const maze = parseMaze([
+    "#####",
+    "#...#",
+    "#.#.#",
+    "#S.G#",
+    "#####",
+  ]);
+  const state = initialState(maze);
+  const out = encodeState(state);
+  assertAlmostEquals(out[0], 2 / SENSOR_CAP, 1e-6, "north sensor");
+  assertAlmostEquals(out[1], 2 / SENSOR_CAP, 1e-6, "east sensor");
+  assertAlmostEquals(out[2], 0, 1e-6, "south sensor");
+  assertAlmostEquals(out[3], 0, 1e-6, "west sensor");
+});
+
+Deno.test("encodeState — heading sensor points toward the goal", () => {
+  // Agent at (1,1); goal at (3,1) — purely east.
+  const maze = parseMaze([
+    "#####",
+    "#S.G#",
+    "#####",
+  ]);
+  const state = initialState(maze);
+  const out = encodeState(state);
+  // Heading vector is (1, 0); packed = (1 + 0) / 2 = 0.5.
+  assertAlmostEquals(out[4], 0.5, 1e-6);
+});
+
+Deno.test("headingToGoal returns the unit vector toward the goal", () => {
+  // Goal directly south.
+  const maze = parseMaze([
+    "###",
+    "#S#",
+    "#.#",
+    "#G#",
+    "###",
+  ]);
+  const [hx, hy] = headingToGoal(maze, maze.start);
+  assertAlmostEquals(hx, 0, 1e-6);
+  assertAlmostEquals(hy, 1, 1e-6);
+});
+
+Deno.test("headingToGoal returns [0, 0] when the agent is on the goal", () => {
+  const maze = parseMaze([
+    "###",
+    "#SG",
+    "###",
+  ]);
+  const [hx, hy] = headingToGoal(maze, maze.goal);
+  assertEquals(hx, 0);
+  assertEquals(hy, 0);
+});
+
+Deno.test("decodeAction picks the argmax over the four outputs", () => {
+  for (let i = 0; i < OUTPUT_COUNT; i++) {
+    const outputs = [0.1, 0.1, 0.1, 0.1];
+    outputs[i] = 0.9;
+    assertEquals(decodeAction(outputs), ACTION_ORDER[i]);
+  }
+});
+
+Deno.test("decodeAction never emits Stay — only cardinal actions", () => {
+  for (let i = 0; i < 16; i++) {
+    const outputs = [Math.random(), Math.random(), Math.random(), Math.random()];
+    const action = decodeAction(outputs);
+    assert(action !== Action.Stay);
+  }
+});

--- a/maze_navigation/maze.ts
+++ b/maze_navigation/maze.ts
@@ -1,0 +1,223 @@
+/**
+ * Deterministic grid-maze model.
+ *
+ * A pure-TypeScript maze the NEAT-AI agent has to navigate from a
+ * fixed start cell to a fixed goal cell. The layout is encoded as a
+ * string-art template so it can be reviewed at a glance and altered
+ * without touching code.
+ *
+ * Coordinate system:
+ *   - `(x, y)` are integer cell coordinates with `(0, 0)` in the
+ *     top-left corner. `x` increases rightward, `y` increases downward
+ *     (matching SVG conventions, so the renderer is trivial).
+ *
+ * Step semantics:
+ *   - Each tick the agent picks one of {@link Action.North},
+ *     {@link Action.East}, {@link Action.South}, {@link Action.West},
+ *     or {@link Action.Stay}.
+ *   - The agent moves one cell in the chosen direction unless the
+ *     destination is a wall or off-grid; in either case the agent
+ *     stays put. {@link Action.Stay} also leaves the agent in place.
+ *
+ * Pure functions only — no globals, no hidden timers — so two runs
+ * with the same seed produce byte-identical traces.
+ */
+
+/** Cardinal actions plus a no-op. */
+export enum Action {
+  North = 0,
+  East = 1,
+  South = 2,
+  West = 3,
+  Stay = 4,
+}
+
+/** Translation vector for each action: `[Δx, Δy]`. */
+export const ACTION_DELTAS: ReadonlyArray<readonly [number, number]> = [
+  [0, -1],
+  [1, 0],
+  [0, 1],
+  [-1, 0],
+  [0, 0],
+];
+
+/** A single grid cell. */
+export interface Cell {
+  x: number;
+  y: number;
+}
+
+/** Immutable maze layout — walls plus start and goal cells. */
+export interface Maze {
+  /** Width of the grid in cells. */
+  width: number;
+  /** Height of the grid in cells. */
+  height: number;
+  /** Row-major wall mask: `walls[y * width + x] === true` ⇒ wall cell. */
+  walls: ReadonlyArray<boolean>;
+  /** Start cell — the agent begins here every episode. */
+  start: Cell;
+  /** Goal cell — the agent wins when it reaches this cell. */
+  goal: Cell;
+}
+
+/** Immutable snapshot of an in-progress maze run. */
+export interface MazeState {
+  maze: Maze;
+  /** Current agent position. */
+  position: Cell;
+  /** True once the agent has reached the goal cell. */
+  reached: boolean;
+  /** Number of ticks executed since `initialState`. */
+  steps: number;
+}
+
+/**
+ * Default 12×12 maze layout. `S` marks the start, `G` the goal, `#`
+ * walls and `.` open cells. The layout is an L-shaped corridor that
+ * forces the agent to go east first, then south — a small linear
+ * policy (no hidden layer) can pick this up in a few generations
+ * while the path is still long enough to give the SVG room to
+ * breathe.
+ */
+export const DEFAULT_LAYOUT: ReadonlyArray<string> = [
+  "############",
+  "#S.........#",
+  "##########.#",
+  "##########.#",
+  "##########.#",
+  "##########.#",
+  "##########.#",
+  "##########.#",
+  "##########.#",
+  "##########.#",
+  "##########G#",
+  "############",
+];
+
+/**
+ * Parse a string-art layout into a {@link Maze}. Every row must have
+ * the same length. Exactly one `S` and one `G` are required.
+ */
+export function parseMaze(layout: ReadonlyArray<string>): Maze {
+  if (layout.length === 0) {
+    throw new Error("layout must contain at least one row");
+  }
+  const width = layout[0].length;
+  const height = layout.length;
+  for (const row of layout) {
+    if (row.length !== width) {
+      throw new Error(
+        `every layout row must be ${width} characters wide, got ${row.length}: "${row}"`,
+      );
+    }
+  }
+  const walls: boolean[] = new Array(width * height).fill(false);
+  let start: Cell | undefined;
+  let goal: Cell | undefined;
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const ch = layout[y][x];
+      switch (ch) {
+        case "#":
+          walls[y * width + x] = true;
+          break;
+        case "S":
+          if (start) throw new Error("layout must contain exactly one start cell (S)");
+          start = { x, y };
+          break;
+        case "G":
+          if (goal) throw new Error("layout must contain exactly one goal cell (G)");
+          goal = { x, y };
+          break;
+        case ".":
+          break;
+        default:
+          throw new Error(`unrecognised layout character "${ch}" at (${x}, ${y})`);
+      }
+    }
+  }
+  if (!start) throw new Error("layout must contain a start cell (S)");
+  if (!goal) throw new Error("layout must contain a goal cell (G)");
+  return { width, height, walls, start, goal };
+}
+
+/** The default 12×12 maze used by the runner and renderer. */
+export function defaultMaze(): Maze {
+  return parseMaze(DEFAULT_LAYOUT);
+}
+
+/** Returns true when `(x, y)` is on the grid. */
+export function inBounds(maze: Maze, x: number, y: number): boolean {
+  return x >= 0 && y >= 0 && x < maze.width && y < maze.height;
+}
+
+/** Returns true when `(x, y)` is a wall cell. Off-grid counts as a wall. */
+export function isWall(maze: Maze, x: number, y: number): boolean {
+  if (!inBounds(maze, x, y)) return true;
+  return maze.walls[y * maze.width + x];
+}
+
+/** Returns true when `a` and `b` cover the same grid cell. */
+export function cellsEqual(a: Cell, b: Cell): boolean {
+  return a.x === b.x && a.y === b.y;
+}
+
+/** Manhattan distance between `a` and `b`. */
+export function manhattan(a: Cell, b: Cell): number {
+  return Math.abs(a.x - b.x) + Math.abs(a.y - b.y);
+}
+
+/** Build the initial state — agent at the maze's start cell. */
+export function initialState(maze: Maze): MazeState {
+  return {
+    maze,
+    position: { x: maze.start.x, y: maze.start.y },
+    reached: cellsEqual(maze.start, maze.goal),
+    steps: 0,
+  };
+}
+
+/**
+ * Advance the simulation by one tick. The agent attempts to move in
+ * the requested direction; if the destination is a wall or off-grid
+ * the position stays unchanged.
+ */
+export function step(state: MazeState, action: Action): MazeState {
+  if (state.reached) return state;
+  const [dx, dy] = ACTION_DELTAS[action];
+  const tx = state.position.x + dx;
+  const ty = state.position.y + dy;
+  const blocked = isWall(state.maze, tx, ty);
+  const next: Cell = blocked ? { x: state.position.x, y: state.position.y } : { x: tx, y: ty };
+  return {
+    maze: state.maze,
+    position: next,
+    reached: cellsEqual(next, state.maze.goal),
+    steps: state.steps + 1,
+  };
+}
+
+/**
+ * Wall distance from `(x, y)` along `(dx, dy)` — number of free cells
+ * the agent could move through before bumping into a wall (or the
+ * grid boundary). The starting cell itself is not counted.
+ */
+export function wallDistance(
+  maze: Maze,
+  x: number,
+  y: number,
+  dx: number,
+  dy: number,
+  cap: number,
+): number {
+  let distance = 0;
+  let cx = x + dx;
+  let cy = y + dy;
+  while (distance < cap && !isWall(maze, cx, cy)) {
+    distance += 1;
+    cx += dx;
+    cy += dy;
+  }
+  return distance;
+}

--- a/maze_navigation/maze_navigation.ts
+++ b/maze_navigation/maze_navigation.ts
@@ -1,0 +1,390 @@
+/**
+ * Maze Navigation Example.
+ *
+ * Evolves a NEAT-AI controller to navigate a fixed grid maze from a
+ * start cell to a goal cell using local sensor inputs (wall distances
+ * plus a packed heading-to-goal). Truncation selection plus per-gene
+ * mutation drives a small linear policy (5 inputs, 4 logistic outputs,
+ * no hidden layer) toward a successful trajectory.
+ *
+ * Score = `1 / (1 + manhattan_to_goal_at_terminal_step) − step_count
+ * × STEP_PENALTY`. A controller that reaches the goal scores 1 minus
+ * the per-step cost; one that gets stuck scores significantly less.
+ */
+import { format } from "@std/fmt/duration";
+import { ensureDirSync } from "@std/fs";
+import { join } from "@std/path";
+import { Creature, type CreatureExport, safeWriteJson } from "@stsoftware/neat-ai";
+
+import { createDeterministicRandom } from "../common/deterministic_random.ts";
+import { setupWorkingDirs } from "../common/working_dirs.ts";
+import { asCreatureExport, type LegacyCreatureJSON } from "../common/legacy_types.ts";
+import { decodeAction, encodeState, INPUT_COUNT, OUTPUT_COUNT } from "./agent.ts";
+import { defaultMaze, initialState, manhattan, type MazeState, step } from "./maze.ts";
+import { renderRunSVG } from "./svg.ts";
+
+/** Index of the first output neuron. */
+const FIRST_OUTPUT_INDEX = INPUT_COUNT;
+
+/** Hard cap on the number of ticks a single episode is allowed. */
+export const MAX_STEPS = 200;
+
+/** Penalty applied per step taken (subtracted from the terminal score). */
+export const STEP_PENALTY = 0.001;
+
+/** Configuration options for {@link evolveMazeController}. */
+export interface EvolveOptions {
+  seed: number;
+  populationSize: number;
+  maxGenerations: number;
+  mutationStrength: number;
+  mutationRate: number;
+  /** Hard cap on episode length. Defaults to {@link MAX_STEPS}. */
+  maxSteps?: number;
+  onGeneration?: (info: GenerationInfo) => void;
+}
+
+/** Statistics emitted after each generation. */
+export interface GenerationInfo {
+  generation: number;
+  bestScore: number;
+  meanScore: number;
+  bestReached: boolean;
+}
+
+/** Result of the evolutionary search. */
+export interface EvolveResult {
+  champion: Creature;
+  bestScore: number;
+  generations: number;
+  championReached: boolean;
+  championSteps: number;
+  championFinalDistance: number;
+}
+
+/** Sensible defaults for the demonstration runner. */
+export const DEFAULT_EVOLVE_OPTIONS: EvolveOptions = {
+  seed: 42,
+  populationSize: 80,
+  maxGenerations: 60,
+  mutationStrength: 0.5,
+  mutationRate: 0.4,
+};
+
+/**
+ * Build a small linear network: five inputs feeding directly into
+ * four LOGISTIC outputs (one per cardinal action). 20 weights and 4
+ * biases is a compact search space that captures simple "head toward
+ * the goal while avoiding walls" policies without inflating evolution
+ * time.
+ */
+export function buildInitialCreatureJSON(
+  weights: number[],
+  biases: [number, number, number, number],
+): LegacyCreatureJSON {
+  if (weights.length !== INPUT_COUNT * OUTPUT_COUNT) {
+    throw new Error(
+      `weights must contain exactly ${INPUT_COUNT * OUTPUT_COUNT} entries, ` +
+        `got ${weights.length}`,
+    );
+  }
+  const neurons: LegacyCreatureJSON["neurons"] = [];
+  for (let i = 0; i < INPUT_COUNT; i++) {
+    neurons.push({ type: "input", squash: "LOGISTIC", index: i, uuid: `input-${i}` });
+  }
+  for (let o = 0; o < OUTPUT_COUNT; o++) {
+    neurons.push({
+      type: "output",
+      squash: "LOGISTIC",
+      index: FIRST_OUTPUT_INDEX + o,
+      bias: biases[o],
+      uuid: `output-${o}`,
+    });
+  }
+  const synapses: LegacyCreatureJSON["synapses"] = [];
+  for (let o = 0; o < OUTPUT_COUNT; o++) {
+    for (let i = 0; i < INPUT_COUNT; i++) {
+      synapses.push({
+        from: i,
+        to: FIRST_OUTPUT_INDEX + o,
+        weight: weights[o * INPUT_COUNT + i],
+      });
+    }
+  }
+  return { neurons, synapses, input: INPUT_COUNT, output: OUTPUT_COUNT };
+}
+
+/** Sample a value from `[-range, range]` using the supplied PRNG. */
+function uniformSigned(random: () => number, range: number): number {
+  return (random() * 2 - 1) * range;
+}
+
+/** Random initial creature: weights in `[-1, 1]`, biases in `[-0.5, 0.5]`. */
+export function randomCreatureJSON(random: () => number): LegacyCreatureJSON {
+  const weights: number[] = [];
+  for (let i = 0; i < INPUT_COUNT * OUTPUT_COUNT; i++) {
+    weights.push(uniformSigned(random, 1));
+  }
+  const biases: [number, number, number, number] = [
+    uniformSigned(random, 0.5),
+    uniformSigned(random, 0.5),
+    uniformSigned(random, 0.5),
+    uniformSigned(random, 0.5),
+  ];
+  return buildInitialCreatureJSON(weights, biases);
+}
+
+/** Decode a creature export back into its weights and biases. */
+export function genesFromCreatureJSON(
+  json: LegacyCreatureJSON,
+): { weights: number[]; biases: [number, number, number, number] } {
+  const weights = new Array(INPUT_COUNT * OUTPUT_COUNT).fill(0);
+  for (const synapse of json.synapses) {
+    const o = synapse.to - FIRST_OUTPUT_INDEX;
+    if (o >= 0 && o < OUTPUT_COUNT && synapse.from >= 0 && synapse.from < INPUT_COUNT) {
+      weights[o * INPUT_COUNT + synapse.from] = synapse.weight;
+    }
+  }
+  const biases: [number, number, number, number] = [0, 0, 0, 0];
+  for (let o = 0; o < OUTPUT_COUNT; o++) {
+    const neuron = json.neurons.find((n) => n.uuid === `output-${o}`);
+    biases[o] = neuron?.bias ?? 0;
+  }
+  return { weights, biases };
+}
+
+/** Mutate each gene independently with probability `mutationRate`. */
+export function mutateCreatureJSON(
+  parent: LegacyCreatureJSON,
+  random: () => number,
+  mutationRate: number,
+  mutationStrength: number,
+): LegacyCreatureJSON {
+  const { weights, biases } = genesFromCreatureJSON(parent);
+  const newWeights = weights.map((w) =>
+    random() < mutationRate ? w + uniformSigned(random, mutationStrength) : w
+  );
+  const newBiases = biases.map((b) =>
+    random() < mutationRate ? b + uniformSigned(random, mutationStrength) : b
+  ) as [number, number, number, number];
+  return buildInitialCreatureJSON(newWeights, newBiases);
+}
+
+/** Outcome of a single scoring episode. */
+export interface EpisodeResult {
+  score: number;
+  reached: boolean;
+  steps: number;
+  finalDistance: number;
+  finalState: MazeState;
+}
+
+/**
+ * Play one episode and score the controller. Each agent starts at
+ * the maze's start cell; the simulator runs until the agent reaches
+ * the goal or the step cap fires.
+ */
+export function scoreController(
+  creature: Creature,
+  maxSteps: number = MAX_STEPS,
+): EpisodeResult {
+  const maze = defaultMaze();
+  let state = initialState(maze);
+  for (let i = 0; i < maxSteps; i++) {
+    if (state.reached) break;
+    creature.clearState();
+    const out = creature.activate(encodeState(state));
+    const action = decodeAction(out);
+    state = step(state, action);
+  }
+  const finalDistance = manhattan(state.position, maze.goal);
+  const score = 1 / (1 + finalDistance) - state.steps * STEP_PENALTY;
+  return {
+    score,
+    reached: state.reached,
+    steps: state.steps,
+    finalDistance,
+    finalState: state,
+  };
+}
+
+/**
+ * Replay a creature's run, returning the full trajectory (one entry
+ * per tick, including the initial state) suitable for the SVG
+ * renderer.
+ */
+export function replayController(
+  creature: Creature,
+  maxSteps: number = MAX_STEPS,
+): MazeState[] {
+  const maze = defaultMaze();
+  let state = initialState(maze);
+  const trace: MazeState[] = [state];
+  for (let i = 0; i < maxSteps; i++) {
+    if (state.reached) break;
+    creature.clearState();
+    const out = creature.activate(encodeState(state));
+    const action = decodeAction(out);
+    state = step(state, action);
+    trace.push(state);
+  }
+  return trace;
+}
+
+/**
+ * Run a generational evolutionary algorithm. Truncation selection
+ * keeps the top half as parents; the elite carries over so the best
+ * score is monotonically non-decreasing.
+ */
+export function evolveMazeController(
+  options: EvolveOptions = DEFAULT_EVOLVE_OPTIONS,
+): EvolveResult {
+  const random = createDeterministicRandom(options.seed);
+  const maxSteps = options.maxSteps ?? MAX_STEPS;
+
+  let population: Array<{
+    json: LegacyCreatureJSON;
+    score: number;
+    reached: boolean;
+    steps: number;
+    finalDistance: number;
+  }> = [];
+  for (let i = 0; i < options.populationSize; i++) {
+    const json = randomCreatureJSON(random);
+    const creature = Creature.fromJSON(asCreatureExport(json));
+    const r = scoreController(creature, maxSteps);
+    population.push({
+      json,
+      score: r.score,
+      reached: r.reached,
+      steps: r.steps,
+      finalDistance: r.finalDistance,
+    });
+  }
+
+  let bestJSON = population[0].json;
+  let bestScore = -Infinity;
+  let bestReached = false;
+  let bestSteps = 0;
+  let bestFinalDistance = Number.POSITIVE_INFINITY;
+
+  for (let generation = 0; generation < options.maxGenerations; generation++) {
+    population.sort((a, b) => b.score - a.score);
+    const generationBest = population[0];
+    if (generationBest.score > bestScore) {
+      bestScore = generationBest.score;
+      bestJSON = generationBest.json;
+      bestReached = generationBest.reached;
+      bestSteps = generationBest.steps;
+      bestFinalDistance = generationBest.finalDistance;
+    }
+
+    const meanScore = population.reduce((acc, p) => acc + p.score, 0) /
+      population.length;
+    options.onGeneration?.({
+      generation,
+      bestScore: generationBest.score,
+      meanScore,
+      bestReached: generationBest.reached,
+    });
+
+    const parentCount = Math.max(1, Math.floor(options.populationSize / 2));
+    const parents = population.slice(0, parentCount);
+
+    const next: typeof population = [];
+    next.push(parents[0]); // elite
+    while (next.length < options.populationSize) {
+      const parent = parents[Math.floor(random() * parents.length)];
+      const childJSON = mutateCreatureJSON(
+        parent.json,
+        random,
+        options.mutationRate,
+        options.mutationStrength,
+      );
+      const childCreature = Creature.fromJSON(asCreatureExport(childJSON));
+      const r = scoreController(childCreature, maxSteps);
+      next.push({
+        json: childJSON,
+        score: r.score,
+        reached: r.reached,
+        steps: r.steps,
+        finalDistance: r.finalDistance,
+      });
+    }
+    population = next;
+  }
+
+  const champion = Creature.fromJSON(asCreatureExport(bestJSON));
+  return {
+    champion,
+    bestScore,
+    generations: options.maxGenerations,
+    championReached: bestReached,
+    championSteps: bestSteps,
+    championFinalDistance: bestFinalDistance,
+  };
+}
+
+/** Path to the SVG snapshot the runner emits for the README. */
+export const SCREENSHOT_PATH = "docs/screenshots/maze_navigation.svg";
+
+if (import.meta.main) {
+  const start = Date.now();
+
+  console.log("🗺️  Maze Navigation Example");
+  console.log("");
+
+  const { creaturesDir, outputDir } = setupWorkingDirs(".synthetic-maze");
+
+  console.log("🧬 Evolving controller...");
+  const result = evolveMazeController({
+    ...DEFAULT_EVOLVE_OPTIONS,
+    onGeneration: ({ generation, bestScore, meanScore, bestReached }) => {
+      if (generation % 5 === 0) {
+        console.log(
+          `   Gen ${generation.toString().padStart(3)}  ` +
+            `best=${bestScore.toFixed(3).padStart(8)}  ` +
+            `mean=${meanScore.toFixed(3).padStart(8)}  ` +
+            `reached=${bestReached ? "✅" : "··"}`,
+        );
+      }
+    },
+  });
+
+  const verdictIcon = result.championReached ? "✅" : "⚠️";
+  console.log(
+    `\n${verdictIcon} Champion ` +
+      `${result.championReached ? "reached the goal" : "did not reach the goal"} ` +
+      `in ${result.championSteps} steps (final distance ${result.championFinalDistance}, ` +
+      `score=${result.bestScore.toFixed(3)}, generations=${result.generations}).`,
+  );
+
+  // Save the champion creature.
+  const championPath = join(creaturesDir, "champion.json");
+  const championExport: CreatureExport = result.champion.exportJSON();
+  await safeWriteJson(championPath, championExport);
+  console.log(`💾 Saved champion to ${championPath}`);
+
+  // Replay and save the trajectory log so subsequent inspection runs
+  // can rebuild the SVG without re-evolving.
+  const trace = replayController(result.champion);
+  const trajectoryPath = join(outputDir, "trajectory.json");
+  const trajectoryLog = {
+    reached: result.championReached,
+    steps: result.championSteps,
+    finalDistance: result.championFinalDistance,
+    positions: trace.map((s) => ({ x: s.position.x, y: s.position.y })),
+  };
+  await Deno.writeTextFile(trajectoryPath, JSON.stringify(trajectoryLog, null, 2));
+  console.log(`📜 Saved trajectory log to ${trajectoryPath}`);
+
+  // Render the animated SVG showing the champion's playthrough.
+  const svg = renderRunSVG(trace);
+  ensureDirSync("docs/screenshots");
+  await Deno.writeTextFile(SCREENSHOT_PATH, svg);
+  console.log(`🖼️  Wrote screenshot ${SCREENSHOT_PATH} (${trace.length} frames captured)`);
+
+  console.log(
+    `\n🏁 Example completed in ${format(Date.now() - start, { ignoreZero: true })}`,
+  );
+}

--- a/maze_navigation/maze_navigation_test.ts
+++ b/maze_navigation/maze_navigation_test.ts
@@ -1,0 +1,173 @@
+/**
+ * Unit tests for the maze-navigation NEAT controller. "What" tests
+ * only — each test calls a real function, runs the simulator or
+ * evolver, and asserts on the observable outputs.
+ */
+import { assert, assertEquals, assertGreaterOrEqual, assertNotEquals } from "@std/assert";
+import { existsSync } from "@std/fs";
+import { join } from "@std/path";
+import { Creature, safeWriteJson } from "@stsoftware/neat-ai";
+
+import { asCreatureExport } from "../common/legacy_types.ts";
+import { createDeterministicRandom } from "../common/deterministic_random.ts";
+import {
+  buildInitialCreatureJSON,
+  DEFAULT_EVOLVE_OPTIONS,
+  evolveMazeController,
+  genesFromCreatureJSON,
+  mutateCreatureJSON,
+  randomCreatureJSON,
+  replayController,
+  scoreController,
+} from "./maze_navigation.ts";
+import { renderRunSVG } from "./svg.ts";
+import { INPUT_COUNT, OUTPUT_COUNT } from "./agent.ts";
+
+Deno.test("buildInitialCreatureJSON has 5 inputs and 4 outputs", () => {
+  const weights = new Array(INPUT_COUNT * OUTPUT_COUNT).fill(0);
+  const json = buildInitialCreatureJSON(weights, [0, 0, 0, 0]);
+  assertEquals(json.input, INPUT_COUNT);
+  assertEquals(json.output, OUTPUT_COUNT);
+  assertEquals(json.synapses.length, INPUT_COUNT * OUTPUT_COUNT);
+});
+
+Deno.test("buildInitialCreatureJSON produces a valid creature", () => {
+  const weights = new Array(INPUT_COUNT * OUTPUT_COUNT).fill(0.1);
+  const json = buildInitialCreatureJSON(weights, [0.1, 0.2, 0.3, 0.4]);
+  const creature = Creature.fromJSON(asCreatureExport(json));
+  creature.validate();
+});
+
+Deno.test("buildInitialCreatureJSON rejects wrong-sized weight vectors", () => {
+  let threw = false;
+  try {
+    buildInitialCreatureJSON([1, 2, 3], [0, 0, 0, 0]);
+  } catch {
+    threw = true;
+  }
+  assertEquals(threw, true);
+});
+
+Deno.test("genesFromCreatureJSON round-trips weights and biases", () => {
+  const weights: number[] = [];
+  for (let i = 0; i < INPUT_COUNT * OUTPUT_COUNT; i++) weights.push(i * 0.01);
+  const biases: [number, number, number, number] = [0.1, -0.2, 0.3, -0.4];
+  const json = buildInitialCreatureJSON(weights, biases);
+  const genes = genesFromCreatureJSON(json);
+  assertEquals(genes.weights, weights);
+  assertEquals(genes.biases, biases);
+});
+
+Deno.test("randomCreatureJSON is deterministic for the same seed", () => {
+  const a = randomCreatureJSON(createDeterministicRandom(99));
+  const b = randomCreatureJSON(createDeterministicRandom(99));
+  assertEquals(JSON.stringify(a), JSON.stringify(b));
+});
+
+Deno.test("mutateCreatureJSON yields a valid creature", () => {
+  const random = createDeterministicRandom(7);
+  const weights = new Array(INPUT_COUNT * OUTPUT_COUNT).fill(0);
+  const parent = buildInitialCreatureJSON(weights, [0, 0, 0, 0]);
+  const child = mutateCreatureJSON(parent, random, 1.0, 0.3);
+  const creature = Creature.fromJSON(asCreatureExport(child));
+  creature.validate();
+});
+
+Deno.test("scoreController returns a finite score for an arbitrary creature", () => {
+  const weights = new Array(INPUT_COUNT * OUTPUT_COUNT).fill(0);
+  const json = buildInitialCreatureJSON(weights, [0, 0, 0, 0]);
+  const creature = Creature.fromJSON(asCreatureExport(json));
+  const result = scoreController(creature, 50);
+  assert(Number.isFinite(result.score), `expected finite score, got ${result.score}`);
+  assertGreaterOrEqual(result.steps, 1);
+});
+
+Deno.test("evolveMazeController champion reaches the goal within the step cap", async () => {
+  const result = evolveMazeController(DEFAULT_EVOLVE_OPTIONS);
+  assertEquals(
+    result.championReached,
+    true,
+    `expected the champion to reach the goal, got finalDistance=${result.championFinalDistance}`,
+  );
+  // Champion must serialise cleanly for downstream consumption.
+  const tmp = await Deno.makeTempDir({ prefix: "maze_test_" });
+  try {
+    const path = join(tmp, "champion.json");
+    await safeWriteJson(path, result.champion.exportJSON());
+    assertEquals(existsSync(path), true);
+  } finally {
+    await Deno.remove(tmp, { recursive: true });
+  }
+});
+
+Deno.test("evolveMazeController is reproducible — fixed seed produces byte-identical champions", () => {
+  const a = evolveMazeController(DEFAULT_EVOLVE_OPTIONS);
+  const b = evolveMazeController(DEFAULT_EVOLVE_OPTIONS);
+  const aJson = JSON.stringify(a.champion.exportJSON());
+  const bJson = JSON.stringify(b.champion.exportJSON());
+  assertEquals(aJson, bJson, "champions from the same seed must serialise identically");
+  assertEquals(a.bestScore, b.bestScore);
+  assertEquals(a.championReached, b.championReached);
+});
+
+Deno.test("evolveMazeController with different seeds produces different champions", () => {
+  const a = evolveMazeController({ ...DEFAULT_EVOLVE_OPTIONS, seed: 1, maxGenerations: 5 });
+  const b = evolveMazeController({ ...DEFAULT_EVOLVE_OPTIONS, seed: 2, maxGenerations: 5 });
+  const aJson = JSON.stringify(a.champion.exportJSON());
+  const bJson = JSON.stringify(b.champion.exportJSON());
+  assertNotEquals(aJson, bJson);
+});
+
+Deno.test("replayController returns a non-empty trace starting at the start cell", () => {
+  const weights = new Array(INPUT_COUNT * OUTPUT_COUNT).fill(0);
+  const json = buildInitialCreatureJSON(weights, [0, 0, 0, 0]);
+  const creature = Creature.fromJSON(asCreatureExport(json));
+  const trace = replayController(creature, 50);
+  assert(trace.length > 0);
+  assertEquals(trace[0].steps, 0);
+  assertEquals(trace[0].position, trace[0].maze.start);
+});
+
+Deno.test("renderRunSVG emits an <svg> root with SMIL animation elements", () => {
+  const weights = new Array(INPUT_COUNT * OUTPUT_COUNT).fill(0);
+  const json = buildInitialCreatureJSON(weights, [0, 0, 0, 0]);
+  const creature = Creature.fromJSON(asCreatureExport(json));
+  const trace = replayController(creature, 30);
+  const svg = renderRunSVG(trace);
+  assert(svg.startsWith("<svg"), "must start with <svg>");
+  assert(svg.includes("</svg>"), "must contain </svg>");
+  const animateMatches = svg.match(/<animate /g) ?? [];
+  // Agent cx/cy, goal pulse opacity, progress bar width.
+  assertGreaterOrEqual(animateMatches.length, 4);
+});
+
+Deno.test("renderRunSVG repeats the animation indefinitely", () => {
+  const weights = new Array(INPUT_COUNT * OUTPUT_COUNT).fill(0);
+  const json = buildInitialCreatureJSON(weights, [0, 0, 0, 0]);
+  const creature = Creature.fromJSON(asCreatureExport(json));
+  const trace = replayController(creature, 30);
+  const svg = renderRunSVG(trace);
+  assert(svg.includes('repeatCount="indefinite"'));
+});
+
+Deno.test("renderRunSVG draws the agent circle, footprint polyline, and goal pulse", () => {
+  const weights = new Array(INPUT_COUNT * OUTPUT_COUNT).fill(0);
+  const json = buildInitialCreatureJSON(weights, [0, 0, 0, 0]);
+  const creature = Creature.fromJSON(asCreatureExport(json));
+  const trace = replayController(creature, 30);
+  const svg = renderRunSVG(trace);
+  assert(svg.includes('class="agent"'), "expected the agent circle");
+  assert(svg.includes('class="footprint"'), "expected the footprint polyline");
+  assert(svg.includes('class="goal-pulse"'), "expected the goal pulse overlay");
+  assert(svg.includes('class="walls"'), "expected the walls group");
+});
+
+Deno.test("renderRunSVG rejects an empty trace", () => {
+  let threw = false;
+  try {
+    renderRunSVG([]);
+  } catch {
+    threw = true;
+  }
+  assertEquals(threw, true);
+});

--- a/maze_navigation/maze_test.ts
+++ b/maze_navigation/maze_test.ts
@@ -1,0 +1,207 @@
+/**
+ * Unit tests for the deterministic grid-maze model.
+ *
+ * "What" tests only — each test calls a real function, runs the
+ * simulator, and asserts on observable output (state values, reached
+ * flag, manhattan distances, sensor readings).
+ */
+import { assert, assertEquals, assertThrows } from "@std/assert";
+import {
+  Action,
+  cellsEqual,
+  defaultMaze,
+  inBounds,
+  initialState,
+  isWall,
+  manhattan,
+  parseMaze,
+  step,
+  wallDistance,
+} from "./maze.ts";
+
+Deno.test("parseMaze accepts a minimal layout with S and G", () => {
+  const maze = parseMaze([
+    "###",
+    "#SG",
+    "###",
+  ]);
+  assertEquals(maze.width, 3);
+  assertEquals(maze.height, 3);
+  assertEquals(maze.start, { x: 1, y: 1 });
+  assertEquals(maze.goal, { x: 2, y: 1 });
+});
+
+Deno.test("parseMaze rejects rows of differing widths", () => {
+  assertThrows(() =>
+    parseMaze([
+      "###",
+      "##",
+    ])
+  );
+});
+
+Deno.test("parseMaze rejects layouts without a start cell", () => {
+  assertThrows(() =>
+    parseMaze([
+      "###",
+      "#.G",
+      "###",
+    ])
+  );
+});
+
+Deno.test("parseMaze rejects layouts without a goal cell", () => {
+  assertThrows(() =>
+    parseMaze([
+      "###",
+      "#S.",
+      "###",
+    ])
+  );
+});
+
+Deno.test("parseMaze rejects unrecognised characters", () => {
+  assertThrows(() =>
+    parseMaze([
+      "###",
+      "#S?",
+      "###",
+    ])
+  );
+});
+
+Deno.test("defaultMaze returns a non-trivial maze with start and goal in opposite corners", () => {
+  const maze = defaultMaze();
+  assert(maze.width >= 10, `expected width >= 10, got ${maze.width}`);
+  assert(maze.height >= 10, `expected height >= 10, got ${maze.height}`);
+  assert(!cellsEqual(maze.start, maze.goal));
+});
+
+Deno.test("inBounds rejects cells outside the grid", () => {
+  const maze = defaultMaze();
+  assert(inBounds(maze, 0, 0));
+  assert(inBounds(maze, maze.width - 1, maze.height - 1));
+  assert(!inBounds(maze, -1, 0));
+  assert(!inBounds(maze, 0, maze.height));
+});
+
+Deno.test("isWall flags border cells in the default maze", () => {
+  const maze = defaultMaze();
+  assert(isWall(maze, 0, 0), "the top-left corner should be a wall");
+  assert(isWall(maze, maze.width - 1, 0), "the top-right corner should be a wall");
+});
+
+Deno.test("isWall returns true for off-grid cells", () => {
+  const maze = defaultMaze();
+  assert(isWall(maze, -1, 0));
+  assert(isWall(maze, maze.width, 0));
+});
+
+Deno.test("manhattan computes the |Δx| + |Δy| distance", () => {
+  assertEquals(manhattan({ x: 0, y: 0 }, { x: 3, y: 4 }), 7);
+  assertEquals(manhattan({ x: 5, y: 5 }, { x: 5, y: 5 }), 0);
+});
+
+Deno.test("initialState places the agent on the start cell with 0 steps", () => {
+  const maze = defaultMaze();
+  const state = initialState(maze);
+  assertEquals(state.position, maze.start);
+  assertEquals(state.steps, 0);
+  assertEquals(state.reached, false);
+});
+
+Deno.test("step — happy path: agent placed adjacent to the goal solves in one step", () => {
+  const maze = parseMaze([
+    "#####",
+    "#S.G#",
+    "#####",
+  ]);
+  let state = initialState(maze);
+  state = step(state, Action.East);
+  state = step(state, Action.East);
+  assertEquals(state.position, maze.goal);
+  assertEquals(state.reached, true);
+  assertEquals(state.steps, 2);
+});
+
+Deno.test("step — walls block movement; agent position is unchanged", () => {
+  // Tiny maze: agent at (1,1) surrounded by walls on the north and west.
+  const maze = parseMaze([
+    "#####",
+    "#S.G#",
+    "#####",
+  ]);
+  const state = initialState(maze);
+  const next = step(state, Action.North);
+  assertEquals(next.position, state.position, "north move into wall must leave position unchanged");
+  // Step still increments because the action consumed a tick.
+  assertEquals(next.steps, 1);
+});
+
+Deno.test("step — Stay leaves the position unchanged", () => {
+  const maze = defaultMaze();
+  const state = initialState(maze);
+  const next = step(state, Action.Stay);
+  assertEquals(next.position, state.position);
+  assertEquals(next.steps, 1);
+});
+
+Deno.test("step — once reached, further steps do not advance state", () => {
+  const maze = parseMaze([
+    "###",
+    "#SG",
+    "###",
+  ]);
+  // Wait — start at (1,1), goal at (2,1).
+  let state = initialState(maze);
+  state = step(state, Action.East);
+  assertEquals(state.reached, true);
+  const stepsAtArrival = state.steps;
+  const after = step(state, Action.East);
+  assertEquals(after.position, state.position, "must stay on goal cell");
+  assertEquals(after.steps, stepsAtArrival, "step counter must freeze once reached");
+});
+
+Deno.test("wallDistance — hand-computed sensor table at a known cell", () => {
+  // 5×5 box with a vertical wall splitting the centre row. The
+  // start (S) and goal (G) are placed in corners; only the centre
+  // row's wall layout matters for this test.
+  //   #####
+  //   #S..#
+  //   #.#.#
+  //   #..G#
+  //   #####
+  // Agent placed (for sensor purposes) at (1, 2) — east-facing wall
+  // is at (2, 2) so wallDistance east is 0, west is 0 (wall at (0, 2)),
+  // north is 1 (free at (1,1), wall at (1,0)), south is 1 (free at
+  // (1,3), wall at (1,4)).
+  const maze = parseMaze([
+    "#####",
+    "#S..#",
+    "#.#.#",
+    "#..G#",
+    "#####",
+  ]);
+  const cap = 8;
+  const east = wallDistance(maze, 1, 2, 1, 0, cap);
+  const west = wallDistance(maze, 1, 2, -1, 0, cap);
+  const north = wallDistance(maze, 1, 2, 0, -1, cap);
+  const south = wallDistance(maze, 1, 2, 0, 1, cap);
+  assertEquals(east, 0, "east blocked by central wall");
+  assertEquals(west, 0, "west blocked by border wall");
+  assertEquals(north, 1, "one free cell to the north");
+  assertEquals(south, 1, "one free cell to the south");
+});
+
+Deno.test("wallDistance respects the cap", () => {
+  // Long open corridor: cap should bound the answer.
+  const maze = parseMaze([
+    "##########",
+    "#S......G#",
+    "##########",
+  ]);
+  // From (1, 1) east, the corridor has 7 free cells before hitting
+  // the wall — but cap of 3 should clamp the result.
+  const dist = wallDistance(maze, 1, 1, 1, 0, 3);
+  assertEquals(dist, 3);
+});

--- a/maze_navigation/run.sh
+++ b/maze_navigation/run.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -euo pipefail
+
+# Maze Navigation Example Runner
+#
+# Evolves a NEAT-AI controller that navigates a fixed grid maze from a
+# start cell to a goal cell using local sensor inputs (wall distances
+# plus a packed heading-to-goal). Saves the champion creature, the
+# trajectory log, and writes an animated SVG of the champion's run to
+# docs/screenshots/maze_navigation.svg.
+
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd -P)"
+cd "${REPO_ROOT}"
+
+# Add deno to PATH if not already available
+if ! command -v deno &> /dev/null; then
+  export PATH="$HOME/.deno/bin:$PATH"
+fi
+
+echo "🗺️  Maze Navigation Example"
+echo ""
+
+deno run \
+  --v8-flags=--max-old-space-size=4096 \
+  --allow-read \
+  --allow-write \
+  --allow-env \
+  --allow-net \
+  maze_navigation/maze_navigation.ts \
+  "$@"
+
+# Re-format the regenerated SVG so subsequent `deno fmt --check` runs
+# stay clean — the renderer emits compact output for readability, and
+# `deno fmt` prefers attributes split across multiple lines.
+if [[ -f "docs/screenshots/maze_navigation.svg" ]]; then
+  deno fmt docs/screenshots/maze_navigation.svg > /dev/null
+fi

--- a/maze_navigation/svg.ts
+++ b/maze_navigation/svg.ts
@@ -1,0 +1,232 @@
+/**
+ * SVG rendering helpers for the Maze Navigation example.
+ *
+ * Produces a single animated SVG of the champion's run. The maze
+ * walls are drawn statically on a coloured floor; a circle representing
+ * the agent moves along the recorded trajectory using SMIL `<animate>`
+ * on `cx` / `cy`. A trailing dotted "footprint" polyline is drawn so
+ * the path remains visible after the agent has reached the goal. The
+ * goal cell pulses via an opacity animation when the agent arrives.
+ */
+import type { MazeState } from "./maze.ts";
+
+/** Pixel size of each grid cell. */
+const CELL_SIZE = 32;
+
+/** Top margin reserved for the title row and step counter. */
+const MARGIN_TOP = 40;
+
+/** Side margin around the maze. */
+const MARGIN_SIDE = 12;
+
+/** Total animation duration (seconds) for one full replay loop. */
+export const ANIMATION_DURATION_SECONDS = 8;
+
+/** Maximum number of trajectory keyframes baked into the SMIL value lists. */
+export const MAX_KEYFRAMES = 200;
+
+/** Wall colour. */
+const WALL_COLOUR = "#1f2933";
+
+/** Floor (open cell) colour. */
+const FLOOR_COLOUR = "#f5e9d3";
+
+/** Floor secondary colour for the chequer pattern. */
+const FLOOR_COLOUR_ALT = "#f0dfb8";
+
+/** Start cell colour. */
+const START_COLOUR = "#7ed6df";
+
+/** Goal cell colour. */
+const GOAL_COLOUR = "#e056fd";
+
+/** Agent (circle) colour. */
+const AGENT_COLOUR = "#ff7f50";
+
+/** Footprint polyline colour. */
+const FOOTPRINT_COLOUR = "#ff7f50";
+
+/** Convert a cell x-coordinate to its SVG-x position. */
+function cellLeft(x: number): number {
+  return MARGIN_SIDE + x * CELL_SIZE;
+}
+
+/** Convert a cell y-coordinate to its SVG-y position. */
+function cellTop(y: number): number {
+  return MARGIN_TOP + y * CELL_SIZE;
+}
+
+/** Convert a cell coordinate to its SVG-centre x position. */
+function cellCenterX(x: number): number {
+  return cellLeft(x) + CELL_SIZE / 2;
+}
+
+/** Convert a cell coordinate to its SVG-centre y position. */
+function cellCenterY(y: number): number {
+  return cellTop(y) + CELL_SIZE / 2;
+}
+
+/**
+ * Sub-sample the trace down to at most {@link MAX_KEYFRAMES} entries.
+ * The first and final entries are always retained so a SMIL-disabled
+ * preview shows a sensible static frame and the step counter ends on
+ * the correct value.
+ */
+function sampleTrace(trace: MazeState[]): MazeState[] {
+  if (trace.length <= MAX_KEYFRAMES) return trace.slice();
+  const stride = Math.ceil(trace.length / MAX_KEYFRAMES);
+  const samples: MazeState[] = [];
+  for (let i = 0; i < trace.length; i += stride) samples.push(trace[i]);
+  if (samples[samples.length - 1] !== trace[trace.length - 1]) {
+    samples.push(trace[trace.length - 1]);
+  }
+  return samples;
+}
+
+/**
+ * Render the champion's run as an animated SVG. The trace must
+ * contain at least one state. The first state is taken as the static
+ * base pose so SMIL-disabled viewers see a sensible frame.
+ */
+export function renderRunSVG(trace: MazeState[]): string {
+  if (trace.length === 0) {
+    throw new Error("trace must contain at least one state");
+  }
+
+  const samples = sampleTrace(trace);
+  const first = samples[0];
+  const final = samples[samples.length - 1];
+  const maze = first.maze;
+  const animDur = `${ANIMATION_DURATION_SECONDS}s`;
+  const animationCommon = `dur="${animDur}" repeatCount="indefinite" ` +
+    `calcMode="discrete" fill="freeze"`;
+
+  const svgWidth = maze.width * CELL_SIZE + MARGIN_SIDE * 2;
+  const svgHeight = MARGIN_TOP + maze.height * CELL_SIZE + 28;
+
+  const lines: string[] = [];
+
+  lines.push(
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${svgWidth} ${svgHeight}" ` +
+      `width="${svgWidth}" height="${svgHeight}" role="img" ` +
+      `aria-label="Maze navigation champion run, animated through ${samples.length} keyframes">`,
+  );
+  lines.push(`  <title>Maze Navigation Champion Run (animated)</title>`);
+  lines.push(
+    `  <desc>SMIL-animated SVG: a NEAT-AI agent navigates a ${maze.width}×${maze.height} grid ` +
+      `maze from start (S) to goal (G). The agent's footsteps are traced as a dotted polyline. ` +
+      `Loops every ${ANIMATION_DURATION_SECONDS} seconds.</desc>`,
+  );
+  lines.push(`  <rect width="${svgWidth}" height="${svgHeight}" fill="#2c3e50"/>`);
+
+  // Floor — chequered for visual interest, drawn before walls.
+  lines.push(`  <g class="floor">`);
+  for (let y = 0; y < maze.height; y++) {
+    for (let x = 0; x < maze.width; x++) {
+      const fill = (x + y) % 2 === 0 ? FLOOR_COLOUR : FLOOR_COLOUR_ALT;
+      lines.push(
+        `    <rect x="${cellLeft(x)}" y="${cellTop(y)}" ` +
+          `width="${CELL_SIZE}" height="${CELL_SIZE}" fill="${fill}"/>`,
+      );
+    }
+  }
+  lines.push(`  </g>`);
+
+  // Start cell highlight.
+  lines.push(
+    `  <rect class="start" x="${cellLeft(maze.start.x)}" y="${cellTop(maze.start.y)}" ` +
+      `width="${CELL_SIZE}" height="${CELL_SIZE}" fill="${START_COLOUR}" opacity="0.55"/>`,
+  );
+  lines.push(
+    `  <text x="${cellCenterX(maze.start.x)}" y="${cellCenterY(maze.start.y) + 5}" ` +
+      `text-anchor="middle" font-family="monospace" font-size="14" font-weight="bold" ` +
+      `fill="#1a2230">S</text>`,
+  );
+
+  // Goal cell — base rect, then a pulsing overlay that animates its
+  // opacity once the agent reaches the goal.
+  lines.push(
+    `  <rect class="goal" x="${cellLeft(maze.goal.x)}" y="${cellTop(maze.goal.y)}" ` +
+      `width="${CELL_SIZE}" height="${CELL_SIZE}" fill="${GOAL_COLOUR}" opacity="0.65"/>`,
+  );
+  lines.push(
+    `  <rect class="goal-pulse" x="${cellLeft(maze.goal.x)}" y="${cellTop(maze.goal.y)}" ` +
+      `width="${CELL_SIZE}" height="${CELL_SIZE}" fill="${GOAL_COLOUR}" opacity="0">`,
+  );
+  lines.push(
+    `    <animate attributeName="opacity" values="0;0.85;0" ` +
+      `dur="0.9s" repeatCount="indefinite" calcMode="linear"/>`,
+  );
+  lines.push(`  </rect>`);
+  lines.push(
+    `  <text x="${cellCenterX(maze.goal.x)}" y="${cellCenterY(maze.goal.y) + 5}" ` +
+      `text-anchor="middle" font-family="monospace" font-size="14" font-weight="bold" ` +
+      `fill="#1a2230">G</text>`,
+  );
+
+  // Walls — drawn over the floor.
+  lines.push(`  <g class="walls">`);
+  for (let y = 0; y < maze.height; y++) {
+    for (let x = 0; x < maze.width; x++) {
+      if (maze.walls[y * maze.width + x]) {
+        lines.push(
+          `    <rect x="${cellLeft(x)}" y="${cellTop(y)}" ` +
+            `width="${CELL_SIZE}" height="${CELL_SIZE}" fill="${WALL_COLOUR}"/>`,
+        );
+      }
+    }
+  }
+  lines.push(`  </g>`);
+
+  // Trailing footprint polyline — lays down the agent's full path so
+  // the trail remains visible once the run completes.
+  const polylinePoints = samples
+    .map((s) => `${cellCenterX(s.position.x)},${cellCenterY(s.position.y)}`)
+    .join(" ");
+  lines.push(
+    `  <polyline class="footprint" points="${polylinePoints}" fill="none" ` +
+      `stroke="${FOOTPRINT_COLOUR}" stroke-width="3" stroke-linecap="round" ` +
+      `stroke-linejoin="round" stroke-dasharray="2 6" opacity="0.85"/>`,
+  );
+
+  // Agent — circle that snaps from cell to cell using SMIL keyframes.
+  const cxValues = samples.map((s) => cellCenterX(s.position.x).toFixed(0)).join(";");
+  const cyValues = samples.map((s) => cellCenterY(s.position.y).toFixed(0)).join(";");
+  lines.push(
+    `  <circle class="agent" cx="${cellCenterX(first.position.x)}" ` +
+      `cy="${cellCenterY(first.position.y)}" r="${CELL_SIZE / 3}" ` +
+      `fill="${AGENT_COLOUR}" stroke="#a04030" stroke-width="2">`,
+  );
+  lines.push(`    <animate attributeName="cx" values="${cxValues}" ${animationCommon}/>`);
+  lines.push(`    <animate attributeName="cy" values="${cyValues}" ${animationCommon}/>`);
+  lines.push(`  </circle>`);
+
+  // Title row — example label and final summary (static).
+  const verdict = final.reached ? "reached goal" : "did not reach goal";
+  lines.push(
+    `  <text x="12" y="22" font-family="monospace" font-size="14" fill="#ecf0f1">` +
+      `🗺️ Maze · ${final.steps} steps · ${verdict}</text>`,
+  );
+
+  // Bottom playhead progress bar — sweeps left-to-right over the loop.
+  const progressBarY = svgHeight - 18;
+  const progressBarLeft = MARGIN_SIDE;
+  const progressBarWidth = svgWidth - MARGIN_SIDE * 2;
+  lines.push(
+    `  <rect x="${progressBarLeft}" y="${progressBarY}" ` +
+      `width="${progressBarWidth}" height="4" fill="#34495e" rx="2"/>`,
+  );
+  lines.push(
+    `  <rect class="progress" x="${progressBarLeft}" y="${progressBarY}" ` +
+      `width="0" height="4" fill="${AGENT_COLOUR}" rx="2">`,
+  );
+  lines.push(
+    `    <animate attributeName="width" values="0;${progressBarWidth}" ` +
+      `dur="${animDur}" repeatCount="indefinite" fill="freeze"/>`,
+  );
+  lines.push(`  </rect>`);
+
+  lines.push(`</svg>`);
+  lines.push("");
+  return lines.join("\n");
+}

--- a/quality.sh
+++ b/quality.sh
@@ -106,7 +106,7 @@ fi
 # --- Example Programs ---
 # Clean up any previous synthetic data
 echo "Cleaning up previous runs..."
-rm -rf .synthetic-discovery .synthetic-intelligent-design .synthetic-suggest-improvements .synthetic-crossover .synthetic-cart-pole .synthetic-lunar-lander .synthetic-mountain-car .synthetic-snake .synthetic-xor .synthetic-stock .synthetic-mnist .discovery
+rm -rf .synthetic-discovery .synthetic-intelligent-design .synthetic-suggest-improvements .synthetic-crossover .synthetic-cart-pole .synthetic-lunar-lander .synthetic-mountain-car .synthetic-snake .synthetic-maze .synthetic-xor .synthetic-stock .synthetic-mnist .discovery
 echo ""
 
 # Run the Intelligent Design example
@@ -129,6 +129,9 @@ run_example "Mountain Car Control Example" "./mountain_car/run.sh"
 
 # Run the Snake Game example
 run_example "Snake Game Example" "./snake_game/run.sh"
+
+# Run the Maze Navigation example
+run_example "Maze Navigation Example" "./maze_navigation/run.sh"
 
 # Run the XOR Classification example
 run_example "XOR Classification Example" "./xor_classification/run.sh"

--- a/readme_structure_test.ts
+++ b/readme_structure_test.ts
@@ -17,6 +17,7 @@ const EXAMPLE_DIRS = [
   "discovery",
   "intelligent_design",
   "lunar_lander",
+  "maze_navigation",
   "mnist_classification",
   "mountain_car",
   "snake_game",
@@ -31,6 +32,7 @@ const SCREENSHOT_PATHS = [
   "docs/screenshots/lunar_lander.svg",
   "docs/screenshots/mountain_car.svg",
   "docs/screenshots/snake_game.svg",
+  "docs/screenshots/maze_navigation.svg",
   "docs/screenshots/stock_market.svg",
   "docs/screenshots/mnist_classification.svg",
 ] as const;
@@ -106,6 +108,7 @@ Deno.test("README.md introduces every example by name", () => {
     "Lunar Lander",
     "Mountain Car",
     "Snake",
+    "Maze Navigation",
     "Stock Market",
     "MNIST",
   ];


### PR DESCRIPTION
# Maze Navigation Example

## Summary

Adds a new `maze_navigation/` example that evolves a NEAT-AI agent to navigate a fixed 12×12 grid
maze from a start cell to a goal cell using local sensor inputs (four wall distances plus a packed
heading-to-goal). The example mirrors the structure of `snake_game/`: a pure-TypeScript simulator
(`maze.ts`), a sensor/action module (`agent.ts`), an evolutionary loop with truncation selection
(`maze_navigation.ts`), and an animated SVG renderer (`svg.ts`) that traces the agent's footsteps
through the maze with a dotted breadcrumb polyline and a pulsing goal cell. Closes #79.

## Evidence

The example is a CLI / SVG-rendering task with no web interface — evidence is the deterministic
champion run plus the unit tests.

```mermaid
flowchart LR
    MAZE["🗺️ Static grid maze<br/>(maze.ts)"]
    SENSE["🛰️ Wall + heading sensors<br/>(agent.ts)"]
    POLICY["🧠 Network → cardinal action"]
    STEP["🚶 Step or block on wall"]
    DONE{"goal reached<br/>or 200-step cap?"}
    SCORE["📏 Score = f(distance, steps)"]
    SVG["🖼️ Animated maze SVG"]

    MAZE --> SENSE --> POLICY --> STEP --> DONE
    DONE -- no --> SENSE
    DONE -- yes --> SCORE --> SVG
```

Champion run output (deterministic seed `42`, 80-creature population, 60 generations):

```
✅ Champion reached the goal in 18 steps (final distance 0, score=0.982, generations=60).
```

The agent solves the L-shaped corridor in the optimal 18 steps (9 east + 9 south).

`./quality.sh` passes end-to-end including the new `maze_navigation` example, all 39 maze-navigation
unit tests, and the README structure / mermaid / archive tests.

The animated SVG embedded in the top README is committed at `docs/screenshots/maze_navigation.svg`.

## Test Plan

- New unit tests in `maze_navigation/maze_test.ts` (17 tests) cover:
  - Parsing string-art layouts (happy path + rejecting malformed layouts).
  - Bounds, wall, and Manhattan helpers.
  - Step semantics: happy path, walls block, `Stay` no-op, frozen-once-reached.
  - **Walls block movement** — moving into a wall leaves the agent's position unchanged.
  - **Sensor reading** — at a known cell the four wall distances match a hand-computed table.
  - `wallDistance` cap behaviour.
- New unit tests in `maze_navigation/agent_test.ts` (7 tests) cover sensor encoding, heading-to-goal
  unit vector, argmax decoding, and the rule that `Stay` is never emitted.
- New unit tests in `maze_navigation/maze_navigation_test.ts` (15 tests) cover creature
  construction, gene round-tripping, mutation, scoring, evolution, replay, SVG rendering, and
  **reproducibility** (fixed seed → byte-identical champions).
- Updated `readme_structure_test.ts` to include `maze_navigation` in `EXAMPLE_DIRS`,
  `SCREENSHOT_PATHS`, and the required-name list — all existing structural tests continue to pass.
- Wired the example into `quality.sh` (added `run_example` line and `.synthetic-maze` cleanup); the
  full pipeline (`./quality.sh`) passes.
- Updated `docs/archive_test.ts` allowlist to include `pr-summary-79.md` (this PR) and
  `pr-summary-81.md` (a pre-existing miss from PR #81 that was breaking the test).



---

🤖 Processed by: stservice<!-- vibe-worker-issue-79 -->