### PR TITLE
Wire mountain_car to evolution chart (Issue #109)

### DIFF
--- a/docs/pr-summary-109.md
+++ b/docs/pr-summary-109.md
@@ -1,0 +1,47 @@
+## Summary
+
+Wire `mountain_car` to the shared evolution chart helper. The
+per-generation `GenerationInfo` callback now reports the champion
+creature's `neurons` and `synapses` counts alongside scores; the main
+runner collects those samples and renders a deterministic dual-axis
+chart at `docs/screenshots/mountain_car/evolution.svg`, embedded in
+`mountain_car/README.md` with descriptive alt-text. Closes #109.
+
+## Evidence
+
+CLI/example change — verified by running the example end-to-end and by
+the unit test added below.
+
+```mermaid
+flowchart LR
+    EVO["evolveMountainCarController"] -- onGeneration --> CB["{generation, score, neurons, synapses}"]
+    CB --> SAMPLES["EvolutionSample[]"]
+    SAMPLES --> CHART["renderEvolutionChartSVG"]
+    CHART --> SVG["docs/screenshots/<br/>mountain_car/evolution.svg"]
+    SVG --> README["mountain_car/README.md"]
+```
+
+Run output:
+
+```
+🧬 Evolving controller...
+   Gen   0  best=   310.0  mean=   -64.7  neurons=5  synapses=6
+
+✅ Solved after 1 generations (steps=138, score=310.00).
+🖼️  Wrote screenshot docs/screenshots/mountain_car.svg (139 frames captured)
+📈 Wrote evolution chart docs/screenshots/mountain_car/evolution.svg
+```
+
+`./quality.sh < /dev/null` passes cleanly: "All examples passed!".
+
+## Test Plan
+
+- Added `mountain_car/mountain_car_test.ts ::
+  evolveMountainCarController emits neurons and synapses on each
+  generation event` — asserts the new `GenerationInfo` shape and that
+  the linear genome reports `INPUT_COUNT + OUTPUT_COUNT` neurons and
+  `INPUT_COUNT * OUTPUT_COUNT` synapses on every event.
+- Existing reproducibility/solve tests continue to cover the evolver
+  itself; no behavioural change to scoring or selection.
+- `./quality.sh < /dev/null` — full suite green (lint, fmt, type-check,
+  unit tests, every example runner).

--- a/docs/screenshots/mountain_car/evolution.svg
+++ b/docs/screenshots/mountain_car/evolution.svg
@@ -1,0 +1,59 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" width="800" height="400" role="img" aria-label="Mountain Car — Evolution dual-axis chart">
+  <title>Mountain Car — Evolution</title>
+  <rect width="800" height="400" fill="#fafafa"/>
+  <text x="400" y="24" text-anchor="middle" font-family="sans-serif" font-size="16" font-weight="bold" fill="#222">Mountain Car — Evolution</text>
+  <rect x="70" y="40" width="660" height="300" fill="#ffffff" stroke="#333333" stroke-width="1"/>
+  <g class="x-axis" font-family="sans-serif" font-size="11" fill="#333333">
+    <line x1="400" y1="340" x2="400" y2="344" stroke="#333333" stroke-width="1"/>
+    <text x="400" y="358" text-anchor="middle">0</text>
+    <text x="400" y="376" text-anchor="middle" font-weight="bold">generation</text>
+  </g>
+  <g class="left-axis" font-family="sans-serif" font-size="11" fill="#1f77b4">
+    <line x1="66" y1="190" x2="70" y2="190" stroke="#1f77b4" stroke-width="1"/>
+    <text x="62" y="190" text-anchor="end" dominant-baseline="middle">310</text>
+    <text x="22" y="190" text-anchor="middle" dominant-baseline="middle" font-weight="bold" transform="rotate(-90 22 190)">best score</text>
+  </g>
+  <g class="right-axis" font-family="sans-serif" font-size="11" fill="#333333">
+    <line x1="730" y1="340" x2="734" y2="340" stroke="#333333" stroke-width="1"/>
+    <text x="738" y="340" text-anchor="start" dominant-baseline="middle">0</text>
+    <line x1="730" y1="290" x2="734" y2="290" stroke="#333333" stroke-width="1"/>
+    <text x="738" y="290" text-anchor="start" dominant-baseline="middle">1</text>
+    <line x1="730" y1="240" x2="734" y2="240" stroke="#333333" stroke-width="1"/>
+    <text x="738" y="240" text-anchor="start" dominant-baseline="middle">2</text>
+    <line x1="730" y1="190" x2="734" y2="190" stroke="#333333" stroke-width="1"/>
+    <text x="738" y="190" text-anchor="start" dominant-baseline="middle">3</text>
+    <line x1="730" y1="140" x2="734" y2="140" stroke="#333333" stroke-width="1"/>
+    <text x="738" y="140" text-anchor="start" dominant-baseline="middle">4</text>
+    <line x1="730" y1="90" x2="734" y2="90" stroke="#333333" stroke-width="1"/>
+    <text x="738" y="90" text-anchor="start" dominant-baseline="middle">5</text>
+    <line x1="730" y1="40" x2="734" y2="40" stroke="#333333" stroke-width="1"/>
+    <text x="738" y="40" text-anchor="start" dominant-baseline="middle">6</text>
+    <text x="778" y="190" text-anchor="middle" dominant-baseline="middle" font-weight="bold" transform="rotate(90 778 190)">neurons / synapses</text>
+  </g>
+  <g class="score-line">
+    <polyline fill="none" stroke="#1f77b4" stroke-width="1.5" points="400,190"/>
+    <circle class="score-point" cx="400" cy="190" r="1.8" fill="#1f77b4"/>
+  </g>
+  <g class="neurons-line">
+    <polyline fill="none" stroke="#2ca02c" stroke-width="1.5" points="400,90"/>
+    <circle class="neurons-point" cx="400" cy="90" r="1.8" fill="#2ca02c"/>
+  </g>
+  <g class="synapses-line">
+    <polyline fill="none" stroke="#d62728" stroke-width="1.5" points="400,40"/>
+    <circle class="synapses-point" cx="400" cy="40" r="1.8" fill="#d62728"/>
+  </g>
+  <g class="legend" font-family="sans-serif" font-size="11" fill="#222222">
+    <rect x="76" y="42" width="130" height="56" fill="#ffffff" fill-opacity="0.85" stroke="#cccccc" stroke-width="0.5"/>
+    <line x1="82" y1="52" x2="100" y2="52" stroke="#1f77b4" stroke-width="2"/>
+    <text x="106" y="56">best score</text>
+    <line x1="82" y1="68" x2="100" y2="68" stroke="#2ca02c" stroke-width="2"/>
+    <text x="106" y="72">neurons</text>
+    <line x1="82" y1="84" x2="100" y2="84" stroke="#d62728" stroke-width="2"/>
+    <text x="106" y="88">synapses</text>
+  </g>
+  <g class="final-annotation" font-family="sans-serif" font-size="12" fill="#222222">
+    <line x1="400" y1="190" x2="392" y2="178" stroke="#666666" stroke-width="0.8" stroke-dasharray="2,2"/>
+    <circle cx="400" cy="190" r="3.5" fill="#222222"/>
+    <text x="392" y="178" text-anchor="end">gen 0: 310, 5 neurons, 6 synapses</text>
+  </g>
+</svg>

--- a/mountain_car/README.md
+++ b/mountain_car/README.md
@@ -69,6 +69,12 @@ Artefacts:
 
 - `.synthetic-mountain-car/creatures/champion.json` – the fittest controller from the run
 - `docs/screenshots/mountain_car.svg` – an animated SVG showing the champion's drive up the hill
+- `docs/screenshots/mountain_car/evolution.svg` – dual-axis evolution chart plotting best score and
+  champion neuron / synapse counts against generation
+
+## 📈 Evolution Chart
+
+![Mountain-Car evolution chart — best score on the left axis with champion neuron and synapse counts on the right axis, plotted against generation](../docs/screenshots/mountain_car/evolution.svg)
 
 ## 🧠 Tacit Knowledge
 

--- a/mountain_car/mountain_car.ts
+++ b/mountain_car/mountain_car.ts
@@ -23,6 +23,7 @@ import { Creature, type CreatureExport, safeWriteJson } from "@stsoftware/neat-a
 import { createDeterministicRandom } from "../common/deterministic_random.ts";
 import { setupWorkingDirs } from "../common/working_dirs.ts";
 import { asCreatureExport, type LegacyCreatureJSON } from "../common/legacy_types.ts";
+import { type EvolutionSample, renderEvolutionChartSVG } from "../common/evolution_chart.ts";
 import {
   encodeState,
   initialState,
@@ -81,6 +82,10 @@ export interface GenerationInfo {
   generation: number;
   bestScore: number;
   meanScore: number;
+  /** Neuron count of the champion creature for this generation. */
+  neurons: number;
+  /** Synapse count of the champion creature for this generation. */
+  synapses: number;
 }
 
 /** Result of the evolutionary search. */
@@ -354,6 +359,8 @@ export function evolveMountainCarController(
       generation,
       bestScore: generationBest.score,
       meanScore,
+      neurons: generationBest.json.neurons.length,
+      synapses: generationBest.json.synapses.length,
     });
 
     if (bestSolved) {
@@ -394,6 +401,9 @@ export function evolveMountainCarController(
 /** Path to the SVG snapshot the runner emits for the README. */
 export const SCREENSHOT_PATH = "docs/screenshots/mountain_car.svg";
 
+/** Path to the per-generation evolution-chart SVG the runner emits. */
+export const EVOLUTION_CHART_PATH = "docs/screenshots/mountain_car/evolution.svg";
+
 if (import.meta.main) {
   const start = Date.now();
 
@@ -410,14 +420,17 @@ if (import.meta.main) {
   );
 
   console.log("\n🧬 Evolving controller...");
+  const evolutionSamples: EvolutionSample[] = [];
   const result = evolveMountainCarController({
     ...DEFAULT_EVOLVE_OPTIONS,
-    onGeneration: ({ generation, bestScore, meanScore }) => {
+    onGeneration: ({ generation, bestScore, meanScore, neurons, synapses }) => {
+      evolutionSamples.push({ generation, score: bestScore, neurons, synapses });
       if (generation % 5 === 0) {
         console.log(
           `   Gen ${generation.toString().padStart(3)}  best=${
             bestScore.toFixed(1).padStart(8)
-          }  mean=${meanScore.toFixed(1).padStart(8)}`,
+          }  mean=${meanScore.toFixed(1).padStart(8)}  ` +
+            `neurons=${neurons}  synapses=${synapses}`,
         );
       }
     },
@@ -442,6 +455,17 @@ if (import.meta.main) {
   ensureDirSync("docs/screenshots");
   await Deno.writeTextFile(SCREENSHOT_PATH, svg);
   console.log(`🖼️  Wrote screenshot ${SCREENSHOT_PATH} (${trace.length} frames captured)`);
+
+  // Render the per-generation evolution chart (score / neurons / synapses).
+  if (evolutionSamples.length > 0) {
+    const evolutionSvg = renderEvolutionChartSVG(evolutionSamples, {
+      title: "Mountain Car — Evolution",
+      scoreLabel: "best score",
+    });
+    ensureDirSync("docs/screenshots/mountain_car");
+    await Deno.writeTextFile(EVOLUTION_CHART_PATH, evolutionSvg);
+    console.log(`📈 Wrote evolution chart ${EVOLUTION_CHART_PATH}`);
+  }
 
   console.log(
     `\n🏁 Example completed in ${format(Date.now() - start, { ignoreZero: true })}`,

--- a/mountain_car/mountain_car_test.ts
+++ b/mountain_car/mountain_car_test.ts
@@ -21,6 +21,7 @@ import {
   decodeAction,
   DEFAULT_EVOLVE_OPTIONS,
   evolveMountainCarController,
+  type GenerationInfo,
   genesFromCreatureJSON,
   INPUT_COUNT,
   MAX_STEPS,
@@ -151,6 +152,31 @@ Deno.test(
     const aJson = JSON.stringify(a.champion.exportJSON());
     const bJson = JSON.stringify(b.champion.exportJSON());
     assertNotEquals(aJson, bJson, "different seeds should explore different genomes");
+  },
+);
+
+Deno.test(
+  "evolveMountainCarController emits neurons and synapses on each generation event",
+  () => {
+    // Issue #109: the per-generation event must include neuron and
+    // synapse counts so the runner can plot them on the evolution
+    // chart. The linear genome has INPUT_COUNT + OUTPUT_COUNT neurons
+    // and INPUT_COUNT * OUTPUT_COUNT synapses, both constant across the
+    // run since this example does not yet add structural mutation.
+    const events: GenerationInfo[] = [];
+    evolveMountainCarController({
+      ...DEFAULT_EVOLVE_OPTIONS,
+      maxGenerations: 3,
+      populationSize: 6,
+      onGeneration: (info) => events.push(info),
+    });
+    assertGreaterOrEqual(events.length, 1);
+    for (const info of events) {
+      assertEquals(typeof info.neurons, "number");
+      assertEquals(typeof info.synapses, "number");
+      assertEquals(info.neurons, INPUT_COUNT + OUTPUT_COUNT);
+      assertEquals(info.synapses, INPUT_COUNT * OUTPUT_COUNT);
+    }
   },
 );
 


### PR DESCRIPTION
## Summary

Wire `mountain_car` to the shared evolution chart helper. The
per-generation `GenerationInfo` callback now reports the champion
creature's `neurons` and `synapses` counts alongside scores; the main
runner collects those samples and renders a deterministic dual-axis
chart at `docs/screenshots/mountain_car/evolution.svg`, embedded in
`mountain_car/README.md` with descriptive alt-text. Closes #109.

## Evidence

CLI/example change — verified by running the example end-to-end and by
the unit test added below.

```mermaid
flowchart LR
    EVO["evolveMountainCarController"] -- onGeneration --> CB["{generation, score, neurons, synapses}"]
    CB --> SAMPLES["EvolutionSample[]"]
    SAMPLES --> CHART["renderEvolutionChartSVG"]
    CHART --> SVG["docs/screenshots/<br/>mountain_car/evolution.svg"]
    SVG --> README["mountain_car/README.md"]
```

Run output:

```
🧬 Evolving controller...
   Gen   0  best=   310.0  mean=   -64.7  neurons=5  synapses=6

✅ Solved after 1 generations (steps=138, score=310.00).
🖼️  Wrote screenshot docs/screenshots/mountain_car.svg (139 frames captured)
📈 Wrote evolution chart docs/screenshots/mountain_car/evolution.svg
```

`./quality.sh < /dev/null` passes cleanly: "All examples passed!".

## Test Plan

- Added `mountain_car/mountain_car_test.ts ::
  evolveMountainCarController emits neurons and synapses on each
  generation event` — asserts the new `GenerationInfo` shape and that
  the linear genome reports `INPUT_COUNT + OUTPUT_COUNT` neurons and
  `INPUT_COUNT * OUTPUT_COUNT` synapses on every event.
- Existing reproducibility/solve tests continue to cover the evolver
  itself; no behavioural change to scoring or selection.
- `./quality.sh < /dev/null` — full suite green (lint, fmt, type-check,
  unit tests, every example runner).



---

🤖 Processed by: stservice<!-- vibe-worker-issue-109 -->