### PR TITLE
Add common/large_creature.ts shared utility for size-adaptive demos

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,7 @@ reinventing equivalent logic in a new example.
 | `common/evolution_chart.ts`        | Dual-axis SVG renderer for NEAT evolution histories.          |
 | `common/evolution_snapshot.ts`     | Capture creature state at checkpoint generations.             |
 | `common/evolution_progress_svg.ts` | Multi-panel animated SVG strip rendered from snapshots.       |
+| `common/large_creature.ts`         | Deterministic large creatures (~10k synapses) for size demos. |
 
 ### `common/data_cache.ts`
 
@@ -175,6 +176,8 @@ common/
   evolution_snapshot_test.ts       — Unit tests for the evolution snapshot helper
   evolution_progress_svg.ts        — Multi-panel animated SVG strip rendered from snapshots
   evolution_progress_svg_test.ts   — Unit tests for the evolution-progress renderer
+  large_creature.ts                — Deterministic large creature builder for size-adaptive demos
+  large_creature_test.ts           — Unit tests for the large creature builder
 
 crossover/
   crossover_example.ts             — Example: breed two creatures (crossover)

--- a/README.md
+++ b/README.md
@@ -196,6 +196,9 @@ The [`common/`](common/) module provides the building blocks every example reuse
   own seed so data sets are independent but deterministic.
 - 📁 **`working_dirs.ts`** — `setupWorkingDirs` creates `data/`, `creatures/`, and `output/`
   subdirectories under a per-example hidden root and clears `output/` on each run.
