### PR TITLE
Add CRISPR gene injection demo (hand-crafted subgraph injection) (Issue #88)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,6 +129,12 @@ crossover/
   crossover_example_test.ts        — Unit tests for the above
   run.sh                           — Runner script for the example
 
+crispr_injection/
+  crispr_injection.ts              — Example: splice a hand-crafted gene into a stalled population
+  crispr_injection_test.ts         — Unit tests for the above
+  svg.ts                           — SVG renderer for gene topology + fitness curve
+  run.sh                           — Runner script for the example
+
 discovery/
   discover_missing_neuron.ts       — Example: recover a removed neuron
   discover_missing_neuron_test.ts  — Unit tests for the above

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ walkthrough — the per-example README explains the workflow, options, and outpu
 | [🧬 Intelligent Design](intelligent_design/README.md)     | Systematically swap activation functions on hidden neurons to find better squashes than random mutation.  | `./intelligent_design/run.sh`   |
 | [🔍 Discovery](discovery/README.md)                       | Cripple a creature by removing a neuron, then use evolutionary search to recover its behaviour.           | `./discovery/run.sh`            |
 | [🔀 Crossover](crossover/README.md)                       | Breed two parents with different architectures into an offspring and (optionally) evolve it further.      | `./crossover/run.sh`            |
+| [🧬 CRISPR Injection](crispr_injection/README.md)         | Splice a hand-crafted "edit gene" into a stalled population mid-evolution and visualise the fitness lift. | `./crispr_injection/run.sh`     |
 | [📈 Stock Market](stock_market/README.md)                 | Evolve a tiny network that predicts next-period S&P 500 direction from a window of recent returns.        | `./stock_market/run.sh`         |
 | [🔢 MNIST](mnist_classification/README.md)                | Evolve a 196 → 10 logistic classifier on a small MNIST subset and render an animated grid of predictions. | `./mnist_classification/run.sh` |
 | [🌡️ MCMC Acceptance](mcmc_acceptance/README.md)           | Visualise Metropolis-Hastings mutation acceptance cooling toward the 23.4% optimal target.                | `./mcmc_acceptance/run.sh`      |
@@ -100,6 +101,16 @@ A 5 × 4 grid of held-out MNIST test digits. Each cell cross-fades through three
 champion classifies correctly, red on a miss. Pixel intensity is rendered through a purple → teal →
 yellow ramp.
 
+### 🧬 CRISPR Injection — gene topology and fitness lift
+
+![CRISPR gene injection — top panel shows two TANH hidden neurons spliced between two inputs and one output, bottom panel shows fitness vs generation with a vertical injection marker](docs/screenshots/crispr_injection.svg)
+
+A combined snapshot of the CRISPR gene injection demo. The top panel shows the hand-crafted edit
+gene's topology — two TANH hidden neurons connected to two inputs and the single output. The bottom
+panel plots best fitness per generation across the experiment; a dashed red marker pinpoints the
+generation at which the gene was spliced into the population, after which fitness lifts sharply as
+the gene's incoming weights are tuned.
+
 ### 🌡️ MCMC Acceptance — cooling toward 23.4%
 
 ![MCMC mutation acceptance rate cooling toward the 23.4% optimal target with the temperature schedule overlaid](docs/screenshots/mcmc_acceptance.svg)
@@ -122,6 +133,7 @@ flowchart TD
     ID["🧬 Intelligent Design<br/>Optimise activation functions<br/>for hidden neurons"]
     DISC["🔍 Discovery<br/>Recover missing neurons<br/>via evolutionary search"]
     CROSS["🔀 Crossover<br/>Breed two creatures<br/>to produce offspring"]
+    CRISPR["🧬 CRISPR Injection<br/>Splice a hand-crafted<br/>edit gene into a stalled<br/>population"]
     STOCK["📈 Stock Market<br/>Predict next-period S&P 500<br/>direction from prior returns"]
     MNIST["🔢 MNIST<br/>Classify handwritten digits<br/>from a 14×14 down-sample"]
     MCMC["🌡️ MCMC Acceptance<br/>Cool MH acceptance rate<br/>toward the 23.4% optimum"]
@@ -136,6 +148,7 @@ flowchart TD
     COMMON --> ID
     COMMON --> DISC
     COMMON --> CROSS
+    COMMON --> CRISPR
     COMMON --> STOCK
     COMMON --> MNIST
     COMMON --> MCMC
@@ -151,6 +164,7 @@ flowchart TD
     style ID fill:#7ed321,stroke:#333,color:#fff
     style DISC fill:#bd10e0,stroke:#333,color:#fff
     style CROSS fill:#e74c3c,stroke:#333,color:#fff
+    style CRISPR fill:#bd10e0,stroke:#333,color:#fff
     style STOCK fill:#16a085,stroke:#333,color:#fff
     style MNIST fill:#34495e,stroke:#333,color:#fff
     style MCMC fill:#e67e22,stroke:#333,color:#fff
@@ -185,6 +199,7 @@ flowchart BT
         ID["🧬 intelligent_design/"]
         DISC["🔍 discovery/"]
         CROSS["🔀 crossover/"]
+        CRISPR["🧬 crispr_injection/"]
         STOCK["📈 stock_market/"]
         MNIST["🔢 mnist_classification/"]
         MCMC["🌡️ mcmc_acceptance/"]
@@ -200,6 +215,7 @@ flowchart BT
     common --> ID
     common --> DISC
     common --> CROSS
+    common --> CRISPR
     common --> STOCK
     common --> MNIST
     common --> MCMC

--- a/crispr_injection/README.md
+++ b/crispr_injection/README.md
@@ -1,0 +1,81 @@
+# 🧬 CRISPR Gene Injection — Hand-Crafted Subgraph Splicing
+
+`crispr_injection.ts` demonstrates a structural intervention that is unique to NEAT-style
+neuroevolution: a hand-crafted **edit gene** — a small subgraph of neurons and synapses with
+known-good behaviour — is spliced directly into a stalled population, then evolution continues.
+Random weight mutation alone cannot construct this structure because the missing topology has no
+gradient to follow; CRISPR-style injection bypasses that obstacle by inserting the structure
+wholesale.
+
+## 🔧 How It Works
+
+```mermaid
+flowchart TD
+    TARGET["🎯 Target Creature<br/>2 inputs → 2 TANH hidden → 1 output"]
+    DATA["📊 Synthetic Data<br/>generated from target"]
+    POP["👥 Baseline Population<br/>no hidden neurons"]
+    EVOLVE1["🔁 Pre-injection Evolution<br/>perturb-and-keep<br/>(plateaus quickly)"]
+    GENE["🧬 Hand-Crafted Gene<br/>2 TANH hidden + synapses"]
+    INJECT["💉 CRISPR Injection<br/>splice into top N members"]
+    EVOLVE2["🔁 Post-injection Evolution<br/>fitness lifts as gene<br/>weights are tuned"]
+    SVG["🖼️ output/crispr_injection.svg<br/>topology + fitness curve"]
+
+    TARGET --> DATA
+    POP --> EVOLVE1
+    DATA --> EVOLVE1
+    EVOLVE1 --> INJECT
+    GENE --> INJECT
+    INJECT --> EVOLVE2
+    DATA --> EVOLVE2
+    EVOLVE2 --> SVG
+
+    style TARGET fill:#16a085,stroke:#333,color:#fff
+    style DATA fill:#f5a623,stroke:#333,color:#fff
+    style POP fill:#4a90d9,stroke:#333,color:#fff
+    style EVOLVE1 fill:#9b59b6,stroke:#333,color:#fff
+    style GENE fill:#bd10e0,stroke:#333,color:#fff
+    style INJECT fill:#e74c3c,stroke:#333,color:#fff
+    style EVOLVE2 fill:#27ae60,stroke:#333,color:#fff
+    style SVG fill:#50e3c2,stroke:#333,color:#fff
+```
+
+1. Build a target creature with two TANH hidden neurons that compute a non-linear function of two
+   inputs. This pair of hidden neurons is the **gene**.
+2. Generate synthetic training data from the target — every record is `(input₀, input₁, target_y)`.
+3. Build a baseline population whose members have **no hidden neurons** — they cannot capture the
+   non-linearity, so a perturb-and-keep evolution loop quickly plateaus.
+4. Inject the hand-crafted gene into the top N members of the stalled population, replacing them
+   with gene-bearing variants.
+5. Resume the same evolution loop. Fitness lifts sharply because the gene has the structure needed
+   to fit the target; the loop merely tunes its incoming weights.
+
+## 🔬 Why CRISPR-Style Injection Matters
+
+Pure random mutation explores the structural space one connection at a time, which is fine for local
+refinements but very slow when the missing topology requires several coordinated additions
+(neurons + their synapses) before any fitness improvement is realised. NEAT-AI's UUID-keyed neurons
+make a structural splice well-defined and reversible:
+
+- **Gene identity is portable.** Each gene neuron has a UUID, so the same gene can be injected into
+  multiple population members and tracked across generations.
+- **Splicing is non-destructive.** Host weights are preserved; the gene's prescribed edges are added
+  to the existing graph rather than replacing it.
+- **The lift is attributable.** Because the gene is added all at once, the post-injection fitness
+  jump is causally tied to the splice — making this a useful debugging and ablation tool.
+
+## 🚀 Running the Example
+
+```bash
+./crispr_injection/run.sh
+```
+
+The script writes all artefacts to `.synthetic-crispr-injection/`, a hidden directory ignored by
+git. You will find:
+
+- `data/` – binary training data generated from the target creature
+- `creatures/target.json` – the creature whose outputs define the synthetic task
+- `creatures/gene.json` – a baseline-with-gene reference creature
+- `creatures/best.json` – the best post-injection creature from the experiment
+- `output/crispr_injection.svg` – the rendered topology + fitness chart
+
+A copy of the chart is also written to `docs/screenshots/crispr_injection.svg` for the main README.

--- a/crispr_injection/crispr_injection.ts
+++ b/crispr_injection/crispr_injection.ts
@@ -1,0 +1,530 @@
+/**
+ * CRISPR Gene Injection Example (issue #88).
+ *
+ * Demonstrates a structural intervention that is unique to NEAT-style
+ * neuroevolution: a hand-crafted "edit gene" — a small subgraph of
+ * neurons and synapses with known-good behaviour — is spliced directly
+ * into a stalled population, then evolution continues. Random weight
+ * mutation alone cannot construct this structure because the missing
+ * topology has no path to follow; CRISPR-style injection bypasses
+ * that gradient by inserting the structure wholesale.
+ *
+ * The runner walks a deterministic synthetic task:
+ *
+ *   1. Build a target creature whose two TANH hidden neurons together
+ *      compute a non-linear function of two inputs.
+ *   2. Generate synthetic training data from the target.
+ *   3. Build a baseline population whose members have *no* hidden
+ *      neurons — they cannot capture the non-linearity, so a simple
+ *      perturb-and-keep evolution loop quickly plateaus.
+ *   4. Inject the hand-crafted gene into the top N members of the
+ *      stalled population, replacing them with gene-bearing variants.
+ *   5. Resume the same evolution loop and watch fitness lift sharply.
+ *
+ * The deterministic perturbation loop keeps the example fast and
+ * reproducible without delegating to the full NEAT evolver — every
+ * generation's best fitness is recorded so the rendered SVG shows the
+ * stall, the injection marker, and the post-injection lift.
+ */
+
+import { format } from "@std/fmt/duration";
+import { ensureDirSync } from "@std/fs";
+import { join } from "@std/path";
+import { Creature, CreatureUtil, safeWriteJson } from "@stsoftware/neat-ai";
+
+import { generateSyntheticData, type SyntheticConfig } from "../common/synthetic_data.ts";
+import { setupWorkingDirs } from "../common/working_dirs.ts";
+import { createDeterministicRandom } from "../common/deterministic_random.ts";
+import {
+  asCreatureExport,
+  type LegacyCreatureJSON,
+  type LegacyNeuron,
+  type LegacySynapse,
+} from "../common/legacy_types.ts";
+
+export const SYNTHETIC_CONFIG: SyntheticConfig = {
+  totalRecords: 96,
+  recordsPerFile: 96,
+  seed: 88008800,
+};
+
+/** Path to the SVG snapshot the runner emits for the README. */
+export const SCREENSHOT_PATH = "docs/screenshots/crispr_injection.svg";
+
+/** UUIDs that identify the hand-crafted edit gene's hidden neurons. */
+export const GENE_NEURON_UUIDS = ["gene-hidden-0", "gene-hidden-1"] as const;
+
+/**
+ * A hand-crafted "edit gene": a structural fragment with hidden neurons
+ * and the synapses needed to wire them into a host creature. The gene
+ * carries the input-side and output-side weights it expects to be
+ * spliced with, so injection is reversible and self-contained.
+ */
+export interface InjectedGene {
+  /** Hidden neurons that make up the gene (in injection order). */
+  hidden: readonly LegacyNeuron[];
+  /** Synapses connecting host inputs into the gene. */
+  inputSynapses: readonly { fromInputIndex: number; toUUID: string; weight: number }[];
+  /** Synapses connecting the gene to host outputs. */
+  outputSynapses: readonly { fromUUID: string; toOutputUUID: string; weight: number }[];
+  /** Synapses internal to the gene (between gene neurons). */
+  internalSynapses: readonly { fromUUID: string; toUUID: string; weight: number }[];
+}
+
+/** Configuration options for {@link runCrisprExperiment}. */
+export interface CrisprConfig {
+  /** Random seed driving mutation and population selection. */
+  seed: number;
+  /** Generations to evolve before injecting the gene. */
+  preInjectionGenerations: number;
+  /** Generations to evolve after injecting the gene. */
+  postInjectionGenerations: number;
+  /** Number of population members to splice the gene into. */
+  injectionCount: number;
+  /** Population size held constant across generations. */
+  populationSize: number;
+  /** Standard deviation of each weight perturbation. */
+  mutationStrength: number;
+}
+
+/** A per-generation fitness snapshot. */
+export interface FitnessRecord {
+  /** Zero-indexed generation number. */
+  generation: number;
+  /** Best score observed across the population at this generation. */
+  bestFitness: number;
+  /** True for the generation that received the gene injection. */
+  injection: boolean;
+}
+
+/** Result of a single CRISPR experiment. */
+export interface CrisprResult {
+  /** Per-generation fitness records (length === pre + post + 1). */
+  records: FitnessRecord[];
+  /** The generation index at which injection occurred. */
+  injectionGeneration: number;
+  /** Best fitness recorded at the moment of injection. */
+  fitnessAtInjection: number;
+  /** Best fitness recorded after injection (max across post records). */
+  bestFitnessAfterInjection: number;
+  /** UUIDs from the injected gene that survive in the final population. */
+  retainedGeneUUIDs: string[];
+  /** The final population's best member, exported. */
+  bestFinalCreatureJSON: LegacyCreatureJSON;
+}
+
+/** Sensible defaults for the demonstration runner. */
+export const DEFAULT_CRISPR_CONFIG: CrisprConfig = {
+  seed: 0xcafebabe,
+  preInjectionGenerations: 8,
+  postInjectionGenerations: 8,
+  injectionCount: 3,
+  populationSize: 6,
+  mutationStrength: 0.15,
+};
+
+/**
+ * Builds the target creature whose two TANH hidden neurons together
+ * compute a non-linear function the baseline (no hidden) cannot match.
+ * Synthetic training data is generated from this creature's outputs.
+ */
+export function createTargetCreature(): Creature {
+  const json: LegacyCreatureJSON = {
+    neurons: [
+      { type: "input", squash: "LOGISTIC", index: 0, uuid: "input-0" },
+      { type: "input", squash: "LOGISTIC", index: 1, uuid: "input-1" },
+
+      // The "gene" — hidden neurons we will later inject into a baseline.
+      // Big weights push the TANH neurons into saturation, so the target
+      // output behaves like an XOR-flavoured discriminator the baseline
+      // cannot mimic with a pair of linear input→output synapses.
+      {
+        type: "hidden",
+        squash: "TANH",
+        index: 2,
+        bias: 0.5,
+        uuid: GENE_NEURON_UUIDS[0],
+      },
+      {
+        type: "hidden",
+        squash: "TANH",
+        index: 3,
+        bias: -0.5,
+        uuid: GENE_NEURON_UUIDS[1],
+      },
+
+      { type: "output", squash: "LOGISTIC", index: 4, bias: 0, uuid: "output-0" },
+    ],
+    synapses: [
+      { from: 0, to: 2, weight: 4.0 },
+      { from: 1, to: 2, weight: -3.5 },
+      { from: 0, to: 3, weight: -3.0 },
+      { from: 1, to: 3, weight: 3.5 },
+      { from: 2, to: 4, weight: 5.0 },
+      { from: 3, to: 4, weight: 5.0 },
+    ],
+    input: 2,
+    output: 1,
+  };
+  return Creature.fromJSON(asCreatureExport(json));
+}
+
+/**
+ * Builds the baseline creature: 2 inputs wired straight to the output.
+ * Without hidden capacity this creature cannot fit the target's non-linearity,
+ * so a perturbation-only evolution loop will plateau quickly.
+ */
+export function createBaselineJSON(seed: number): LegacyCreatureJSON {
+  const random = createDeterministicRandom(seed);
+  return {
+    neurons: [
+      { type: "input", squash: "LOGISTIC", index: 0, uuid: "input-0" },
+      { type: "input", squash: "LOGISTIC", index: 1, uuid: "input-1" },
+      { type: "output", squash: "LOGISTIC", index: 2, bias: 0, uuid: "output-0" },
+    ],
+    synapses: [
+      { from: 0, to: 2, weight: random() * 0.6 - 0.3 },
+      { from: 1, to: 2, weight: random() * 0.6 - 0.3 },
+    ],
+    input: 2,
+    output: 1,
+  };
+}
+
+/**
+ * Returns the hand-crafted edit gene: two TANH hidden neurons plus the
+ * input/output synapses that splice them into a host creature.
+ */
+export function createGene(): InjectedGene {
+  return {
+    hidden: [
+      {
+        type: "hidden",
+        squash: "TANH",
+        index: 0, // Re-indexed during injection.
+        bias: 0.5,
+        uuid: GENE_NEURON_UUIDS[0],
+      },
+      {
+        type: "hidden",
+        squash: "TANH",
+        index: 0,
+        bias: -0.5,
+        uuid: GENE_NEURON_UUIDS[1],
+      },
+    ],
+    inputSynapses: [
+      { fromInputIndex: 0, toUUID: GENE_NEURON_UUIDS[0], weight: 4.0 },
+      { fromInputIndex: 1, toUUID: GENE_NEURON_UUIDS[0], weight: -3.5 },
+      { fromInputIndex: 0, toUUID: GENE_NEURON_UUIDS[1], weight: -3.0 },
+      { fromInputIndex: 1, toUUID: GENE_NEURON_UUIDS[1], weight: 3.5 },
+    ],
+    outputSynapses: [
+      { fromUUID: GENE_NEURON_UUIDS[0], toOutputUUID: "output-0", weight: 5.0 },
+      { fromUUID: GENE_NEURON_UUIDS[1], toOutputUUID: "output-0", weight: 5.0 },
+    ],
+    internalSynapses: [],
+  };
+}
+
+/**
+ * Splices the gene's hidden neurons and synapses into the host JSON.
+ *
+ * Returns a new {@link LegacyCreatureJSON} — the input is not mutated.
+ * The gene's neurons are inserted between the host's inputs and outputs;
+ * indices are recomputed so `Creature.fromJSON` accepts the result.
+ *
+ * If a gene UUID already exists in the host (idempotent re-injection)
+ * the duplicate is skipped so injection can safely run twice.
+ */
+export function injectGene(host: LegacyCreatureJSON, gene: InjectedGene): LegacyCreatureJSON {
+  const existingUUIDs = new Set(host.neurons.map((n) => n.uuid));
+
+  const inputs = host.neurons.filter((n) => n.type === "input");
+  const outputs = host.neurons.filter((n) => n.type === "output");
+  const hiddenHost = host.neurons.filter((n) => n.type === "hidden");
+  const newGeneNeurons = gene.hidden.filter((n) => !existingUUIDs.has(n.uuid));
+
+  const merged: LegacyNeuron[] = [
+    ...inputs.map((n) => ({ ...n })),
+    ...hiddenHost.map((n) => ({ ...n })),
+    ...newGeneNeurons.map((n) => ({ ...n })),
+    ...outputs.map((n) => ({ ...n })),
+  ];
+
+  // Reindex neurons to a contiguous run.
+  merged.forEach((n, i) => {
+    n.index = i;
+  });
+
+  const uuidToIndex = new Map<string, number>();
+  for (const n of merged) uuidToIndex.set(n.uuid, n.index);
+
+  // Translate host synapses through the new index map (uuids are stable).
+  const oldIndexToUUID = new Map<number, string>();
+  for (const n of host.neurons) oldIndexToUUID.set(n.index, n.uuid);
+
+  const synapses: LegacySynapse[] = [];
+  for (const s of host.synapses) {
+    const fromUUID = oldIndexToUUID.get(s.from);
+    const toUUID = oldIndexToUUID.get(s.to);
+    if (fromUUID === undefined || toUUID === undefined) continue;
+    const fromIdx = uuidToIndex.get(fromUUID);
+    const toIdx = uuidToIndex.get(toUUID);
+    if (fromIdx === undefined || toIdx === undefined) continue;
+    synapses.push({ from: fromIdx, to: toIdx, weight: s.weight });
+  }
+
+  // Add gene synapses, deduplicating against any host edges already present.
+  const seen = new Set(synapses.map((s) => `${s.from}->${s.to}`));
+  const addEdge = (from: number, to: number, weight: number) => {
+    const key = `${from}->${to}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    synapses.push({ from, to, weight });
+  };
+
+  for (const s of gene.inputSynapses) {
+    const toIdx = uuidToIndex.get(s.toUUID);
+    if (toIdx === undefined) continue;
+    addEdge(s.fromInputIndex, toIdx, s.weight);
+  }
+  for (const s of gene.internalSynapses) {
+    const fromIdx = uuidToIndex.get(s.fromUUID);
+    const toIdx = uuidToIndex.get(s.toUUID);
+    if (fromIdx === undefined || toIdx === undefined) continue;
+    addEdge(fromIdx, toIdx, s.weight);
+  }
+  for (const s of gene.outputSynapses) {
+    const fromIdx = uuidToIndex.get(s.fromUUID);
+    const toIdx = uuidToIndex.get(s.toOutputUUID);
+    if (fromIdx === undefined || toIdx === undefined) continue;
+    addEdge(fromIdx, toIdx, s.weight);
+  }
+
+  return {
+    neurons: merged,
+    synapses,
+    input: host.input,
+    output: host.output,
+  };
+}
+
+/** Box-Muller standard-normal sample. */
+function gaussian(random: () => number): number {
+  const u1 = Math.max(random(), 1e-12);
+  const u2 = random();
+  return Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * u2);
+}
+
+/**
+ * Returns a clone of {@link member} with each synapse weight perturbed by a
+ * Gaussian draw of standard deviation {@link mutationStrength}. The host JSON
+ * is not modified.
+ */
+export function mutateMember(
+  member: LegacyCreatureJSON,
+  random: () => number,
+  mutationStrength: number,
+): LegacyCreatureJSON {
+  return {
+    ...member,
+    neurons: member.neurons.map((n) => ({ ...n })),
+    synapses: member.synapses.map((s) => ({
+      ...s,
+      weight: s.weight + gaussian(random) * mutationStrength,
+    })),
+  };
+}
+
+/**
+ * Score a JSON creature against the supplied training directory.
+ * Constructs a fresh {@link Creature} so weights from {@link mutateMember}
+ * propagate through to the scorer.
+ */
+export async function scoreMember(member: LegacyCreatureJSON, dataDir: string): Promise<number> {
+  const creature = Creature.fromJSON(asCreatureExport(member));
+  creature.validate();
+  const result = await creature.scoreDir(dataDir, {});
+  return result.score;
+}
+
+/**
+ * Run one (mu + lambda)-style step: keep the elite, fill the rest with
+ * mutated copies of the elite, score everyone, return scores plus the
+ * updated population sorted best-first.
+ */
+async function evolveOneGeneration(
+  population: LegacyCreatureJSON[],
+  dataDir: string,
+  random: () => number,
+  mutationStrength: number,
+): Promise<{ population: LegacyCreatureJSON[]; bestScore: number }> {
+  const scored: { member: LegacyCreatureJSON; score: number }[] = [];
+  for (const m of population) {
+    const score = await scoreMember(m, dataDir);
+    scored.push({ member: m, score });
+  }
+  scored.sort((a, b) => b.score - a.score);
+  const elite = scored[0].member;
+  const next: LegacyCreatureJSON[] = [elite];
+  while (next.length < population.length) {
+    next.push(mutateMember(elite, random, mutationStrength));
+  }
+  return { population: next, bestScore: scored[0].score };
+}
+
+/**
+ * Run the full CRISPR experiment: build a baseline population, evolve
+ * it until fitness plateaus, splice in the hand-crafted gene, and
+ * continue evolving. Returns per-generation fitness records plus the
+ * subset of gene UUIDs that survive in the final population.
+ */
+export async function runCrisprExperiment(
+  config: CrisprConfig,
+  dataDir: string,
+): Promise<CrisprResult> {
+  if (config.populationSize <= 0) {
+    throw new Error(`populationSize must be positive, got ${config.populationSize}`);
+  }
+  if (config.injectionCount < 0 || config.injectionCount > config.populationSize) {
+    throw new Error(
+      `injectionCount must lie in [0, ${config.populationSize}], got ${config.injectionCount}`,
+    );
+  }
+  if (config.preInjectionGenerations < 0 || config.postInjectionGenerations < 0) {
+    throw new Error("generation counts must be non-negative");
+  }
+
+  const random = createDeterministicRandom(config.seed);
+  let population: LegacyCreatureJSON[] = [];
+  for (let i = 0; i < config.populationSize; i++) {
+    population.push(createBaselineJSON(config.seed + i + 1));
+  }
+
+  const records: FitnessRecord[] = [];
+
+  // Pre-injection evolution — expected to plateau quickly.
+  for (let g = 0; g < config.preInjectionGenerations; g++) {
+    const result = await evolveOneGeneration(
+      population,
+      dataDir,
+      random,
+      config.mutationStrength,
+    );
+    population = result.population;
+    records.push({ generation: g, bestFitness: result.bestScore, injection: false });
+  }
+
+  // CRISPR injection: splice the gene into the top N members.
+  const gene = createGene();
+  for (let i = 0; i < config.injectionCount && i < population.length; i++) {
+    population[i] = injectGene(population[i], gene);
+  }
+
+  // Score the post-injection generation immediately so the marker has data.
+  const injectionGen = config.preInjectionGenerations;
+  const scoredInjected: { member: LegacyCreatureJSON; score: number }[] = [];
+  for (const m of population) {
+    scoredInjected.push({ member: m, score: await scoreMember(m, dataDir) });
+  }
+  scoredInjected.sort((a, b) => b.score - a.score);
+  population = scoredInjected.map((s) => s.member);
+  records.push({
+    generation: injectionGen,
+    bestFitness: scoredInjected[0].score,
+    injection: true,
+  });
+
+  // Post-injection evolution — the gene's structure now has weights to tune.
+  for (let g = 0; g < config.postInjectionGenerations; g++) {
+    const result = await evolveOneGeneration(
+      population,
+      dataDir,
+      random,
+      config.mutationStrength,
+    );
+    population = result.population;
+    records.push({
+      generation: injectionGen + 1 + g,
+      bestFitness: result.bestScore,
+      injection: false,
+    });
+  }
+
+  const fitnessAtInjection = records[injectionGen].bestFitness;
+  const post = records.slice(injectionGen + 1);
+  const bestFitnessAfterInjection = post.length > 0
+    ? Math.max(...post.map((r) => r.bestFitness))
+    : fitnessAtInjection;
+
+  // Find the elite (still index 0 after evolveOneGeneration sorts) and
+  // see which gene UUIDs survived in the final population.
+  const finalUUIDs = new Set<string>();
+  for (const m of population) {
+    for (const n of m.neurons) finalUUIDs.add(n.uuid);
+  }
+  const retainedGeneUUIDs = GENE_NEURON_UUIDS.filter((u) => finalUUIDs.has(u));
+
+  return {
+    records,
+    injectionGeneration: injectionGen,
+    fitnessAtInjection,
+    bestFitnessAfterInjection,
+    retainedGeneUUIDs,
+    bestFinalCreatureJSON: population[0],
+  };
+}
+
+if (import.meta.main) {
+  const start = Date.now();
+
+  console.log("🧬 CRISPR Gene Injection Example");
+  console.log("");
+
+  const { dataDir, creaturesDir, outputDir } = setupWorkingDirs(".synthetic-crispr-injection");
+
+  // Step 1: Build target + baseline.
+  console.log("📦 Step 1: Building target creature and baseline population...");
+  const target = createTargetCreature();
+  CreatureUtil.makeUUID(target);
+  await safeWriteJson(join(creaturesDir, "target.json"), target.exportJSON());
+
+  // Step 2: Generate synthetic training data.
+  console.log("\n📊 Step 2: Generating synthetic training data...");
+  generateSyntheticData(target, dataDir, SYNTHETIC_CONFIG);
+
+  // Step 3: Run the CRISPR experiment.
+  console.log("\n🧪 Step 3: Running pre-injection evolution + injection + post-injection...");
+  const result = await runCrisprExperiment(DEFAULT_CRISPR_CONFIG, dataDir);
+  console.log(`   Generations recorded: ${result.records.length}`);
+  console.log(`   Injection generation: ${result.injectionGeneration}`);
+  console.log(`   Fitness at injection:        ${result.fitnessAtInjection.toPrecision(6)}`);
+  console.log(`   Best fitness post-injection: ${result.bestFitnessAfterInjection.toPrecision(6)}`);
+  console.log(`   Retained gene UUIDs: ${result.retainedGeneUUIDs.join(", ") || "(none)"}`);
+
+  // Step 4: Persist the gene topology and the best post-injection creature.
+  const geneCreatureJSON = injectGene(createBaselineJSON(0), createGene());
+  await safeWriteJson(join(creaturesDir, "gene.json"), geneCreatureJSON);
+  await safeWriteJson(join(creaturesDir, "best.json"), result.bestFinalCreatureJSON);
+
+  // Step 5: Render the SVG.
+  const { renderCrisprSVG } = await import("./svg.ts");
+  const svg = renderCrisprSVG({
+    records: result.records,
+    injectionGeneration: result.injectionGeneration,
+    gene: createGene(),
+  });
+
+  const outputSvgPath = join(outputDir, "crispr_injection.svg");
+  await Deno.writeTextFile(outputSvgPath, svg);
+  console.log(`\n🖼️  Wrote run output ${outputSvgPath}`);
+
+  ensureDirSync("docs/screenshots");
+  await Deno.writeTextFile(SCREENSHOT_PATH, svg);
+  console.log(`🖼️  Wrote committed screenshot ${SCREENSHOT_PATH}`);
+
+  console.log(
+    `\n🏁 Example completed in ${format(Date.now() - start, { ignoreZero: true })}`,
+  );
+}

--- a/crispr_injection/crispr_injection_test.ts
+++ b/crispr_injection/crispr_injection_test.ts
@@ -1,0 +1,268 @@
+/**
+ * Unit tests for the CRISPR gene-injection demo (issue #88).
+ *
+ * "What" tests only — each test calls a real function and asserts on
+ * observable outputs (creature structure, fitness records, SVG markup).
+ * No greps over source files.
+ */
+import {
+  assert,
+  assertEquals,
+  assertGreater,
+  assertGreaterOrEqual,
+  assertNotEquals,
+} from "@std/assert";
+import { join } from "@std/path";
+import { Creature } from "@stsoftware/neat-ai";
+
+import {
+  createBaselineJSON,
+  createGene,
+  createTargetCreature,
+  DEFAULT_CRISPR_CONFIG,
+  GENE_NEURON_UUIDS,
+  injectGene,
+  mutateMember,
+  runCrisprExperiment,
+  SYNTHETIC_CONFIG,
+} from "./crispr_injection.ts";
+import { generateSyntheticData } from "../common/synthetic_data.ts";
+import { asCreatureExport } from "../common/legacy_types.ts";
+import { GENE_TOPOLOGY_CLASS, INJECTION_MARKER_CLASS, renderCrisprSVG } from "./svg.ts";
+
+Deno.test("createTargetCreature builds a 2→2-hidden-TANH→1 creature", () => {
+  const target = createTargetCreature();
+  target.validate();
+  assertEquals(target.input, 2);
+  assertEquals(target.output, 1);
+  // Both gene UUIDs must be present in the target creature.
+  const uuids = new Set(target.neurons.map((n) => n.uuid));
+  for (const u of GENE_NEURON_UUIDS) {
+    assert(uuids.has(u), `target creature should contain gene UUID ${u}`);
+  }
+});
+
+Deno.test("createBaselineJSON has no hidden neurons", () => {
+  const json = createBaselineJSON(7);
+  const hidden = json.neurons.filter((n) => n.type === "hidden");
+  assertEquals(hidden.length, 0);
+  assertEquals(json.input, 2);
+  assertEquals(json.output, 1);
+  // The baseline must still be a valid creature.
+  const c = Creature.fromJSON(asCreatureExport(json));
+  c.validate();
+});
+
+Deno.test("createBaselineJSON produces deterministic weights for the same seed", () => {
+  const a = createBaselineJSON(123);
+  const b = createBaselineJSON(123);
+  assertEquals(a.synapses.length, b.synapses.length);
+  for (let i = 0; i < a.synapses.length; i++) {
+    assertEquals(a.synapses[i].weight, b.synapses[i].weight);
+  }
+});
+
+Deno.test("injectGene adds the gene's hidden neurons to a baseline host", () => {
+  const host = createBaselineJSON(11);
+  const gene = createGene();
+  const merged = injectGene(host, gene);
+
+  const hostHidden = host.neurons.filter((n) => n.type === "hidden").length;
+  const mergedHidden = merged.neurons.filter((n) => n.type === "hidden").length;
+  assertEquals(mergedHidden - hostHidden, gene.hidden.length);
+
+  const uuids = new Set(merged.neurons.map((n) => n.uuid));
+  for (const u of GENE_NEURON_UUIDS) {
+    assert(uuids.has(u), `injected creature should contain gene UUID ${u}`);
+  }
+
+  // Indices are contiguous starting from zero.
+  const indices = merged.neurons.map((n) => n.index).sort((a, b) => a - b);
+  for (let i = 0; i < indices.length; i++) {
+    assertEquals(indices[i], i);
+  }
+
+  // The merged creature must validate.
+  const c = Creature.fromJSON(asCreatureExport(merged));
+  c.validate();
+});
+
+Deno.test("injectGene preserves existing host synapses", () => {
+  const host = createBaselineJSON(13);
+  const merged = injectGene(host, createGene());
+  // Each host synapse should be re-mapped into the merged synapse list.
+  assertGreaterOrEqual(merged.synapses.length, host.synapses.length);
+});
+
+Deno.test("injectGene is idempotent — re-injecting does not duplicate the gene", () => {
+  const host = createBaselineJSON(17);
+  const once = injectGene(host, createGene());
+  const twice = injectGene(once, createGene());
+  // Same neuron count + same synapse count after the second injection.
+  assertEquals(twice.neurons.length, once.neurons.length);
+  assertEquals(twice.synapses.length, once.synapses.length);
+});
+
+Deno.test("injectGene does not mutate the host JSON", () => {
+  const host = createBaselineJSON(19);
+  const beforeNeuronCount = host.neurons.length;
+  const beforeSynapseCount = host.synapses.length;
+  injectGene(host, createGene());
+  assertEquals(host.neurons.length, beforeNeuronCount);
+  assertEquals(host.synapses.length, beforeSynapseCount);
+});
+
+Deno.test("mutateMember perturbs synapse weights without altering structure", () => {
+  let count = 0;
+  const random = () => {
+    count++;
+    // Cycle a small repertoire so Box-Muller produces non-zero draws.
+    return ((count * 0.1234567) % 1) || 0.5;
+  };
+  const host = createBaselineJSON(23);
+  const mutated = mutateMember(host, random, 0.1);
+  assertEquals(mutated.neurons.length, host.neurons.length);
+  assertEquals(mutated.synapses.length, host.synapses.length);
+  let anyChanged = false;
+  for (let i = 0; i < host.synapses.length; i++) {
+    if (mutated.synapses[i].weight !== host.synapses[i].weight) anyChanged = true;
+  }
+  assert(anyChanged, "at least one synapse weight should change after mutation");
+});
+
+Deno.test("runCrisprExperiment lifts fitness after the gene is injected", async () => {
+  const tmp = await Deno.makeTempDir({ prefix: "crispr-test-" });
+  try {
+    const dataDir = join(tmp, "data");
+    Deno.mkdirSync(dataDir, { recursive: true });
+    const target = createTargetCreature();
+    generateSyntheticData(target, dataDir, SYNTHETIC_CONFIG);
+
+    const result = await runCrisprExperiment(
+      {
+        ...DEFAULT_CRISPR_CONFIG,
+        preInjectionGenerations: 4,
+        postInjectionGenerations: 4,
+        populationSize: 4,
+        injectionCount: 2,
+      },
+      dataDir,
+    );
+
+    // One record per pre-gen + the injection generation + one per post-gen.
+    assertEquals(result.records.length, 4 + 1 + 4);
+
+    // Exactly one injection-flagged record exists, at the recorded generation.
+    const injected = result.records.filter((r) => r.injection);
+    assertEquals(injected.length, 1);
+    assertEquals(injected[0].generation, result.injectionGeneration);
+
+    // Acceptance criterion: best fitness post-injection must be higher
+    // than at the moment of injection.
+    assertGreater(
+      result.bestFitnessAfterInjection,
+      result.fitnessAtInjection,
+      `expected post-injection fitness (${result.bestFitnessAfterInjection}) > ` +
+        `injection-time fitness (${result.fitnessAtInjection})`,
+    );
+
+    // Acceptance criterion: at least one gene UUID survives in a descendant.
+    assertGreater(result.retainedGeneUUIDs.length, 0);
+
+    // The best final creature must validate.
+    const best = Creature.fromJSON(asCreatureExport(result.bestFinalCreatureJSON));
+    best.validate();
+  } finally {
+    await Deno.remove(tmp, { recursive: true });
+  }
+});
+
+Deno.test("runCrisprExperiment is deterministic for the same seed", async () => {
+  const tmp = await Deno.makeTempDir({ prefix: "crispr-deterministic-" });
+  try {
+    const dataDir = join(tmp, "data");
+    Deno.mkdirSync(dataDir, { recursive: true });
+    generateSyntheticData(createTargetCreature(), dataDir, SYNTHETIC_CONFIG);
+
+    const cfg = {
+      ...DEFAULT_CRISPR_CONFIG,
+      preInjectionGenerations: 3,
+      postInjectionGenerations: 3,
+      populationSize: 3,
+      injectionCount: 1,
+    };
+    const a = await runCrisprExperiment(cfg, dataDir);
+    const b = await runCrisprExperiment(cfg, dataDir);
+    assertEquals(a.records.length, b.records.length);
+    for (let i = 0; i < a.records.length; i++) {
+      assertEquals(a.records[i].generation, b.records[i].generation);
+      assertEquals(a.records[i].injection, b.records[i].injection);
+      assertEquals(a.records[i].bestFitness, b.records[i].bestFitness);
+    }
+  } finally {
+    await Deno.remove(tmp, { recursive: true });
+  }
+});
+
+Deno.test("runCrisprExperiment rejects invalid config", async () => {
+  let threw = false;
+  try {
+    await runCrisprExperiment(
+      { ...DEFAULT_CRISPR_CONFIG, populationSize: 0 },
+      ".",
+    );
+  } catch (_err) {
+    threw = true;
+  }
+  assert(threw);
+});
+
+Deno.test("renderCrisprSVG produces a well-formed SVG with both panels", () => {
+  const records = [
+    { generation: 0, bestFitness: -0.5, injection: false },
+    { generation: 1, bestFitness: -0.49, injection: false },
+    { generation: 2, bestFitness: -0.48, injection: true },
+    { generation: 3, bestFitness: -0.2, injection: false },
+    { generation: 4, bestFitness: -0.1, injection: false },
+  ];
+  const svg = renderCrisprSVG({
+    records,
+    injectionGeneration: 2,
+    gene: createGene(),
+  });
+  assert(svg.startsWith("<svg"));
+  assert(svg.includes("</svg>"));
+  assert(svg.includes(INJECTION_MARKER_CLASS), "must include the injection-marker class");
+  assert(svg.includes(GENE_TOPOLOGY_CLASS), "must include the gene topology group");
+  // Width and height attributes must be positive integers.
+  const widthMatch = svg.match(/width="(\d+)"/);
+  const heightMatch = svg.match(/height="(\d+)"/);
+  assert(widthMatch);
+  assert(heightMatch);
+  assertGreater(Number.parseInt(widthMatch![1], 10), 0);
+  assertGreater(Number.parseInt(heightMatch![1], 10), 0);
+  // The fitness curve must be drawn as a polyline.
+  const polylines = svg.match(/<polyline /g) ?? [];
+  assertGreaterOrEqual(polylines.length, 1);
+  // Title text is present.
+  assert(svg.includes("CRISPR"));
+});
+
+Deno.test("renderCrisprSVG throws when records are empty", () => {
+  let threw = false;
+  try {
+    renderCrisprSVG({ records: [], injectionGeneration: 0, gene: createGene() });
+  } catch (_err) {
+    threw = true;
+  }
+  assert(threw);
+});
+
+Deno.test("createGene returns the canonical pair of TANH neurons", () => {
+  const gene = createGene();
+  assertEquals(gene.hidden.length, 2);
+  for (const n of gene.hidden) {
+    assertEquals(n.squash, "TANH");
+    assertNotEquals(n.uuid, undefined);
+  }
+});

--- a/crispr_injection/run.sh
+++ b/crispr_injection/run.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -euo pipefail
+
+# CRISPR Gene Injection Example Runner
+#
+# Builds a baseline population on a synthetic two-input task, evolves it
+# until fitness plateaus, splices a hand-crafted "edit gene" (two TANH
+# hidden neurons + their synapses) into the top members, and continues
+# evolving. Renders a single SVG with the gene topology in the top panel
+# and the fitness-vs-generation curve (with an injection marker) below.
+
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd -P)"
+cd "${REPO_ROOT}"
+
+# Add deno to PATH if not already available
+if ! command -v deno &> /dev/null; then
+  export PATH="$HOME/.deno/bin:$PATH"
+fi
+
+echo "🧬 CRISPR Gene Injection Example"
+echo ""
+
+deno run \
+  --v8-flags=--max-old-space-size=4096 \
+  --allow-read \
+  --allow-write \
+  --allow-env \
+  --allow-net \
+  --allow-ffi \
+  crispr_injection/crispr_injection.ts \
+  "$@"
+
+# Re-format the regenerated SVG so subsequent `deno fmt --check` runs
+# stay clean — the renderer emits compact output for readability, and
+# `deno fmt` prefers attributes split across multiple lines.
+if [[ -f "docs/screenshots/crispr_injection.svg" ]]; then
+  deno fmt docs/screenshots/crispr_injection.svg > /dev/null
+fi

--- a/crispr_injection/svg.ts
+++ b/crispr_injection/svg.ts
@@ -1,0 +1,287 @@
+/**
+ * SVG rendering for the CRISPR gene-injection demo.
+ *
+ * The output combines two panels in one SVG:
+ *
+ * - Top: the injected gene's topology in isolation — input ports on
+ *   the left, gene's hidden neurons in the middle, output port on the
+ *   right, with the gene's input/output synapses drawn as lines.
+ * - Bottom: a fitness-vs-generation line chart with a vertical dashed
+ *   marker at the injection generation, so the post-injection lift is
+ *   visually obvious.
+ */
+import type { FitnessRecord, InjectedGene } from "./crispr_injection.ts";
+
+/** SVG canvas width. */
+export const PLOT_WIDTH = 880;
+/** SVG canvas height (top gene panel + bottom fitness chart). */
+export const PLOT_HEIGHT = 540;
+/** Height of the gene topology panel. */
+export const GENE_PANEL_HEIGHT = 200;
+
+const MARGIN_LEFT = 70;
+const MARGIN_RIGHT = 32;
+const CHART_TOP = GENE_PANEL_HEIGHT + 40;
+const MARGIN_BOTTOM = 64;
+
+const INNER_WIDTH = PLOT_WIDTH - MARGIN_LEFT - MARGIN_RIGHT;
+const CHART_HEIGHT = PLOT_HEIGHT - CHART_TOP - MARGIN_BOTTOM;
+
+/** CSS class assigned to the vertical injection marker line. */
+export const INJECTION_MARKER_CLASS = "injection-marker";
+/** CSS class assigned to the gene topology group. */
+export const GENE_TOPOLOGY_CLASS = "gene-topology";
+
+/** Inputs to {@link renderCrisprSVG}. */
+export interface RenderCrisprOptions {
+  /** Per-generation fitness records. */
+  records: readonly FitnessRecord[];
+  /** Generation at which the gene was injected. */
+  injectionGeneration: number;
+  /** The hand-crafted gene whose topology is rendered in the top panel. */
+  gene: InjectedGene;
+}
+
+/**
+ * Render the combined gene-topology + fitness-curve SVG.
+ *
+ * The fitness panel uses the actual recorded values for axis bounds —
+ * very flat pre-injection traces still get a visible spread.
+ */
+export function renderCrisprSVG(options: RenderCrisprOptions): string {
+  const { records, injectionGeneration, gene } = options;
+  if (records.length === 0) {
+    throw new Error("records must contain at least one fitness entry");
+  }
+  if (gene.hidden.length === 0) {
+    throw new Error("gene must contain at least one hidden neuron");
+  }
+
+  const totalGens = records.length;
+  const xScale = (g: number) => MARGIN_LEFT + (g / Math.max(1, totalGens - 1)) * INNER_WIDTH;
+
+  const fitnesses = records.map((r) => r.bestFitness);
+  let yMin = Math.min(...fitnesses);
+  let yMax = Math.max(...fitnesses);
+  if (yMax === yMin) {
+    yMin -= 0.5;
+    yMax += 0.5;
+  } else {
+    const pad = (yMax - yMin) * 0.1;
+    yMin -= pad;
+    yMax += pad;
+  }
+  const yScale = (f: number) => {
+    const norm = (f - yMin) / (yMax - yMin);
+    return CHART_TOP + (1 - norm) * CHART_HEIGHT;
+  };
+
+  const fitnessPoints = records
+    .map((r) => `${xScale(r.generation).toFixed(2)},${yScale(r.bestFitness).toFixed(2)}`)
+    .join(" ");
+
+  const injectionX = xScale(injectionGeneration);
+
+  const yTickCount = 4;
+  const yTicks: string[] = [];
+  for (let i = 0; i < yTickCount; i++) {
+    const t = i / (yTickCount - 1);
+    const value = yMin + t * (yMax - yMin);
+    const y = yScale(value);
+    yTicks.push(
+      `    <line x1="${MARGIN_LEFT.toFixed(2)}" y1="${y.toFixed(2)}" ` +
+        `x2="${(MARGIN_LEFT - 5).toFixed(2)}" y2="${y.toFixed(2)}" ` +
+        `stroke="#333" stroke-width="1"/>`,
+    );
+    yTicks.push(
+      `    <text x="${(MARGIN_LEFT - 8).toFixed(2)}" y="${(y + 4).toFixed(2)}" ` +
+        `text-anchor="end" font-size="11" fill="#333">${value.toFixed(3)}</text>`,
+    );
+  }
+
+  const xTickCount = Math.min(6, totalGens);
+  const xTicks: string[] = [];
+  for (let i = 0; i < xTickCount; i++) {
+    const t = i / Math.max(1, xTickCount - 1);
+    const gen = Math.round(t * (totalGens - 1));
+    const x = xScale(gen);
+    xTicks.push(
+      `    <line x1="${x.toFixed(2)}" y1="${(CHART_TOP + CHART_HEIGHT).toFixed(2)}" ` +
+        `x2="${x.toFixed(2)}" y2="${(CHART_TOP + CHART_HEIGHT + 5).toFixed(2)}" ` +
+        `stroke="#333" stroke-width="1"/>`,
+    );
+    xTicks.push(
+      `    <text x="${x.toFixed(2)}" y="${(CHART_TOP + CHART_HEIGHT + 20).toFixed(2)}" ` +
+        `text-anchor="middle" font-size="11" fill="#333">${gen}</text>`,
+    );
+  }
+
+  return [
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${PLOT_WIDTH} ${PLOT_HEIGHT}" ` +
+    `width="${PLOT_WIDTH}" height="${PLOT_HEIGHT}" role="img" ` +
+    `aria-label="CRISPR gene injection — gene topology and fitness lift">`,
+    `  <title>CRISPR Gene Injection — Topology and Fitness Lift</title>`,
+    `  <rect width="${PLOT_WIDTH}" height="${PLOT_HEIGHT}" fill="#fafafa"/>`,
+    `  <text x="${PLOT_WIDTH / 2}" y="28" text-anchor="middle" ` +
+    `font-family="sans-serif" font-size="16" font-weight="bold" fill="#222">` +
+    `CRISPR Gene Injection — Topology and Fitness Lift</text>`,
+    renderGenePanel(gene),
+    renderFitnessFrame(),
+    yTicks.join("\n"),
+    xTicks.join("\n"),
+    renderInjectionMarker(injectionX),
+    `  <polyline class="fitness" fill="none" stroke="#16a085" stroke-width="2" ` +
+    `points="${fitnessPoints}"/>`,
+    renderFitnessLabels(),
+    `</svg>`,
+    "",
+  ].join("\n");
+}
+
+function renderGenePanel(gene: InjectedGene): string {
+  const panelTop = 40;
+  const panelBottom = panelTop + GENE_PANEL_HEIGHT - 40;
+  const inputXs = new Set<number>();
+  for (const s of gene.inputSynapses) inputXs.add(s.fromInputIndex);
+  const inputIndices = Array.from(inputXs).sort((a, b) => a - b);
+
+  const outputUUIDs = new Set<string>();
+  for (const s of gene.outputSynapses) outputUUIDs.add(s.toOutputUUID);
+
+  const inputX = MARGIN_LEFT + 40;
+  const hiddenX = MARGIN_LEFT + INNER_WIDTH / 2;
+  const outputX = MARGIN_LEFT + INNER_WIDTH - 40;
+
+  const positions = new Map<string, { x: number; y: number }>();
+  inputIndices.forEach((idx, i) => {
+    const y = panelTop + 30 + (panelBottom - panelTop - 30) *
+        (inputIndices.length === 1 ? 0.5 : i / (inputIndices.length - 1));
+    positions.set(`in:${idx}`, { x: inputX, y });
+  });
+
+  gene.hidden.forEach((n, i) => {
+    const y = panelTop + 30 + (panelBottom - panelTop - 30) *
+        (gene.hidden.length === 1 ? 0.5 : i / (gene.hidden.length - 1));
+    positions.set(`h:${n.uuid}`, { x: hiddenX, y });
+  });
+
+  const outputList = Array.from(outputUUIDs);
+  outputList.forEach((u, i) => {
+    const y = panelTop + 30 + (panelBottom - panelTop - 30) *
+        (outputList.length === 1 ? 0.5 : i / (outputList.length - 1));
+    positions.set(`out:${u}`, { x: outputX, y });
+  });
+
+  const synapseLines: string[] = [];
+  for (const s of gene.inputSynapses) {
+    const a = positions.get(`in:${s.fromInputIndex}`);
+    const b = positions.get(`h:${s.toUUID}`);
+    if (!a || !b) continue;
+    synapseLines.push(synapseLine(a, b, s.weight));
+  }
+  for (const s of gene.internalSynapses) {
+    const a = positions.get(`h:${s.fromUUID}`);
+    const b = positions.get(`h:${s.toUUID}`);
+    if (!a || !b) continue;
+    synapseLines.push(synapseLine(a, b, s.weight));
+  }
+  for (const s of gene.outputSynapses) {
+    const a = positions.get(`h:${s.fromUUID}`);
+    const b = positions.get(`out:${s.toOutputUUID}`);
+    if (!a || !b) continue;
+    synapseLines.push(synapseLine(a, b, s.weight));
+  }
+
+  const nodes: string[] = [];
+  for (const idx of inputIndices) {
+    const p = positions.get(`in:${idx}`);
+    if (!p) continue;
+    nodes.push(neuronCircle(p.x, p.y, "#4a90d9", `in[${idx}]`));
+  }
+  for (const n of gene.hidden) {
+    const p = positions.get(`h:${n.uuid}`);
+    if (!p) continue;
+    nodes.push(neuronCircle(p.x, p.y, "#bd10e0", n.squash ?? "?"));
+  }
+  for (const u of outputList) {
+    const p = positions.get(`out:${u}`);
+    if (!p) continue;
+    nodes.push(neuronCircle(p.x, p.y, "#16a085", "out"));
+  }
+
+  return [
+    `  <g class="${GENE_TOPOLOGY_CLASS}" font-family="sans-serif">`,
+    `    <text x="${MARGIN_LEFT}" y="${panelTop - 6}" font-size="13" ` +
+    `font-weight="bold" fill="#222">Injected gene topology</text>`,
+    ...synapseLines,
+    ...nodes,
+    `  </g>`,
+  ].join("\n");
+}
+
+function synapseLine(
+  a: { x: number; y: number },
+  b: { x: number; y: number },
+  weight: number,
+): string {
+  const colour = weight >= 0 ? "#27ae60" : "#e74c3c";
+  const strokeWidth = Math.min(3, Math.max(1, Math.abs(weight)));
+  return `    <line x1="${a.x.toFixed(2)}" y1="${a.y.toFixed(2)}" x2="${b.x.toFixed(2)}" ` +
+    `y2="${b.y.toFixed(2)}" stroke="${colour}" stroke-width="${strokeWidth.toFixed(2)}" ` +
+    `stroke-opacity="0.7"/>`;
+}
+
+function neuronCircle(x: number, y: number, fill: string, label: string): string {
+  return [
+    `    <circle cx="${x.toFixed(2)}" cy="${y.toFixed(2)}" r="14" fill="${fill}" ` +
+    `stroke="#222" stroke-width="1"/>`,
+    `    <text x="${x.toFixed(2)}" y="${(y + 4).toFixed(2)}" text-anchor="middle" ` +
+    `font-size="10" fill="#fff" font-weight="bold">${escapeXml(label)}</text>`,
+  ].join("\n");
+}
+
+function renderFitnessFrame(): string {
+  return [
+    `  <g class="fitness-frame" font-family="sans-serif">`,
+    `    <rect x="${MARGIN_LEFT}" y="${CHART_TOP}" width="${INNER_WIDTH}" ` +
+    `height="${CHART_HEIGHT}" fill="#ffffff" stroke="#333" stroke-width="1"/>`,
+    `    <text x="${MARGIN_LEFT}" y="${CHART_TOP - 8}" font-size="13" ` +
+    `font-weight="bold" fill="#222">Fitness vs generation</text>`,
+    `  </g>`,
+  ].join("\n");
+}
+
+function renderInjectionMarker(x: number): string {
+  return [
+    `  <g class="${INJECTION_MARKER_CLASS}" font-family="sans-serif">`,
+    `    <line x1="${x.toFixed(2)}" y1="${CHART_TOP.toFixed(2)}" x2="${x.toFixed(2)}" ` +
+    `y2="${(CHART_TOP + CHART_HEIGHT).toFixed(2)}" stroke="#e74c3c" stroke-width="2" ` +
+    `stroke-dasharray="6 4"/>`,
+    `    <text x="${(x + 6).toFixed(2)}" y="${(CHART_TOP + 14).toFixed(2)}" ` +
+    `font-size="11" fill="#e74c3c">CRISPR injection</text>`,
+    `  </g>`,
+  ].join("\n");
+}
+
+function renderFitnessLabels(): string {
+  const baseY = CHART_TOP + CHART_HEIGHT;
+  const xMid = MARGIN_LEFT + INNER_WIDTH / 2;
+  return [
+    `  <g class="axis-labels" font-family="sans-serif" font-size="12" fill="#333">`,
+    `    <text x="${xMid}" y="${baseY + 44}" text-anchor="middle">generation</text>`,
+    `    <text x="${MARGIN_LEFT - 50}" y="${CHART_TOP + CHART_HEIGHT / 2}" ` +
+    `text-anchor="middle" dominant-baseline="middle" ` +
+    `transform="rotate(-90 ${MARGIN_LEFT - 50} ${CHART_TOP + CHART_HEIGHT / 2})">` +
+    `best fitness</text>`,
+    `  </g>`,
+  ].join("\n");
+}
+
+function escapeXml(s: string): string {
+  return s
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+}

--- a/docs/pr-summary-88.md
+++ b/docs/pr-summary-88.md
@@ -1,0 +1,54 @@
+# Add CRISPR gene injection demo
+
+## Summary
+
+Adds a new `crispr_injection/` worked example that demonstrates a structural intervention unique to
+NEAT-style neuroevolution: a hand-crafted "edit gene" — two TANH hidden neurons with their input and
+output synapses — is spliced directly into a stalled population mid-evolution, after which fitness
+lifts sharply because the missing topology now has weights to tune. Random weight mutation alone
+cannot construct this structure quickly because the absent neurons have no path to follow;
+CRISPR-style injection bypasses that by inserting the structure wholesale. The runner emits a
+combined SVG with the gene's topology in the top panel and the fitness-vs-generation curve (with a
+vertical injection marker) below. Closes #88.
+
+## Evidence
+
+The change is a backend/CLI example — there is no web UI to capture. Evidence is provided by the
+embedded SVG snapshot and the unit tests.
+
+![CRISPR gene injection — top panel shows two TANH hidden neurons spliced between two inputs and one output, bottom panel shows fitness vs generation with a vertical injection marker](docs/screenshots/crispr_injection.svg)
+
+```mermaid
+flowchart TD
+    TARGET["🎯 Target<br/>2→TANH×2→1"]
+    POP["👥 Baseline Population<br/>no hidden neurons"]
+    EVOLVE1["🔁 Pre-injection evolution<br/>(plateaus)"]
+    GENE["🧬 Hand-crafted gene"]
+    INJECT["💉 CRISPR injection"]
+    EVOLVE2["🔁 Post-injection evolution<br/>(lifts)"]
+    SVG["🖼️ Topology + fitness SVG"]
+    TARGET --> POP --> EVOLVE1 --> INJECT
+    GENE --> INJECT
+    INJECT --> EVOLVE2 --> SVG
+```
+
+## Test Plan
+
+Added `crispr_injection/crispr_injection_test.ts` with 14 "what" tests covering:
+
+- `createTargetCreature` builds a valid 2→TANH×2→1 creature whose hidden UUIDs match the gene.
+- `createBaselineJSON` has zero hidden neurons and produces deterministic weights for the same seed.
+- `injectGene` adds the gene's hidden neurons, preserves host synapses, is idempotent under
+  re-injection, does not mutate the host JSON, and yields a creature that validates.
+- `mutateMember` perturbs synapse weights without altering structure.
+- `runCrisprExperiment` records one entry per pre-generation + the injection generation + one per
+  post-generation, lifts best fitness post-injection above the at-injection value, retains at least
+  one gene UUID in a descendant, and is deterministic for the same seed.
+- `runCrisprExperiment` rejects invalid configurations.
+- `renderCrisprSVG` produces a well-formed SVG containing the gene topology group and the injection
+  marker, and throws on empty input.
+- `createGene` returns the canonical TANH neuron pair.
+
+Updated `readme_structure_test.ts` and `docs/archive_test.ts` to register the new example directory,
+screenshot path, and PR summary file. The full `./quality.sh` pipeline (lint, format, type check,
+unit tests, every example runner) passes.

