### PR TITLE
Add common/evolution_progress_svg.ts multi-panel SVG renderer (#94)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,14 +71,15 @@ programs. See [README.md](README.md#-quality-check) for full details.
 The `common/` directory holds helpers that every example may reuse. Reach for these before
 reinventing equivalent logic in a new example.
 
-| Module                           | Purpose                                                       |
-| -------------------------------- | ------------------------------------------------------------- |
-| `common/deterministic_random.ts` | Seeded PRNG for reproducible data generation.                 |
-| `common/synthetic_data.ts`       | Synthetic dataset generation and scoring.                     |
-| `common/working_dirs.ts`         | Standard hidden working-directory layout for examples.        |
-| `common/data_cache.ts`           | Download datasets into hidden directories with on-disk cache. |
-| `common/evolution_chart.ts`      | Dual-axis SVG renderer for NEAT evolution histories.          |
-| `common/evolution_snapshot.ts`   | Capture creature state at checkpoint generations.             |
+| Module                             | Purpose                                                       |
+| ---------------------------------- | ------------------------------------------------------------- |
+| `common/deterministic_random.ts`   | Seeded PRNG for reproducible data generation.                 |
+| `common/synthetic_data.ts`         | Synthetic dataset generation and scoring.                     |
+| `common/working_dirs.ts`           | Standard hidden working-directory layout for examples.        |
+| `common/data_cache.ts`             | Download datasets into hidden directories with on-disk cache. |
+| `common/evolution_chart.ts`        | Dual-axis SVG renderer for NEAT evolution histories.          |
+| `common/evolution_snapshot.ts`     | Capture creature state at checkpoint generations.             |
+| `common/evolution_progress_svg.ts` | Multi-panel animated SVG strip rendered from snapshots.       |
 
 ### `common/data_cache.ts`
 
@@ -130,6 +131,32 @@ for (let gen = 1; gen <= 10000; gen++) {
 }
 ```
 
+### `common/evolution_progress_svg.ts`
+
+`renderEvolutionProgressSvg(snapshots, opts?)` consumes the snapshots loaded via
+`loadSnapshots(...)` and returns a single multi-panel animated SVG string showing how the network
+and its score evolved across the captured generations. Each panel displays a small topology diagram,
+the generation label (e.g. "Gen 1", "Gen 10000"), and the score formatted to a configurable
+precision (default three decimals). A score-progression polyline links the panels, and SMIL
+`<animate>` elements pulse each panel's background colour in sequence so the eye is led from the
+first generation through to the last. Output is byte-deterministic for identical inputs — no
+external dependencies are added.
+
+```ts
+import { loadSnapshots } from "../common/evolution_snapshot.ts";
+import { renderEvolutionProgressSvg } from "../common/evolution_progress_svg.ts";
+
+const snaps = loadSnapshots(".synthetic-xor/snapshots");
+const svg = renderEvolutionProgressSvg(snaps, {
+  caption: {
+    finalScore: snaps[snaps.length - 1].score,
+    totalGenerations: 10000,
+    wallClockMs: 65_000,
+  },
+});
+await Deno.writeTextFile(".synthetic-xor/evolution_progress.svg", svg);
+```
+
 ## 📂 Project Structure
 
 ```
@@ -146,6 +173,8 @@ common/
   evolution_chart_test.ts          — Unit tests for the evolution chart renderer
   evolution_snapshot.ts            — Capture creature state at checkpoint generations
   evolution_snapshot_test.ts       — Unit tests for the evolution snapshot helper
+  evolution_progress_svg.ts        — Multi-panel animated SVG strip rendered from snapshots
+  evolution_progress_svg_test.ts   — Unit tests for the evolution-progress renderer
 
 crossover/
   crossover_example.ts             — Example: breed two creatures (crossover)

--- a/common/evolution_progress_svg.ts
+++ b/common/evolution_progress_svg.ts
@@ -1,0 +1,491 @@
+/**
+ * Multi-panel evolution-progress SVG renderer.
+ *
+ * Consumes the snapshots produced by `common/evolution_snapshot.ts` and
+ * emits a single horizontal strip of panels — one per snapshot generation
+ * — visualising how the network and its score evolved from the first
+ * captured generation through to the last.
+ *
+ * Each panel contains:
+ *
+ *   - a small network topology diagram (inputs → hidden → outputs),
+ *   - the generation label (e.g. "Gen 1", "Gen 10000"),
+ *   - the score for that snapshot, formatted to a documented precision.
+ *
+ * A score progression polyline is drawn across the bottom of the strip,
+ * linking all panels. An optional caption summarises the run (final
+ * score, total generations, wall-clock time). SMIL `<animate>` elements
+ * pulse each panel's background in sequence so the eye is led from the
+ * first generation through to the last.
+ *
+ * The renderer is pure string emission — no DOM, no extra dependencies —
+ * and is byte-deterministic for identical inputs.
+ */
+
+import type { Snapshot } from "./evolution_snapshot.ts";
+
+/** Snapshot input shape — matches `Snapshot` from `evolution_snapshot.ts`. */
+export type EvolutionProgressSnapshot = Snapshot;
+
+/** Optional caption fields summarising the run. */
+export interface EvolutionCaption {
+  /** Final/best score reached during the run. */
+  finalScore?: number;
+  /** Total generations evolved (typically the highest checkpoint). */
+  totalGenerations?: number;
+  /** Wall-clock time in milliseconds. Rendered as seconds or minutes. */
+  wallClockMs?: number;
+  /** Optional free-form text appended after the structured fields. */
+  text?: string;
+}
+
+/** Options controlling {@link renderEvolutionProgressSvg}. */
+export interface RenderEvolutionProgressOptions {
+  /** Width of an individual panel in user units. Default 200. */
+  panelWidth?: number;
+  /** Height of the topology + label area inside a panel. Default 200. */
+  panelHeight?: number;
+  /** Height reserved for the score-progression line strip. Default 100. */
+  progressionHeight?: number;
+  /** Number of decimals used when formatting score values. Default 3. */
+  scorePrecision?: number;
+  /** Title rendered at the top of the SVG. Default "Evolution Progress". */
+  title?: string;
+  /** Optional caption overlay summarising the run. */
+  caption?: EvolutionCaption;
+  /** Per-panel pulse duration in seconds. Default 0.6. */
+  pulseSeconds?: number;
+}
+
+const DEFAULT_PANEL_WIDTH = 200;
+const DEFAULT_PANEL_HEIGHT = 200;
+const DEFAULT_PROGRESSION_HEIGHT = 100;
+const DEFAULT_SCORE_PRECISION = 3;
+const DEFAULT_PULSE_SECONDS = 0.6;
+const TITLE_HEIGHT = 36;
+const CAPTION_HEIGHT = 40;
+
+const NEURON_COLOURS = {
+  input: "#4a90d9",
+  hidden: "#bd10e0",
+  output: "#16a085",
+  constant: "#888888",
+} as const;
+
+const PANEL_BG = "#ffffff";
+const STRIP_BG = "#fafafa";
+const PROGRESSION_COLOUR = "#1f77b4";
+const SYNAPSE_POSITIVE = "#27ae60";
+const SYNAPSE_NEGATIVE = "#e74c3c";
+
+/**
+ * Render snapshots as a single horizontal multi-panel SVG string.
+ *
+ * Throws if `snapshots` is empty.
+ */
+export function renderEvolutionProgressSvg(
+  snapshots: readonly EvolutionProgressSnapshot[],
+  options: RenderEvolutionProgressOptions = {},
+): string {
+  if (snapshots.length === 0) {
+    throw new Error("renderEvolutionProgressSvg requires at least one snapshot");
+  }
+
+  const panelWidth = options.panelWidth ?? DEFAULT_PANEL_WIDTH;
+  const panelHeight = options.panelHeight ?? DEFAULT_PANEL_HEIGHT;
+  const progressionHeight = options.progressionHeight ?? DEFAULT_PROGRESSION_HEIGHT;
+  const scorePrecision = options.scorePrecision ?? DEFAULT_SCORE_PRECISION;
+  const title = options.title ?? "Evolution Progress";
+  const pulseSeconds = options.pulseSeconds ?? DEFAULT_PULSE_SECONDS;
+  const hasCaption = options.caption !== undefined;
+
+  const totalWidth = panelWidth * snapshots.length;
+  const totalHeight = TITLE_HEIGHT + panelHeight + progressionHeight +
+    (hasCaption ? CAPTION_HEIGHT : 0);
+
+  const scoreMin = Math.min(...snapshots.map((s) => s.score));
+  const scoreMax = Math.max(...snapshots.map((s) => s.score));
+
+  const lines: string[] = [];
+  lines.push(
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${totalWidth} ${totalHeight}" ` +
+      `width="${totalWidth}" height="${totalHeight}" role="img" ` +
+      `aria-label="${escapeAttr(title)} multi-panel strip">`,
+    `  <title>${escapeText(title)}</title>`,
+    `  <rect width="${totalWidth}" height="${totalHeight}" fill="${STRIP_BG}"/>`,
+    `  <text x="${fmt(totalWidth / 2)}" y="22" text-anchor="middle" ` +
+      `font-family="sans-serif" font-size="16" font-weight="bold" fill="#222">` +
+      escapeText(title) + `</text>`,
+  );
+
+  // Per-panel rendering.
+  const totalPulseDuration = snapshots.length * pulseSeconds;
+  for (let i = 0; i < snapshots.length; i++) {
+    const x = i * panelWidth;
+    lines.push(
+      renderPanel(
+        snapshots[i],
+        x,
+        TITLE_HEIGHT,
+        panelWidth,
+        panelHeight,
+        scorePrecision,
+        i,
+        pulseSeconds,
+        totalPulseDuration,
+      ),
+    );
+  }
+
+  // Score progression polyline across the bottom of the strip.
+  lines.push(
+    renderScoreProgression(
+      snapshots,
+      panelWidth,
+      TITLE_HEIGHT + panelHeight,
+      progressionHeight,
+      scoreMin,
+      scoreMax,
+      scorePrecision,
+    ),
+  );
+
+  if (hasCaption) {
+    lines.push(
+      renderCaption(
+        options.caption!,
+        totalWidth,
+        TITLE_HEIGHT + panelHeight + progressionHeight,
+        CAPTION_HEIGHT,
+        scorePrecision,
+      ),
+    );
+  }
+
+  lines.push("</svg>", "");
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Panel rendering
+// ---------------------------------------------------------------------------
+
+function renderPanel(
+  snap: EvolutionProgressSnapshot,
+  panelX: number,
+  panelY: number,
+  panelW: number,
+  panelH: number,
+  scorePrecision: number,
+  index: number,
+  pulseSeconds: number,
+  totalPulseDuration: number,
+): string {
+  const inset = 6;
+  const innerX = panelX + inset;
+  const innerY = panelY + inset;
+  const innerW = panelW - inset * 2;
+  const innerH = panelH - inset * 2;
+
+  // SMIL <animate> sequencing — each panel pulses in turn. begin offsets
+  // by index * pulseSeconds; the cycle restarts after totalPulseDuration.
+  const begin = (index * pulseSeconds).toFixed(2);
+  const dur = pulseSeconds.toFixed(2);
+  const cycle = totalPulseDuration.toFixed(2);
+
+  const out: string[] = [];
+  out.push(
+    `  <g class="panel" data-generation="${snap.generation}" data-index="${index}">`,
+    `    <rect x="${fmt(innerX)}" y="${fmt(innerY)}" width="${fmt(innerW)}" ` +
+      `height="${fmt(innerH)}" fill="${PANEL_BG}" stroke="#cccccc" stroke-width="1" rx="4">`,
+    `      <animate attributeName="fill" values="${PANEL_BG};#fff7c2;${PANEL_BG}" ` +
+      `begin="${begin}s" dur="${dur}s" repeatCount="indefinite" ` +
+      `repeatDur="${cycle}s"/>`,
+    `    </rect>`,
+  );
+
+  // Generation label and score.
+  out.push(
+    `    <text x="${fmt(innerX + innerW / 2)}" y="${fmt(innerY + 16)}" ` +
+      `text-anchor="middle" font-family="sans-serif" font-size="12" ` +
+      `font-weight="bold" fill="#222">Gen ${snap.generation}</text>`,
+    `    <text x="${fmt(innerX + innerW / 2)}" y="${fmt(innerY + innerH - 8)}" ` +
+      `text-anchor="middle" font-family="sans-serif" font-size="11" fill="#555">` +
+      `score ${escapeText(formatScore(snap.score, scorePrecision))}</text>`,
+  );
+
+  // Topology drawing area.
+  const topoTop = innerY + 22;
+  const topoBottom = innerY + innerH - 22;
+  out.push(renderTopology(snap.creature, innerX + 4, topoTop, innerW - 8, topoBottom - topoTop));
+
+  // Index label below the generation, helps screen readers and stable
+  // ordering — and feeds the assertion about `<g class="panel">` count.
+  out.push(`  </g>`);
+  return out.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Topology rendering — defensive against creature JSON shape variation
+// ---------------------------------------------------------------------------
+
+interface NeuronLike {
+  type: "input" | "hidden" | "output" | "constant";
+}
+
+interface SynapseLike {
+  from: number;
+  to: number;
+  weight: number;
+}
+
+/** Coerce arbitrary creature JSON to neurons + synapses arrays. */
+function extractTopology(creature: unknown): {
+  neurons: NeuronLike[];
+  synapses: SynapseLike[];
+} {
+  if (creature === null || typeof creature !== "object") {
+    return { neurons: [], synapses: [] };
+  }
+  const obj = creature as Record<string, unknown>;
+  const rawNeurons = (obj.neurons ?? obj.nodes) as unknown;
+  const rawSynapses = (obj.synapses ?? obj.connections) as unknown;
+
+  const neurons: NeuronLike[] = [];
+  if (Array.isArray(rawNeurons)) {
+    for (const n of rawNeurons) {
+      if (n && typeof n === "object") {
+        const t = (n as Record<string, unknown>).type;
+        const type = (t === "input" || t === "hidden" || t === "output" || t === "constant")
+          ? t
+          : "hidden";
+        neurons.push({ type });
+      }
+    }
+  }
+
+  const synapses: SynapseLike[] = [];
+  if (Array.isArray(rawSynapses)) {
+    for (const s of rawSynapses) {
+      if (s && typeof s === "object") {
+        const so = s as Record<string, unknown>;
+        const from = typeof so.from === "number" ? so.from : -1;
+        const to = typeof so.to === "number" ? so.to : -1;
+        const weight = typeof so.weight === "number" ? so.weight : 0;
+        if (from >= 0 && to >= 0) synapses.push({ from, to, weight });
+      }
+    }
+  }
+
+  return { neurons, synapses };
+}
+
+function renderTopology(
+  creature: unknown,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+): string {
+  const { neurons, synapses } = extractTopology(creature);
+  if (neurons.length === 0) {
+    return `    <text x="${fmt(x + w / 2)}" y="${fmt(y + h / 2)}" ` +
+      `text-anchor="middle" font-family="sans-serif" font-size="10" fill="#999">` +
+      `(no topology)</text>`;
+  }
+
+  // Bucket neurons by layer.
+  const inputs: number[] = [];
+  const hidden: number[] = [];
+  const outputs: number[] = [];
+  for (let i = 0; i < neurons.length; i++) {
+    if (neurons[i].type === "input") inputs.push(i);
+    else if (neurons[i].type === "output") outputs.push(i);
+    else hidden.push(i); // hidden + constant fold to the middle column
+  }
+
+  // Three columns: inputs (left), hidden (middle), outputs (right).
+  const colXs = [x + 12, x + w / 2, x + w - 12];
+
+  const positions = new Map<number, { x: number; y: number }>();
+  layoutColumn(positions, inputs, colXs[0], y + 4, h - 8);
+  layoutColumn(positions, hidden, colXs[1], y + 4, h - 8);
+  layoutColumn(positions, outputs, colXs[2], y + 4, h - 8);
+
+  const out: string[] = [];
+
+  // Synapses behind nodes.
+  for (const s of synapses) {
+    const a = positions.get(s.from);
+    const b = positions.get(s.to);
+    if (!a || !b) continue;
+    const colour = s.weight >= 0 ? SYNAPSE_POSITIVE : SYNAPSE_NEGATIVE;
+    out.push(
+      `    <line x1="${fmt(a.x)}" y1="${fmt(a.y)}" x2="${fmt(b.x)}" y2="${fmt(b.y)}" ` +
+        `stroke="${colour}" stroke-width="0.8" stroke-opacity="0.7"/>`,
+    );
+  }
+
+  // Nodes.
+  for (let i = 0; i < neurons.length; i++) {
+    const p = positions.get(i);
+    if (!p) continue;
+    const fill = NEURON_COLOURS[neurons[i].type] ?? NEURON_COLOURS.hidden;
+    out.push(
+      `    <circle cx="${fmt(p.x)}" cy="${fmt(p.y)}" r="3" fill="${fill}" ` +
+        `stroke="#222" stroke-width="0.5"/>`,
+    );
+  }
+
+  return out.join("\n");
+}
+
+function layoutColumn(
+  positions: Map<number, { x: number; y: number }>,
+  indices: readonly number[],
+  colX: number,
+  topY: number,
+  height: number,
+): void {
+  if (indices.length === 0) return;
+  if (indices.length === 1) {
+    positions.set(indices[0], { x: colX, y: topY + height / 2 });
+    return;
+  }
+  for (let i = 0; i < indices.length; i++) {
+    const t = i / (indices.length - 1);
+    positions.set(indices[i], { x: colX, y: topY + t * height });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Score progression
+// ---------------------------------------------------------------------------
+
+function renderScoreProgression(
+  snapshots: readonly EvolutionProgressSnapshot[],
+  panelWidth: number,
+  topY: number,
+  height: number,
+  scoreMin: number,
+  scoreMax: number,
+  scorePrecision: number,
+): string {
+  // Map each snapshot to the centre of its panel on the X axis.
+  const padTop = 14;
+  const padBottom = 14;
+  const innerTop = topY + padTop;
+  const innerHeight = Math.max(1, height - padTop - padBottom);
+
+  const span = scoreMax - scoreMin;
+  const yFor = (score: number) => {
+    if (span === 0) return innerTop + innerHeight / 2;
+    // Higher score → smaller y (top of strip).
+    return innerTop + (1 - (score - scoreMin) / span) * innerHeight;
+  };
+
+  const points = snapshots.map((s, i) => {
+    const x = i * panelWidth + panelWidth / 2;
+    return `${fmt(x)},${fmt(yFor(s.score))}`;
+  }).join(" ");
+
+  const out: string[] = [];
+  out.push(
+    `  <g class="progression" data-min="${formatScore(scoreMin, scorePrecision)}" ` +
+      `data-max="${formatScore(scoreMax, scorePrecision)}">`,
+    `    <rect x="0" y="${fmt(topY)}" width="${fmt(snapshots.length * panelWidth)}" ` +
+      `height="${fmt(height)}" fill="#f4f4f4"/>`,
+    `    <polyline class="score-progression" fill="none" stroke="${PROGRESSION_COLOUR}" ` +
+      `stroke-width="2" points="${points}"/>`,
+  );
+  for (const s of snapshots) {
+    const i = snapshots.indexOf(s);
+    const x = i * panelWidth + panelWidth / 2;
+    out.push(
+      `    <circle cx="${fmt(x)}" cy="${fmt(yFor(s.score))}" r="3" ` +
+        `fill="${PROGRESSION_COLOUR}"/>`,
+    );
+  }
+  // Min/max score labels at the strip edges.
+  out.push(
+    `    <text x="6" y="${fmt(topY + 12)}" font-family="sans-serif" font-size="10" fill="#555">` +
+      `max ${escapeText(formatScore(scoreMax, scorePrecision))}</text>`,
+    `    <text x="6" y="${fmt(topY + height - 4)}" font-family="sans-serif" ` +
+      `font-size="10" fill="#555">min ${escapeText(formatScore(scoreMin, scorePrecision))}</text>`,
+    `  </g>`,
+  );
+  return out.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Caption
+// ---------------------------------------------------------------------------
+
+function renderCaption(
+  caption: EvolutionCaption,
+  totalWidth: number,
+  topY: number,
+  height: number,
+  scorePrecision: number,
+): string {
+  const parts: string[] = [];
+  if (caption.finalScore !== undefined) {
+    parts.push(`final score ${formatScore(caption.finalScore, scorePrecision)}`);
+  }
+  if (caption.totalGenerations !== undefined) {
+    parts.push(`${caption.totalGenerations} generations`);
+  }
+  if (caption.wallClockMs !== undefined) {
+    parts.push(formatDuration(caption.wallClockMs));
+  }
+  if (caption.text) {
+    parts.push(caption.text);
+  }
+  const text = parts.join(" • ") || " ";
+
+  return [
+    `  <g class="caption">`,
+    `    <rect x="0" y="${fmt(topY)}" width="${fmt(totalWidth)}" height="${fmt(height)}" ` +
+    `fill="#222222"/>`,
+    `    <text x="${fmt(totalWidth / 2)}" y="${fmt(topY + height / 2 + 4)}" ` +
+    `text-anchor="middle" font-family="sans-serif" font-size="12" fill="#ffffff">` +
+    escapeText(text) + `</text>`,
+    `  </g>`,
+  ].join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Formatting helpers
+// ---------------------------------------------------------------------------
+
+function formatScore(v: number, precision: number): string {
+  if (!Number.isFinite(v)) return "0";
+  const factor = Math.pow(10, precision);
+  return (Math.round(v * factor) / factor).toFixed(precision);
+}
+
+function formatDuration(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return "0s";
+  if (ms < 60_000) {
+    const secs = ms / 1000;
+    return `${(Math.round(secs * 10) / 10).toFixed(1)}s`;
+  }
+  const mins = ms / 60_000;
+  return `${(Math.round(mins * 10) / 10).toFixed(1)}min`;
+}
+
+function fmt(v: number): string {
+  if (!Number.isFinite(v)) return "0";
+  return (Math.round(v * 100) / 100).toString();
+}
+
+function escapeText(s: string): string {
+  return s
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+function escapeAttr(s: string): string {
+  return escapeText(s).replaceAll('"', "&quot;");
+}

--- a/common/evolution_progress_svg_test.ts
+++ b/common/evolution_progress_svg_test.ts
@@ -1,0 +1,197 @@
+/**
+ * Unit tests for the multi-panel evolution-progress SVG renderer.
+ *
+ * "What" tests only — they verify observable output of
+ * `renderEvolutionProgressSvg` (panel groups, generation labels, score
+ * progression line, deterministic byte-identical output) without
+ * inspecting how the renderer builds its strings.
+ */
+
+import { assert, assertEquals, assertStringIncludes, assertThrows } from "@std/assert";
+
+import {
+  type EvolutionProgressSnapshot,
+  renderEvolutionProgressSvg,
+} from "./evolution_progress_svg.ts";
+
+function makeSnapshot(
+  generation: number,
+  score: number,
+): EvolutionProgressSnapshot {
+  return {
+    generation,
+    score,
+    creature: {
+      neurons: [
+        { type: "input", uuid: `in-${generation}-0`, index: 0 },
+        { type: "input", uuid: `in-${generation}-1`, index: 1 },
+        { type: "hidden", uuid: `hid-${generation}-0`, index: 2 },
+        { type: "output", uuid: `out-${generation}-0`, index: 3 },
+      ],
+      synapses: [
+        { from: 0, to: 2, weight: 0.5 },
+        { from: 1, to: 2, weight: -0.3 },
+        { from: 2, to: 3, weight: 0.8 },
+      ],
+      input: 2,
+      output: 1,
+    },
+  };
+}
+
+Deno.test("renderEvolutionProgressSvg: happy path emits one panel per snapshot with generation labels", () => {
+  const snapshots = [
+    makeSnapshot(1, 0.10),
+    makeSnapshot(10, 0.55),
+    makeSnapshot(10000, 0.97),
+  ];
+  const svg = renderEvolutionProgressSvg(snapshots);
+
+  // Well-formed root element.
+  assertStringIncludes(svg, "<svg");
+  assertStringIncludes(svg, "</svg>");
+
+  // Three panel groups.
+  const panelMatches = svg.match(/<g class="panel"/g) ?? [];
+  assertEquals(panelMatches.length, 3, "expected three panel groups");
+
+  // Each generation label appears verbatim.
+  assertStringIncludes(svg, "Gen 1");
+  assertStringIncludes(svg, "Gen 10");
+  assertStringIncludes(svg, "Gen 10000");
+
+  // Score progression polyline is present.
+  assertStringIncludes(svg, 'class="score-progression"');
+});
+
+Deno.test("renderEvolutionProgressSvg: empty snapshot list raises a clear error", () => {
+  assertThrows(
+    () => renderEvolutionProgressSvg([]),
+    Error,
+    "at least one snapshot",
+  );
+});
+
+Deno.test("renderEvolutionProgressSvg: score progression polyline endpoints match first and last scores", () => {
+  const snapshots = [
+    makeSnapshot(1, 0.20),
+    makeSnapshot(100, 0.50),
+    makeSnapshot(10000, 0.90),
+  ];
+  const svg = renderEvolutionProgressSvg(snapshots);
+
+  // Pull the polyline points out of the score-progression group.
+  const match = svg.match(
+    /<polyline class="score-progression"[^>]*points="([^"]+)"/,
+  );
+  assert(match, "score-progression polyline must be present with points attribute");
+  const pts = match[1].trim().split(/\s+/).map((p) => {
+    const [x, y] = p.split(",").map(Number);
+    return { x, y };
+  });
+  assertEquals(pts.length, snapshots.length, "one point per snapshot");
+
+  // The Y axis is inverted (higher score → smaller y). The endpoint Y
+  // values must reflect the first/last scores: lowest score yields the
+  // largest y, highest score yields the smallest y.
+  const ys = pts.map((p) => p.y);
+  const maxY = Math.max(...ys);
+  const minY = Math.min(...ys);
+
+  // First snapshot has the lowest score, so its y should equal maxY.
+  assert(
+    Math.abs(pts[0].y - maxY) < 0.5,
+    `first endpoint y (${pts[0].y}) should match max y (${maxY}) within rounding tolerance`,
+  );
+  // Last snapshot has the highest score, so its y should equal minY.
+  assert(
+    Math.abs(pts[pts.length - 1].y - minY) < 0.5,
+    `last endpoint y (${
+      pts[pts.length - 1].y
+    }) should match min y (${minY}) within rounding tolerance`,
+  );
+});
+
+Deno.test("renderEvolutionProgressSvg: caption overlay summarises the run when supplied", () => {
+  const snapshots = [
+    makeSnapshot(1, 0.10),
+    makeSnapshot(10000, 0.90),
+  ];
+  const svg = renderEvolutionProgressSvg(snapshots, {
+    caption: {
+      finalScore: 0.90,
+      totalGenerations: 10000,
+      wallClockMs: 65_000,
+    },
+  });
+
+  assertStringIncludes(svg, 'class="caption"');
+  assertStringIncludes(svg, "10000");
+  // Wall-clock time formatted as either seconds or minutes — ensure some
+  // human-readable duration appears.
+  assert(
+    /\d+(\.\d+)?\s?(s|min|sec)/.test(svg),
+    "caption should include a human-readable wall-clock duration",
+  );
+});
+
+Deno.test("renderEvolutionProgressSvg: SMIL <animate> sequences panel highlights", () => {
+  const snapshots = [
+    makeSnapshot(1, 0.10),
+    makeSnapshot(10, 0.50),
+    makeSnapshot(10000, 0.90),
+  ];
+  const svg = renderEvolutionProgressSvg(snapshots);
+
+  const animateMatches = svg.match(/<animate /g) ?? [];
+  // One pulse per panel.
+  assert(
+    animateMatches.length >= snapshots.length,
+    `expected at least ${snapshots.length} <animate> elements, got ${animateMatches.length}`,
+  );
+});
+
+Deno.test("renderEvolutionProgressSvg: deterministic — identical input yields byte-identical SVG", () => {
+  const snapshots = [
+    makeSnapshot(1, 0.11),
+    makeSnapshot(100, 0.33),
+    makeSnapshot(10000, 0.99),
+  ];
+  const a = renderEvolutionProgressSvg(snapshots, {
+    caption: { finalScore: 0.99, totalGenerations: 10000, wallClockMs: 1234 },
+  });
+  const b = renderEvolutionProgressSvg(snapshots, {
+    caption: { finalScore: 0.99, totalGenerations: 10000, wallClockMs: 1234 },
+  });
+  assertEquals(a, b);
+});
+
+Deno.test("renderEvolutionProgressSvg: handles creature JSON with `nodes`/`connections` aliases", () => {
+  const snapshots: EvolutionProgressSnapshot[] = [
+    {
+      generation: 1,
+      score: 0.1,
+      creature: {
+        nodes: [
+          { type: "input" },
+          { type: "hidden" },
+          { type: "output" },
+        ],
+        connections: [
+          { from: 0, to: 1, weight: 0.4 },
+          { from: 1, to: 2, weight: 0.6 },
+        ],
+      },
+    },
+    {
+      generation: 10,
+      score: 0.5,
+      creature: { nodes: [], connections: [] },
+    },
+  ];
+
+  const svg = renderEvolutionProgressSvg(snapshots);
+  assertStringIncludes(svg, "Gen 1");
+  assertStringIncludes(svg, "Gen 10");
+  assert(!svg.includes("NaN"), "SVG must not contain NaN");
+});

--- a/docs/pr-summary-94.md
+++ b/docs/pr-summary-94.md
@@ -1,0 +1,55 @@
+# PR Summary — Issue #94
+
+## Summary
+
+Adds `common/evolution_progress_svg.ts`, a shared multi-panel animated SVG renderer that consumes
+`Snapshot[]` (from `common/evolution_snapshot.ts`) and emits a horizontal strip — one panel per
+snapshot — visualising how the network and its score evolved from the first checkpoint generation
+through to the last. Each panel renders a small network topology diagram (inputs → hidden →
+outputs), a generation label (e.g. "Gen 1", "Gen 10000"), and the score formatted to a configurable
+precision. A score-progression polyline links the panels, an optional caption summarises the run
+(final score, total generations, wall-clock time), and SMIL `<animate>` elements pulse each panel's
+background in sequence so the eye is led from gen 1 → gen 10000. Output is byte-deterministic for
+identical inputs and adds no third-party dependencies. Closes #94.
+
+## Evidence
+
+This is a backend/CLI change with no web UI to screenshot. Evidence:
+
+- **Validation**: the rendered SVG passes `xmllint --noout` (well-formed XML).
+- **Unit tests**: seven "what" tests in `common/evolution_progress_svg_test.ts` cover the four
+  acceptance-criteria cases plus three additional scenarios (caption overlay, SMIL `<animate>`
+  sequencing, defensive handling of `nodes`/`connections` aliases). The full suite of 575 tests
+  passes under `deno test`.
+- **Quality gate**: `deno fmt --check`, `deno lint`, and `deno check **/*.ts` all pass.
+
+```mermaid
+flowchart LR
+    SNAPS["snapshots[]<br/>(gen 1, 10, 100, 1000, 10000)"]
+    PANEL["render panel per snapshot<br/>(topology + score + label)"]
+    LINE["overlay score progression line"]
+    CAPT["render caption"]
+    SVG["📐 evolution_progress.svg"]
+
+    SNAPS --> PANEL --> LINE --> CAPT --> SVG
+```
+
+## Test Plan
+
+Tests added in `common/evolution_progress_svg_test.ts`:
+
+- `happy path emits one panel per snapshot with generation labels` — three fixture snapshots produce
+  three `<g class="panel">` groups and the expected "Gen N" labels.
+- `empty snapshot list raises a clear error` — the renderer throws an `Error` mentioning "at least
+  one snapshot".
+- `score progression polyline endpoints match first and last scores` — parses the polyline `points`
+  attribute and asserts that the endpoints match the min/max Y values within rounding tolerance.
+- `caption overlay summarises the run when supplied` — caption fields for final score, total
+  generations, and wall-clock time appear in the rendered output.
+- `SMIL <animate> sequences panel highlights` — at least one `<animate>` element per panel.
+- `deterministic — identical input yields byte-identical SVG` — two renders with the same input
+  produce byte-identical strings.
+- `handles creature JSON with 'nodes'/'connections' aliases` — the renderer accepts both the
+  `neurons`/`synapses` and `nodes`/`connections` shapes without producing `NaN`.
+
+Documentation updated in `AGENTS.md` under "📦 Shared Utilities" with a usage example.


### PR DESCRIPTION
# PR Summary — Issue #94

## Summary

Adds `common/evolution_progress_svg.ts`, a shared multi-panel animated SVG renderer that consumes
`Snapshot[]` (from `common/evolution_snapshot.ts`) and emits a horizontal strip — one panel per
snapshot — visualising how the network and its score evolved from the first checkpoint generation
through to the last. Each panel renders a small network topology diagram (inputs → hidden →
outputs), a generation label (e.g. "Gen 1", "Gen 10000"), and the score formatted to a configurable
precision. A score-progression polyline links the panels, an optional caption summarises the run
(final score, total generations, wall-clock time), and SMIL `<animate>` elements pulse each panel's
background in sequence so the eye is led from gen 1 → gen 10000. Output is byte-deterministic for
identical inputs and adds no third-party dependencies. Closes #94.

## Evidence

This is a backend/CLI change with no web UI to screenshot. Evidence:

- **Validation**: the rendered SVG passes `xmllint --noout` (well-formed XML).
- **Unit tests**: seven "what" tests in `common/evolution_progress_svg_test.ts` cover the four
  acceptance-criteria cases plus three additional scenarios (caption overlay, SMIL `<animate>`
  sequencing, defensive handling of `nodes`/`connections` aliases). The full suite of 575 tests
  passes under `deno test`.
- **Quality gate**: `deno fmt --check`, `deno lint`, and `deno check **/*.ts` all pass.

```mermaid
flowchart LR
    SNAPS["snapshots[]<br/>(gen 1, 10, 100, 1000, 10000)"]
    PANEL["render panel per snapshot<br/>(topology + score + label)"]
    LINE["overlay score progression line"]
    CAPT["render caption"]
    SVG["📐 evolution_progress.svg"]

    SNAPS --> PANEL --> LINE --> CAPT --> SVG
```

## Test Plan

Tests added in `common/evolution_progress_svg_test.ts`:

- `happy path emits one panel per snapshot with generation labels` — three fixture snapshots produce
  three `<g class="panel">` groups and the expected "Gen N" labels.
- `empty snapshot list raises a clear error` — the renderer throws an `Error` mentioning "at least
  one snapshot".
- `score progression polyline endpoints match first and last scores` — parses the polyline `points`
  attribute and asserts that the endpoints match the min/max Y values within rounding tolerance.
- `caption overlay summarises the run when supplied` — caption fields for final score, total
  generations, and wall-clock time appear in the rendered output.
- `SMIL <animate> sequences panel highlights` — at least one `<animate>` element per panel.
- `deterministic — identical input yields byte-identical SVG` — two renders with the same input
  produce byte-identical strings.
- `handles creature JSON with 'nodes'/'connections' aliases` — the renderer accepts both the
  `neurons`/`synapses` and `nodes`/`connections` shapes without producing `NaN`.

Documentation updated in `AGENTS.md` under "📦 Shared Utilities" with a usage example.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-94 -->