+- 🐘 **`large_creature.ts`** — `buildLargeCreature(opts)` constructs a deterministic creature with
+  configurable input/hidden/output counts and connection density (defaults yield ~10,000 synapses)
+  for size-adaptive demos.
 
 ```mermaid
 flowchart BT

--- a/common/large_creature.ts
+++ b/common/large_creature.ts
@@ -1,0 +1,194 @@
+/**
+ * Shared builder for large, deterministic NEAT creatures.
+ *
+ * Several planned demos (discovery-at-scale, synthetic synapse pruning,
+ * adaptive mutation, neuron pruning — see issue #75) need a consistent way
+ * to spawn realistically-sized creatures with hundreds of hidden neurons and
+ * thousands of synapses. `buildLargeCreature(opts)` returns such a creature
+ * deterministically — the same seed and options produce a byte-identical
+ * `Creature` across machines, because the construction is driven by the
+ * shared seeded PRNG in `common/deterministic_random.ts`.
+ *
+ * Defaults (8 inputs, 256 hidden, 4 outputs, 30% connection density) yield
+ * roughly 10,000 synapses — large enough to exercise size-adaptive
+ * behaviours but small enough to run on developer hardware.
+ *
+ * The connection topology is strictly feed-forward: every synapse goes from
+ * a lower-indexed neuron (inputs first, then hidden, then outputs) to a
+ * higher-indexed one. This guarantees the network is acyclic and that
+ * `Creature.validate()` succeeds without further fix-up.
+ */
+
+import { Creature, CreatureUtil } from "@stsoftware/neat-ai";
+
+import { createDeterministicRandom } from "./deterministic_random.ts";
+import {
+  asCreatureExport,
+  type LegacyCreatureJSON,
+  type LegacyNeuron,
+  type LegacySynapse,
+} from "./legacy_types.ts";
+
+/** Configuration for `buildLargeCreature`. All fields are optional. */
+export interface LargeCreatureOptions {
+  /** Number of input neurons. Default 8. */
+  inputs?: number;
+  /** Number of hidden neurons. Default 256. */
+  hidden?: number;
+  /** Number of output neurons. Default 4. */
+  outputs?: number;
+  /**
+   * Fraction of all possible feed-forward edges to populate, in [0, 1].
+   * Default 0.3 — yields roughly 10,000 synapses for the default neuron
+   * counts. Mandatory wiring (one incoming per hidden/output, one outgoing
+   * per hidden) is added regardless of density to keep the graph valid.
+   */
+  density?: number;
+  /** Seed for the deterministic PRNG. Default 1337. */
+  seed?: number;
+  /** Activation function for hidden neurons. Default "TANH". */
+  hiddenSquash?: string;
+  /** Activation function for output neurons. Default "LOGISTIC". */
+  outputSquash?: string;
+}
+
+/** Concrete defaults applied when an option is omitted. */
+export const DEFAULT_LARGE_CREATURE_OPTIONS = {
+  inputs: 8,
+  hidden: 256,
+  outputs: 4,
+  density: 0.3,
+  seed: 1337,
+  hiddenSquash: "TANH",
+  outputSquash: "LOGISTIC",
+} as const satisfies Required<LargeCreatureOptions>;
+
+/**
+ * Builds a deterministic large creature suitable for size-adaptive demos.
+ *
+ * @param opts Optional overrides for neuron counts, density, seed, and
+ *             activation functions. Any omitted field falls back to
+ *             {@link DEFAULT_LARGE_CREATURE_OPTIONS}.
+ * @returns A validated `Creature` whose serialised form is identical for
+ *          identical inputs.
+ * @throws If neuron counts are not all positive, or `density` is outside [0, 1].
+ */
+export function buildLargeCreature(opts: LargeCreatureOptions = {}): Creature {
+  const o = { ...DEFAULT_LARGE_CREATURE_OPTIONS, ...opts };
+
+  if (!Number.isInteger(o.inputs) || o.inputs < 1) {
+    throw new Error(`inputs must be a positive integer, got ${o.inputs}`);
+  }
+  if (!Number.isInteger(o.hidden) || o.hidden < 1) {
+    throw new Error(`hidden must be a positive integer, got ${o.hidden}`);
+  }
+  if (!Number.isInteger(o.outputs) || o.outputs < 1) {
+    throw new Error(`outputs must be a positive integer, got ${o.outputs}`);
+  }
+  if (!(o.density >= 0 && o.density <= 1)) {
+    throw new Error(`density must be in [0, 1], got ${o.density}`);
+  }
+
+  const rng = createDeterministicRandom(o.seed);
+  const totalNeurons = o.inputs + o.hidden + o.outputs;
+  const neurons: LegacyNeuron[] = [];
+
+  for (let i = 0; i < o.inputs; i++) {
+    neurons.push({
+      type: "input",
+      squash: "IDENTITY",
+      index: i,
+      uuid: `input-${i}`,
+    });
+  }
+  for (let i = 0; i < o.hidden; i++) {
+    neurons.push({
+      type: "hidden",
+      squash: o.hiddenSquash,
+      index: o.inputs + i,
+      bias: rng() * 0.4 - 0.2,
+      uuid: `hidden-${i}`,
+    });
+  }
+  for (let i = 0; i < o.outputs; i++) {
+    neurons.push({
+      type: "output",
+      squash: o.outputSquash,
+      index: o.inputs + o.hidden + i,
+      bias: rng() * 0.4 - 0.2,
+      uuid: `output-${i}`,
+    });
+  }
+
+  const synapses: LegacySynapse[] = [];
+  const seen = new Set<string>();
+  const addSynapse = (from: number, to: number): void => {
+    const key = `${from}->${to}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    synapses.push({ from, to, weight: rng() * 2 - 1 });
+  };
+
+  // Mandatory: every hidden neuron must have at least one incoming synapse
+  // from a lower-indexed neuron (input or earlier hidden).
+  for (let h = 0; h < o.hidden; h++) {
+    const to = o.inputs + h;
+    const from = Math.floor(rng() * to);
+    addSynapse(from, to);
+  }
+  // Mandatory: every hidden neuron must have at least one outgoing synapse
+  // to a higher-indexed neuron (later hidden or output).
+  for (let h = 0; h < o.hidden; h++) {
+    const from = o.inputs + h;
+    const remaining = totalNeurons - from - 1;
+    const to = from + 1 + Math.floor(rng() * remaining);
+    addSynapse(from, to);
+  }
+  // Mandatory: every output neuron must have at least one incoming synapse
+  // from a hidden neuron, so outputs are not stranded from the inputs.
+  for (let p = 0; p < o.outputs; p++) {
+    const to = o.inputs + o.hidden + p;
+    const from = o.inputs + Math.floor(rng() * o.hidden);
+    addSynapse(from, to);
+  }
+
+  // Build the list of all candidate feed-forward edges (i -> j with i < j,
+  // j must be a hidden or output neuron).
+  const candidates: Array<[number, number]> = [];
+  for (let i = 0; i < o.inputs + o.hidden; i++) {
+    const jStart = Math.max(i + 1, o.inputs);
+    for (let j = jStart; j < totalNeurons; j++) {
+      candidates.push([i, j]);
+    }
+  }
+
+  const target = Math.floor(candidates.length * o.density);
+
+  // Fisher-Yates shuffle of candidate indices using the same PRNG so the
+  // selection order is deterministic.
+  const order = candidates.map((_, k) => k);
+  for (let i = order.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    const tmp = order[i];
+    order[i] = order[j];
+    order[j] = tmp;
+  }
+
+  for (const idx of order) {
+    if (synapses.length >= target) break;
+    const [from, to] = candidates[idx];
+    addSynapse(from, to);
+  }
+
+  const json: LegacyCreatureJSON = {
+    neurons,
+    synapses,
+    input: o.inputs,
+    output: o.outputs,
+  };
+
+  const creature = Creature.fromJSON(asCreatureExport(json));
+  creature.validate();
+  CreatureUtil.makeUUID(creature);
+  return creature;
+}