--- a/docs/screenshots/crispr_injection.svg
+++ b/docs/screenshots/crispr_injection.svg
@@ -1,0 +1,175 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 880 540"
+  width="880"
+  height="540"
+  role="img"
+  aria-label="CRISPR gene injection — gene topology and fitness lift"
+>
+  <title>CRISPR Gene Injection — Topology and Fitness Lift</title>
+  <rect width="880" height="540" fill="#fafafa" />
+  <text
+    x="440"
+    y="28"
+    text-anchor="middle"
+    font-family="sans-serif"
+    font-size="16"
+    font-weight="bold"
+    fill="#222"
+  >CRISPR Gene Injection — Topology and Fitness Lift</text>
+  <g class="gene-topology" font-family="sans-serif">
+    <text x="70" y="34" font-size="13" font-weight="bold" fill="#222">Injected gene topology</text>
+    <line
+      x1="110.00"
+      y1="70.00"
+      x2="459.00"
+      y2="70.00"
+      stroke="#27ae60"
+      stroke-width="3.00"
+      stroke-opacity="0.7"
+    />
+    <line
+      x1="110.00"
+      y1="200.00"
+      x2="459.00"
+      y2="70.00"
+      stroke="#e74c3c"
+      stroke-width="3.00"
+      stroke-opacity="0.7"
+    />
+    <line
+      x1="110.00"
+      y1="70.00"
+      x2="459.00"
+      y2="200.00"
+      stroke="#e74c3c"
+      stroke-width="3.00"
+      stroke-opacity="0.7"
+    />
+    <line
+      x1="110.00"
+      y1="200.00"
+      x2="459.00"
+      y2="200.00"
+      stroke="#27ae60"
+      stroke-width="3.00"
+      stroke-opacity="0.7"
+    />
+    <line
+      x1="459.00"
+      y1="70.00"
+      x2="808.00"
+      y2="135.00"
+      stroke="#27ae60"
+      stroke-width="3.00"
+      stroke-opacity="0.7"
+    />
+    <line
+      x1="459.00"
+      y1="200.00"
+      x2="808.00"
+      y2="135.00"
+      stroke="#27ae60"
+      stroke-width="3.00"
+      stroke-opacity="0.7"
+    />
+    <circle cx="110.00" cy="70.00" r="14" fill="#4a90d9" stroke="#222" stroke-width="1" />
+    <text
+      x="110.00"
+      y="74.00"
+      text-anchor="middle"
+      font-size="10"
+      fill="#fff"
+      font-weight="bold"
+    >in[0]</text>
+    <circle cx="110.00" cy="200.00" r="14" fill="#4a90d9" stroke="#222" stroke-width="1" />
+    <text
+      x="110.00"
+      y="204.00"
+      text-anchor="middle"
+      font-size="10"
+      fill="#fff"
+      font-weight="bold"
+    >in[1]</text>
+    <circle cx="459.00" cy="70.00" r="14" fill="#bd10e0" stroke="#222" stroke-width="1" />
+    <text
+      x="459.00"
+      y="74.00"
+      text-anchor="middle"
+      font-size="10"
+      fill="#fff"
+      font-weight="bold"
+    >TANH</text>
+    <circle cx="459.00" cy="200.00" r="14" fill="#bd10e0" stroke="#222" stroke-width="1" />
+    <text
+      x="459.00"
+      y="204.00"
+      text-anchor="middle"
+      font-size="10"
+      fill="#fff"
+      font-weight="bold"
+    >TANH</text>
+    <circle cx="808.00" cy="135.00" r="14" fill="#16a085" stroke="#222" stroke-width="1" />
+    <text
+      x="808.00"
+      y="139.00"
+      text-anchor="middle"
+      font-size="10"
+      fill="#fff"
+      font-weight="bold"
+    >out</text>
+  </g>
+  <g class="fitness-frame" font-family="sans-serif">
+    <rect x="70" y="240" width="778" height="236" fill="#ffffff" stroke="#333" stroke-width="1" />
+    <text x="70" y="232" font-size="13" font-weight="bold" fill="#222">Fitness vs generation</text>
+  </g>
+  <line x1="70.00" y1="476.00" x2="65.00" y2="476.00" stroke="#333" stroke-width="1" />
+  <text x="62.00" y="480.00" text-anchor="end" font-size="11" fill="#333">0.977</text>
+  <line x1="70.00" y1="397.33" x2="65.00" y2="397.33" stroke="#333" stroke-width="1" />
+  <text x="62.00" y="401.33" text-anchor="end" font-size="11" fill="#333">0.985</text>
+  <line x1="70.00" y1="318.67" x2="65.00" y2="318.67" stroke="#333" stroke-width="1" />
+  <text x="62.00" y="322.67" text-anchor="end" font-size="11" fill="#333">0.992</text>
+  <line x1="70.00" y1="240.00" x2="65.00" y2="240.00" stroke="#333" stroke-width="1" />
+  <text x="62.00" y="244.00" text-anchor="end" font-size="11" fill="#333">1.000</text>
+  <line x1="70.00" y1="476.00" x2="70.00" y2="481.00" stroke="#333" stroke-width="1" />
+  <text x="70.00" y="496.00" text-anchor="middle" font-size="11" fill="#333">0</text>
+  <line x1="215.88" y1="476.00" x2="215.88" y2="481.00" stroke="#333" stroke-width="1" />
+  <text x="215.88" y="496.00" text-anchor="middle" font-size="11" fill="#333">3</text>
+  <line x1="361.75" y1="476.00" x2="361.75" y2="481.00" stroke="#333" stroke-width="1" />
+  <text x="361.75" y="496.00" text-anchor="middle" font-size="11" fill="#333">6</text>
+  <line x1="556.25" y1="476.00" x2="556.25" y2="481.00" stroke="#333" stroke-width="1" />
+  <text x="556.25" y="496.00" text-anchor="middle" font-size="11" fill="#333">10</text>
+  <line x1="702.13" y1="476.00" x2="702.13" y2="481.00" stroke="#333" stroke-width="1" />
+  <text x="702.13" y="496.00" text-anchor="middle" font-size="11" fill="#333">13</text>
+  <line x1="848.00" y1="476.00" x2="848.00" y2="481.00" stroke="#333" stroke-width="1" />
+  <text x="848.00" y="496.00" text-anchor="middle" font-size="11" fill="#333">16</text>
+  <g class="injection-marker" font-family="sans-serif">
+    <line
+      x1="459.00"
+      y1="240.00"
+      x2="459.00"
+      y2="476.00"
+      stroke="#e74c3c"
+      stroke-width="2"
+      stroke-dasharray="6 4"
+    />
+    <text x="465.00" y="254.00" font-size="11" fill="#e74c3c">CRISPR injection</text>
+  </g>
+  <polyline
+    class="fitness"
+    fill="none"
+    stroke="#16a085"
+    stroke-width="2"
+    points="70.00,456.33 118.63,405.15 167.25,383.66 215.88,378.22 264.50,378.22 313.13,378.22 361.75,378.22 410.38,378.22 459.00,325.18 507.63,325.18 556.25,285.12 604.88,264.81 653.50,263.92 702.13,263.92 750.75,259.67 799.38,259.67 848.00,259.67"
+  />
+  <g class="axis-labels" font-family="sans-serif" font-size="12" fill="#333">
+    <text x="459" y="520" text-anchor="middle">generation</text>
+    <text
+      x="20"
+      y="358"
+      text-anchor="middle"
+      dominant-baseline="middle"
+      transform="rotate(-90 20 358)"
+    >best fitness</text>
+  </g>
+</svg>

