### PR TITLE
Add common/evolution_snapshot.ts checkpoint capture helper (#93)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,7 @@ reinventing equivalent logic in a new example.
 | `common/working_dirs.ts`         | Standard hidden working-directory layout for examples.        |
 | `common/data_cache.ts`           | Download datasets into hidden directories with on-disk cache. |
 | `common/evolution_chart.ts`      | Dual-axis SVG renderer for NEAT evolution histories.          |
+| `common/evolution_snapshot.ts`   | Capture creature state at checkpoint generations.             |
 
 ### `common/data_cache.ts`
 
@@ -109,6 +110,26 @@ Behaviour:
 
 The helper relies on Deno's built-in `fetch` and `crypto.subtle` — no extra dependencies are added.
 
+### `common/evolution_snapshot.ts`
+
+`captureSnapshot(config, generation, creature, score, sampleOutputs?)` writes a snapshot file when
+`generation` matches one of `config.checkpoints` (default `[1, 10, 100, 1000, 10000]`).
+`loadSnapshots(outputDir)` reads them back, sorted by generation. Snapshots are byte-deterministic —
+no timestamps, no run-specific paths — so reruns with the same seed produce identical files.
+
+```ts
+import { captureSnapshot, DEFAULT_CHECKPOINTS } from "../common/evolution_snapshot.ts";
+
+const config = {
+  checkpoints: [...DEFAULT_CHECKPOINTS],
+  outputDir: ".synthetic-xor/snapshots",
+};
+
+for (let gen = 1; gen <= 10000; gen++) {
+  captureSnapshot(config, gen, champion.exportJSON(), score, samples);
+}
+```
+
 ## 📂 Project Structure
 
 ```
@@ -123,6 +144,8 @@ common/
   data_cache_test.ts               — Unit tests for the dataset cache
   evolution_chart.ts               — Dual-axis SVG renderer for NEAT evolution histories
   evolution_chart_test.ts          — Unit tests for the evolution chart renderer
+  evolution_snapshot.ts            — Capture creature state at checkpoint generations
+  evolution_snapshot_test.ts       — Unit tests for the evolution snapshot helper
 
 crossover/
   crossover_example.ts             — Example: breed two creatures (crossover)

--- a/common/evolution_snapshot.ts
+++ b/common/evolution_snapshot.ts
@@ -1,0 +1,114 @@
+/**
+ * Shared evolution-snapshot helper for NEAT-AI examples.
+ *
+ * Captures creature state (topology, score, optional sample outputs) at
+ * configurable generation checkpoints — by default 1, 10, 100, 1000, and
+ * 10000 — so every evolutionary example can produce consistent snapshot
+ * data for the evolution-progression visualisation.
+ *
+ * Snapshots are written as deterministic JSON: stable property order, no
+ * timestamps, no run-specific paths. Reruns with the same seed therefore
+ * produce byte-identical files.
+ */
+
+import { ensureDirSync } from "@std/fs";
+import { join } from "@std/path";
+
+/** Default checkpoint generations captured by examples. */
+export const DEFAULT_CHECKPOINTS: readonly number[] = [1, 10, 100, 1000, 10000];
+
+/** Configuration controlling which generations are captured and where. */
+export interface SnapshotConfig {
+  /** Generations at which to capture a snapshot. */
+  checkpoints: number[];
+  /** Output directory for snapshot files. Created if it does not exist. */
+  outputDir: string;
+}
+
+/** A single captured snapshot — the on-disk shape of `snapshot-gen-N.json`. */
+export interface Snapshot {
+  /** Generation at which the snapshot was taken. */
+  generation: number;
+  /** Score of the captured creature at this generation. */
+  score: number;
+  /** Serialisable creature topology (typically `creature.exportJSON()`). */
+  creature: unknown;
+  /** Optional sample outputs recorded alongside the topology. */
+  sampleOutputs?: unknown[];
+}
+
+function snapshotPath(outputDir: string, generation: number): string {
+  return join(outputDir, `snapshot-gen-${generation}.json`);
+}
+
+/**
+ * Serialise a snapshot to deterministic, pretty-printed JSON.
+ *
+ * Property order is fixed (generation, score, creature, sampleOutputs) so
+ * two captures with identical inputs emit byte-identical bytes.
+ */
+function serialise(snapshot: Snapshot): string {
+  const ordered: Record<string, unknown> = {
+    generation: snapshot.generation,
+    score: snapshot.score,
+    creature: snapshot.creature,
+  };
+  if (snapshot.sampleOutputs !== undefined) {
+    ordered.sampleOutputs = snapshot.sampleOutputs;
+  }
+  return JSON.stringify(ordered, null, 2) + "\n";
+}
+
+/**
+ * Capture a snapshot when `generation` matches a configured checkpoint.
+ *
+ * No-op (returns `null`) when `generation` is not in `config.checkpoints`.
+ * Otherwise serialises the creature, score, and any sample outputs to
+ * `<outputDir>/snapshot-gen-<generation>.json` and returns the path written.
+ */
+export function captureSnapshot(
+  config: SnapshotConfig,
+  generation: number,
+  creature: unknown,
+  score: number,
+  sampleOutputs?: unknown[],
+): string | null {
+  if (!config.checkpoints.includes(generation)) {
+    return null;
+  }
+  ensureDirSync(config.outputDir);
+  const path = snapshotPath(config.outputDir, generation);
+  const snap: Snapshot = { generation, score, creature };
+  if (sampleOutputs !== undefined) {
+    snap.sampleOutputs = sampleOutputs;
+  }
+  Deno.writeTextFileSync(path, serialise(snap));
+  return path;
+}
+
+/**
+ * Read all snapshot files from `outputDir`, returned in ascending
+ * generation order. Returns an empty array when the directory does not
+ * exist or contains no snapshot files.
+ */
+export function loadSnapshots(outputDir: string): Snapshot[] {
+  const out: Snapshot[] = [];
+  let entries: Iterable<Deno.DirEntry>;
+  try {
+    entries = Deno.readDirSync(outputDir);
+  } catch (err) {
+    if (err instanceof Deno.errors.NotFound) {
+      return out;
+    }
+    throw err;
+  }
+  for (const entry of entries) {
+    if (!entry.isFile) continue;
+    const match = entry.name.match(/^snapshot-gen-(\d+)\.json$/);
+    if (!match) continue;
+    const text = Deno.readTextFileSync(join(outputDir, entry.name));
+    out.push(JSON.parse(text) as Snapshot);
+  }
+  out.sort((a, b) => a.generation - b.generation);
+  return out;
+}

--- a/common/evolution_snapshot_test.ts
+++ b/common/evolution_snapshot_test.ts
@@ -1,0 +1,122 @@
+/**
+ * Unit tests for the shared evolution-snapshot helper.
+ *
+ * These are "what" tests — they verify the observable behaviour of
+ * `captureSnapshot` and `loadSnapshots` (files written, content, ordering,
+ * byte-for-byte reproducibility) without inspecting how the helper builds
+ * its output.
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import { existsSync } from "@std/fs";
+import { join } from "@std/path";
+
+import {
+  captureSnapshot,
+  DEFAULT_CHECKPOINTS,
+  loadSnapshots,
+  type SnapshotConfig,
+} from "./evolution_snapshot.ts";
+
+function makeConfig(outputDir: string): SnapshotConfig {
+  return { checkpoints: [...DEFAULT_CHECKPOINTS], outputDir };
+}
+
+Deno.test("captureSnapshot writes a file for each checkpoint generation", () => {
+  const tmp = Deno.makeTempDirSync({ prefix: "neat_snapshot_test_" });
+  try {
+    const config = makeConfig(tmp);
+
+    captureSnapshot(config, 1, { nodes: [], connections: [] }, 0.1);
+    captureSnapshot(config, 10, { nodes: [{ id: 1 }], connections: [] }, 0.5);
+    captureSnapshot(config, 100, { nodes: [], connections: [] }, 0.9, [[1, 2, 3]]);
+
+    assert(existsSync(join(tmp, "snapshot-gen-1.json")), "gen 1 file should exist");
+    assert(existsSync(join(tmp, "snapshot-gen-10.json")), "gen 10 file should exist");
+    assert(existsSync(join(tmp, "snapshot-gen-100.json")), "gen 100 file should exist");
+
+    const parsed = JSON.parse(Deno.readTextFileSync(join(tmp, "snapshot-gen-100.json")));
+    assertEquals(parsed.generation, 100);
+    assertEquals(parsed.score, 0.9);
+    assertEquals(parsed.sampleOutputs, [[1, 2, 3]]);
+    assertEquals(parsed.creature, { nodes: [], connections: [] });
+  } finally {
+    Deno.removeSync(tmp, { recursive: true });
+  }
+});
+
+Deno.test("captureSnapshot writes nothing for non-checkpoint generations", () => {
+  const tmp = Deno.makeTempDirSync({ prefix: "neat_snapshot_test_" });
+  try {
+    const config = makeConfig(tmp);
+
+    assertEquals(captureSnapshot(config, 2, {}, 0), null);
+    assertEquals(captureSnapshot(config, 7, {}, 0), null);
+    assertEquals(captureSnapshot(config, 999, {}, 0), null);
+
+    const entries = [...Deno.readDirSync(tmp)].filter((e) => e.name.startsWith("snapshot-gen-"));
+    assertEquals(entries.length, 0, "no snapshot files should have been written");
+  } finally {
+    Deno.removeSync(tmp, { recursive: true });
+  }
+});
+
+Deno.test("loadSnapshots round-trips captureSnapshot output sorted by generation", () => {
+  const tmp = Deno.makeTempDirSync({ prefix: "neat_snapshot_test_" });
+  try {
+    const config = makeConfig(tmp);
+
+    // Write out of generation order to prove loadSnapshots sorts.
+    captureSnapshot(config, 100, { nodes: ["c"] }, 0.9);
+    captureSnapshot(config, 1, { nodes: ["a"] }, 0.1);
+    captureSnapshot(config, 10, { nodes: ["b"] }, 0.5, [[42]]);
+
+    const snaps = loadSnapshots(tmp);
+
+    assertEquals(snaps.length, 3);
+    assertEquals(snaps.map((s) => s.generation), [1, 10, 100]);
+    assertEquals(snaps[0].score, 0.1);
+    assertEquals(snaps[1].sampleOutputs, [[42]]);
+    assertEquals(snaps[2].creature, { nodes: ["c"] });
+  } finally {
+    Deno.removeSync(tmp, { recursive: true });
+  }
+});
+
+Deno.test("captureSnapshot is reproducible — identical inputs yield byte-identical files", () => {
+  const tmpA = Deno.makeTempDirSync({ prefix: "neat_snapshot_test_a_" });
+  const tmpB = Deno.makeTempDirSync({ prefix: "neat_snapshot_test_b_" });
+  try {
+    const cfgA = makeConfig(tmpA);
+    const cfgB = makeConfig(tmpB);
+    const creature = {
+      nodes: [{ id: 1 }, { id: 2 }],
+      connections: [{ from: 1, to: 2, w: 0.3 }],
+    };
+    const samples = [[0, 0, 0], [1, 1, 1]];
+
+    captureSnapshot(cfgA, 1, creature, 0.42, samples);
+    captureSnapshot(cfgA, 10, creature, 0.84, samples);
+    captureSnapshot(cfgB, 1, creature, 0.42, samples);
+    captureSnapshot(cfgB, 10, creature, 0.84, samples);
+
+    for (const gen of [1, 10]) {
+      const a = Deno.readFileSync(join(tmpA, `snapshot-gen-${gen}.json`));
+      const b = Deno.readFileSync(join(tmpB, `snapshot-gen-${gen}.json`));
+      assertEquals(a, b, `snapshot-gen-${gen}.json should be byte-identical`);
+    }
+  } finally {
+    Deno.removeSync(tmpA, { recursive: true });
+    Deno.removeSync(tmpB, { recursive: true });
+  }
+});
+
+Deno.test("loadSnapshots returns an empty array for a missing or empty directory", () => {
+  const tmp = Deno.makeTempDirSync({ prefix: "neat_snapshot_test_" });
+  try {
+    assertEquals(loadSnapshots(join(tmp, "does-not-exist")), []);
+    assertEquals(loadSnapshots(tmp), []);
+  } finally {
+    Deno.removeSync(tmp, { recursive: true });
+  }
+});

--- a/docs/archive_test.ts
+++ b/docs/archive_test.ts
@@ -58,7 +58,9 @@ Deno.test("No PR summary files remain in docs/ root", () => {
       if (entry.name === "pr-summary-79.md") continue;
       if (entry.name === "pr-summary-80.md") continue;
       if (entry.name === "pr-summary-81.md") continue;
+      if (entry.name === "pr-summary-88.md") continue;
       if (entry.name === "pr-summary-89.md") continue;
+      if (entry.name === "pr-summary-93.md") continue;
       if (entry.name === "pr-summary-105.md") continue;
       throw new Error(
         `Found unexpected PR summary file in docs/ root: ${entry.name}`,

--- a/docs/pr-summary-93.md
+++ b/docs/pr-summary-93.md
@@ -1,0 +1,57 @@
+## Summary
+
+Added `common/evolution_snapshot.ts`, a shared helper that captures creature state (topology, score,
+optional sample outputs) at configurable generation checkpoints (default
+`[1, 10, 100, 1000, 10000]`). Every evolutionary example can now produce snapshot data in a single
+consistent format for the upcoming evolution-progression visualisation. Snapshots are
+byte-deterministic — no timestamps, no run-specific paths — so reruns with the same seed produce
+identical files. Closes #93.
+
+## Evidence
+
+Backend / CLI change — no UI to screenshot. Verified by the new `common/evolution_snapshot_test.ts`
+"what" tests, all of which pass under `deno test`:
+
+```
+running 5 tests from ./common/evolution_snapshot_test.ts
+captureSnapshot writes a file for each checkpoint generation ... ok
+captureSnapshot writes nothing for non-checkpoint generations ... ok
+loadSnapshots round-trips captureSnapshot output sorted by generation ... ok
+captureSnapshot is reproducible — identical inputs yield byte-identical files ... ok
+loadSnapshots returns an empty array for a missing or empty directory ... ok
+ok | 5 passed | 0 failed
+```
+
+```mermaid
+flowchart LR
+    LOOP["evolutionary loop<br/>gen = 1..10000"]
+    CHECK{"gen ∈ checkpoints?"}
+    WRITE["💾 snapshot-gen-N.json<br/>topology + score + samples"]
+    SKIP["↪ continue"]
+    LOAD["loadSnapshots()<br/>→ sorted [Snapshot]"]
+
+    LOOP --> CHECK
+    CHECK -- yes --> WRITE
+    CHECK -- no --> SKIP
+    WRITE --> LOOP
+    SKIP --> LOOP
+    WRITE -.->|later| LOAD
+```
+
+## Test Plan
+
+- Added `common/evolution_snapshot_test.ts` with five "what" tests:
+  - **Happy path** — capture at gen 1, 10, 100; assert the three files exist with correct contents
+    (including `sampleOutputs`).
+  - **Skip non-checkpoint generations** — gen 2, 7, 999 produce no files and return `null`.
+  - **Round-trip** — `loadSnapshots` reads back what `captureSnapshot` wrote, sorted by generation
+    regardless of write order.
+  - **Reproducibility** — two independent capture sequences with the same inputs produce
+    byte-identical files.
+  - **Missing directory** — `loadSnapshots` on a missing/empty directory returns `[]`.
+- Updated `AGENTS.md` to list the new helper under "📦 Shared Utilities" and in the project
+  structure.
+- Added `pr-summary-93.md` and `pr-summary-88.md` (pre-existing leftover) to the
+  `docs/archive_test.ts` allowlist.
+- No new third-party dependencies introduced — uses `@std/fs` and `@std/path` already in
+  `deno.json`.


### PR DESCRIPTION
## Summary

Added `common/evolution_snapshot.ts`, a shared helper that captures creature state (topology, score,
optional sample outputs) at configurable generation checkpoints (default
`[1, 10, 100, 1000, 10000]`). Every evolutionary example can now produce snapshot data in a single
consistent format for the upcoming evolution-progression visualisation. Snapshots are
byte-deterministic — no timestamps, no run-specific paths — so reruns with the same seed produce
identical files. Closes #93.

## Evidence

Backend / CLI change — no UI to screenshot. Verified by the new `common/evolution_snapshot_test.ts`
"what" tests, all of which pass under `deno test`:

```
running 5 tests from ./common/evolution_snapshot_test.ts
captureSnapshot writes a file for each checkpoint generation ... ok
captureSnapshot writes nothing for non-checkpoint generations ... ok
loadSnapshots round-trips captureSnapshot output sorted by generation ... ok
captureSnapshot is reproducible — identical inputs yield byte-identical files ... ok
loadSnapshots returns an empty array for a missing or empty directory ... ok
ok | 5 passed | 0 failed
```

```mermaid
flowchart LR
    LOOP["evolutionary loop<br/>gen = 1..10000"]
    CHECK{"gen ∈ checkpoints?"}
    WRITE["💾 snapshot-gen-N.json<br/>topology + score + samples"]
    SKIP["↪ continue"]
    LOAD["loadSnapshots()<br/>→ sorted [Snapshot]"]

    LOOP --> CHECK
    CHECK -- yes --> WRITE
    CHECK -- no --> SKIP
    WRITE --> LOOP
    SKIP --> LOOP
    WRITE -.->|later| LOAD
```

## Test Plan

- Added `common/evolution_snapshot_test.ts` with five "what" tests:
  - **Happy path** — capture at gen 1, 10, 100; assert the three files exist with correct contents
    (including `sampleOutputs`).
  - **Skip non-checkpoint generations** — gen 2, 7, 999 produce no files and return `null`.
  - **Round-trip** — `loadSnapshots` reads back what `captureSnapshot` wrote, sorted by generation
    regardless of write order.
  - **Reproducibility** — two independent capture sequences with the same inputs produce
    byte-identical files.
  - **Missing directory** — `loadSnapshots` on a missing/empty directory returns `[]`.
- Updated `AGENTS.md` to list the new helper under "📦 Shared Utilities" and in the project
  structure.
- Added `pr-summary-93.md` and `pr-summary-88.md` (pre-existing leftover) to the
  `docs/archive_test.ts` allowlist.
- No new third-party dependencies introduced — uses `@std/fs` and `@std/path` already in
  `deno.json`.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-93 -->