--- a/common/large_creature_test.ts
+++ b/common/large_creature_test.ts
@@ -1,0 +1,114 @@
+/**
+ * Unit tests for the shared large-creature builder.
+ *
+ * These are "what" tests — they verify the builder produces creatures with
+ * the requested shape, that the same seed reproduces the same creature, and
+ * that the result validates and activates without producing non-finite
+ * outputs. No timing assertions are made (timing belongs in benchmarks).
+ */
+
+import { assert, assertEquals, assertThrows } from "@std/assert";
+
+import { buildLargeCreature, DEFAULT_LARGE_CREATURE_OPTIONS } from "./large_creature.ts";
+
+Deno.test("buildLargeCreature - same seed produces identical creatures", () => {
+  const a = buildLargeCreature({ seed: 42, inputs: 4, hidden: 16, outputs: 2 });
+  const b = buildLargeCreature({ seed: 42, inputs: 4, hidden: 16, outputs: 2 });
+  assertEquals(
+    JSON.stringify(a.exportJSON()),
+    JSON.stringify(b.exportJSON()),
+    "creatures built with the same seed and options must be byte-identical",
+  );
+});
+
+Deno.test("buildLargeCreature - different seeds produce different creatures", () => {
+  const a = buildLargeCreature({ seed: 1, inputs: 4, hidden: 16, outputs: 2 });
+  const b = buildLargeCreature({ seed: 2, inputs: 4, hidden: 16, outputs: 2 });
+  const aJson = JSON.stringify(a.exportJSON());
+  const bJson = JSON.stringify(b.exportJSON());
+  assert(aJson !== bJson, "different seeds should produce different creatures");
+});
+
+Deno.test("buildLargeCreature - neuron counts match requested options", () => {
+  const inputs = 5;
+  const hidden = 32;
+  const outputs = 3;
+  const c = buildLargeCreature({ seed: 7, inputs, hidden, outputs });
+  assertEquals(c.input, inputs, "input count");
+  assertEquals(c.output, outputs, "output count");
+  assertEquals(c.neurons.length, inputs + hidden + outputs, "total neuron count");
+});
+
+Deno.test("buildLargeCreature - synapse count grows with density", () => {
+  const opts = { seed: 11, inputs: 4, hidden: 16, outputs: 2 } as const;
+  const sparse = buildLargeCreature({ ...opts, density: 0.1 });
+  const dense = buildLargeCreature({ ...opts, density: 0.8 });
+  assert(
+    dense.synapses.length > sparse.synapses.length,
+    `expected higher density to add synapses (got ${sparse.synapses.length} vs ${dense.synapses.length})`,
+  );
+});
+
+Deno.test("buildLargeCreature - synapse count matches the density target", () => {
+  const inputs = 4;
+  const hidden = 16;
+  const outputs = 2;
+  const density = 0.5;
+  const c = buildLargeCreature({ seed: 23, inputs, hidden, outputs, density });
+
+  // Count of forward-only candidate edges from any neuron i to a higher-index
+  // hidden or output neuron.
+  let candidates = 0;
+  const total = inputs + hidden + outputs;
+  for (let i = 0; i < inputs + hidden; i++) {
+    for (let j = Math.max(i + 1, inputs); j < total; j++) {
+      candidates++;
+    }
+  }
+  const expected = Math.floor(candidates * density);
+  // Mandatory edges (one incoming per hidden, one incoming per output, one
+  // outgoing per hidden) may push the count above the bare density target,
+  // so the actual synapse count must be at least that target.
+  assert(
+    c.synapses.length >= expected,
+    `expected at least ${expected} synapses (density target), got ${c.synapses.length}`,
+  );
+});
+
+Deno.test("buildLargeCreature - produces finite output for a sample input", () => {
+  const inputs = 6;
+  const c = buildLargeCreature({ seed: 99, inputs, hidden: 32, outputs: 3 });
+  const sample = new Float32Array(inputs);
+  for (let i = 0; i < inputs; i++) sample[i] = (i + 1) * 0.1;
+
+  const out = c.activate(sample);
+  assertEquals(out.length, 3, "output array should match output neuron count");
+  for (const v of out) {
+    assert(Number.isFinite(v), `output value must be finite, got ${v}`);
+  }
+});
+
+Deno.test("buildLargeCreature - default options produce a large, valid creature", () => {
+  const c = buildLargeCreature();
+  const { inputs, hidden, outputs } = DEFAULT_LARGE_CREATURE_OPTIONS;
+  assertEquals(
+    c.neurons.length,
+    inputs + hidden + outputs,
+    "default neuron count",
+  );
+  // Defaults aim for ~10,000 synapses (parent issue #75 calls for size-adaptive demos).
+  assert(
+    c.synapses.length >= 8_000,
+    `expected default creature to have ~10k synapses, got ${c.synapses.length}`,
+  );
+  // Validation is invoked inside the builder; calling it again must remain a no-op.
+  c.validate();
+});
+
+Deno.test("buildLargeCreature - rejects invalid options", () => {
+  assertThrows(() => buildLargeCreature({ inputs: 0 }), Error);
+  assertThrows(() => buildLargeCreature({ hidden: 0 }), Error);
+  assertThrows(() => buildLargeCreature({ outputs: 0 }), Error);
+  assertThrows(() => buildLargeCreature({ density: -0.1 }), Error);
+  assertThrows(() => buildLargeCreature({ density: 1.5 }), Error);
+});