--- a/quality.sh
+++ b/quality.sh
@@ -106,7 +106,7 @@ fi
 # --- Example Programs ---
 # Clean up any previous synthetic data
 echo "Cleaning up previous runs..."
-rm -rf .synthetic-discovery .synthetic-intelligent-design .synthetic-suggest-improvements .synthetic-crossover .synthetic-cart-pole .synthetic-lunar-lander .synthetic-mountain-car .synthetic-snake .synthetic-maze .synthetic-xor .synthetic-stock .synthetic-mnist .synthetic-mcmc .discovery
+rm -rf .synthetic-discovery .synthetic-intelligent-design .synthetic-suggest-improvements .synthetic-crossover .synthetic-crispr-injection .synthetic-cart-pole .synthetic-lunar-lander .synthetic-mountain-car .synthetic-snake .synthetic-maze .synthetic-xor .synthetic-stock .synthetic-mnist .synthetic-mcmc .discovery
 echo ""
 
 # Run the Intelligent Design example
@@ -117,6 +117,9 @@ run_example "Discovery Example" "./discovery/run.sh"
 
 # Run the Crossover (Breeding) example
 run_example "Crossover (Breeding) Example" "./crossover/run.sh"
+
+# Run the CRISPR Gene Injection example
+run_example "CRISPR Gene Injection Example" "./crispr_injection/run.sh"
 
 # Run the Cart-Pole Balancing example
 run_example "Cart-Pole Balancing Example" "./cart_pole/run.sh"

--- a/readme_structure_test.ts
+++ b/readme_structure_test.ts
@@ -13,6 +13,7 @@ const README_PATH = "README.md";
 
 const EXAMPLE_DIRS = [
   "cart_pole",
+  "crispr_injection",
   "crossover",
   "discovery",
   "intelligent_design",
@@ -37,6 +38,7 @@ const SCREENSHOT_PATHS = [
   "docs/screenshots/stock_market.svg",
   "docs/screenshots/mnist_classification.svg",
   "docs/screenshots/mcmc_acceptance.svg",
+  "docs/screenshots/crispr_injection.svg",
 ] as const;
 
 function loadReadme(): string {
@@ -114,6 +116,7 @@ Deno.test("README.md introduces every example by name", () => {
     "Stock Market",
     "MNIST",
     "MCMC Acceptance",
+    "CRISPR",
   ];
   for (const name of required) {
     assertStringIncludes(


### PR DESCRIPTION
# Add CRISPR gene injection demo

## Summary

Adds a new `crispr_injection/` worked example that demonstrates a structural intervention unique to
NEAT-style neuroevolution: a hand-crafted "edit gene" — two TANH hidden neurons with their input and
output synapses — is spliced directly into a stalled population mid-evolution, after which fitness
lifts sharply because the missing topology now has weights to tune. Random weight mutation alone
cannot construct this structure quickly because the absent neurons have no path to follow;
CRISPR-style injection bypasses that by inserting the structure wholesale. The runner emits a
combined SVG with the gene's topology in the top panel and the fitness-vs-generation curve (with a
vertical injection marker) below. Closes #88.

## Evidence

The change is a backend/CLI example — there is no web UI to capture. Evidence is provided by the
embedded SVG snapshot and the unit tests.

![CRISPR gene injection — top panel shows two TANH hidden neurons spliced between two inputs and one output, bottom panel shows fitness vs generation with a vertical injection marker](docs/screenshots/crispr_injection.svg)

```mermaid
flowchart TD
    TARGET["🎯 Target<br/>2→TANH×2→1"]
    POP["👥 Baseline Population<br/>no hidden neurons"]
    EVOLVE1["🔁 Pre-injection evolution<br/>(plateaus)"]
    GENE["🧬 Hand-crafted gene"]
    INJECT["💉 CRISPR injection"]
    EVOLVE2["🔁 Post-injection evolution<br/>(lifts)"]
    SVG["🖼️ Topology + fitness SVG"]
    TARGET --> POP --> EVOLVE1 --> INJECT
    GENE --> INJECT
    INJECT --> EVOLVE2 --> SVG
```

## Test Plan

Added `crispr_injection/crispr_injection_test.ts` with 14 "what" tests covering:

- `createTargetCreature` builds a valid 2→TANH×2→1 creature whose hidden UUIDs match the gene.
- `createBaselineJSON` has zero hidden neurons and produces deterministic weights for the same seed.
- `injectGene` adds the gene's hidden neurons, preserves host synapses, is idempotent under
  re-injection, does not mutate the host JSON, and yields a creature that validates.
- `mutateMember` perturbs synapse weights without altering structure.
- `runCrisprExperiment` records one entry per pre-generation + the injection generation + one per
  post-generation, lifts best fitness post-injection above the at-injection value, retains at least
  one gene UUID in a descendant, and is deterministic for the same seed.
- `runCrisprExperiment` rejects invalid configurations.
- `renderCrisprSVG` produces a well-formed SVG containing the gene topology group and the injection
  marker, and throws on empty input.
- `createGene` returns the canonical TANH neuron pair.

Updated `readme_structure_test.ts` and `docs/archive_test.ts` to register the new example directory,
screenshot path, and PR summary file. The full `./quality.sh` pipeline (lint, format, type check,
unit tests, every example runner) passes.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-88 -->