--- a/docs/pr-summary-83.md
+++ b/docs/pr-summary-83.md
@@ -1,20 +1,18 @@
 ## Summary
 
-Adds `common/large_creature.ts`, a shared utility that builds deterministic
-large creatures (~10,000 synapses with default options) for the size-adaptive
-demos planned in #75. The builder uses the existing
-`common/deterministic_random.ts` PRNG so the same seed and options produce a
-byte-identical `Creature` across machines.
+Adds `common/large_creature.ts`, a shared utility that builds deterministic large creatures (~10,000
+synapses with default options) for the size-adaptive demos planned in #75. The builder uses the
+existing `common/deterministic_random.ts` PRNG so the same seed and options produce a byte-identical
+`Creature` across machines.
 
 Closes #83.
 
 ## Evidence
 
-Backend/CLI change with no web interface to screenshot. `./quality.sh` passes
-end-to-end (lint, format, type-check, all unit tests including the new
-`common/large_creature_test.ts`, and every example program). The new tests
-verify determinism, neuron and synapse count assertions, validation, and that
-activation produces finite output for a sample input — no timing assertions.
+Backend/CLI change with no web interface to screenshot. `./quality.sh` passes end-to-end (lint,
+format, type-check, all unit tests including the new `common/large_creature_test.ts`, and every
+example program). The new tests verify determinism, neuron and synapse count assertions, validation,
+and that activation produces finite output for a sample input — no timing assertions.
 
 ```mermaid
 flowchart LR
@@ -28,18 +26,15 @@ flowchart LR
 
 Added `common/large_creature_test.ts` with eight tests:
 
-- `same seed produces identical creatures` — determinism via `JSON.stringify`
-  of `exportJSON()`.
+- `same seed produces identical creatures` — determinism via `JSON.stringify` of `exportJSON()`.
 - `different seeds produce different creatures`.
-- `neuron counts match requested options` — `input`, `output`, and total
-  neuron count match the supplied options.
-- `synapse count grows with density` — sparse vs dense densities yield more
-  synapses.
+- `neuron counts match requested options` — `input`, `output`, and total neuron count match the
+  supplied options.
+- `synapse count grows with density` — sparse vs dense densities yield more synapses.
 - `synapse count matches the density target` — synapse count is at least
   `floor(possibleEdges * density)`.
-- `produces finite output for a sample input` — `creature.activate(...)`
-  returns finite floats for every output.
-- `default options produce a large, valid creature` — defaults yield
-  ~10,000 synapses and re-validate cleanly.
-- `rejects invalid options` — non-positive neuron counts and out-of-range
-  density throw.
+- `produces finite output for a sample input` — `creature.activate(...)` returns finite floats for
+  every output.
+- `default options produce a large, valid creature` — defaults yield ~10,000 synapses and
+  re-validate cleanly.
+- `rejects invalid options` — non-positive neuron counts and out-of-range density throw.

--- a/docs/pr-summary-83.md
+++ b/docs/pr-summary-83.md
@@ -1,0 +1,45 @@
+## Summary
+
+Adds `common/large_creature.ts`, a shared utility that builds deterministic
+large creatures (~10,000 synapses with default options) for the size-adaptive
+demos planned in #75. The builder uses the existing
+`common/deterministic_random.ts` PRNG so the same seed and options produce a
+byte-identical `Creature` across machines.
+
+Closes #83.
+
+## Evidence
+
+Backend/CLI change with no web interface to screenshot. `./quality.sh` passes
+end-to-end (lint, format, type-check, all unit tests including the new
+`common/large_creature_test.ts`, and every example program). The new tests
+verify determinism, neuron and synapse count assertions, validation, and that
+activation produces finite output for a sample input — no timing assertions.
+
+```mermaid
+flowchart LR
+    LC[common/large_creature.ts] --> H1[Discovery-at-Scale]
+    LC --> H2[Synthetic Synapse]
+    LC --> S1[Adaptive Mutation]
+    LC --> S2[Neuron Pruning]
+```
+
+## Test Plan
+
+Added `common/large_creature_test.ts` with eight tests:
+
+- `same seed produces identical creatures` — determinism via `JSON.stringify`
+  of `exportJSON()`.
+- `different seeds produce different creatures`.
+- `neuron counts match requested options` — `input`, `output`, and total
+  neuron count match the supplied options.
+- `synapse count grows with density` — sparse vs dense densities yield more
+  synapses.
+- `synapse count matches the density target` — synapse count is at least
+  `floor(possibleEdges * density)`.
+- `produces finite output for a sample input` — `creature.activate(...)`
+  returns finite floats for every output.
+- `default options produce a large, valid creature` — defaults yield
+  ~10,000 synapses and re-validate cleanly.
+- `rejects invalid options` — non-positive neuron counts and out-of-range
+  density throw.


### PR DESCRIPTION
## Summary

Adds `common/large_creature.ts`, a shared utility that builds deterministic large creatures (~10,000 synapses with default options) for the size-adaptive demos planned in #75. The builder uses the existing `common/deterministic_random.ts` PRNG so the same seed and options produce a byte-identical `Creature` across machines.

Closes #83.

## Evidence

Backend/CLI change with no web interface to screenshot. `./quality.sh` passes end-to-end (lint, format, type-check, all unit tests including the new `common/large_creature_test.ts`, and every example program). The new tests verify determinism, neuron and synapse count assertions, validation, and that activation produces finite output for a sample input — no timing assertions.

```mermaid
flowchart LR
    LC[common/large_creature.ts] --> H1[Discovery-at-Scale]
    LC --> H2[Synthetic Synapse]
    LC --> S1[Adaptive Mutation]
    LC --> S2[Neuron Pruning]
```

## Test Plan

- [x] `same seed produces identical creatures` — determinism via `JSON.stringify` of `exportJSON()`.
- [x] `different seeds produce different creatures`.
- [x] `neuron counts match requested options` — `input`, `output`, and total neuron count.
- [x] `synapse count grows with density`.
- [x] `synapse count matches the density target` — at least `floor(possibleEdges * density)`.
- [x] `produces finite output for a sample input` — `creature.activate(...)` returns finite floats.
- [x] `default options produce a large, valid creature` — ~10,000 synapses, re-validates cleanly.
- [x] `rejects invalid options` — non-positive neuron counts and out-of-range density throw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)