### PR TITLE
Add adaptive mutation rate demo (size-driven topology vs weight shift) (Issue #86)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ walkthrough — the per-example README explains the workflow, options, and outpu
 | [🧠 Memetic Evolution](memetic_evolution/README.md)                   | Compare evolutions with and without seeding from an archive of the fittest creatures' weights.                                                                                                          | `./memetic_evolution/run.sh`    |
 | [🧬 Synthetic Synapse](synthetic_synapse/README.md)                   | Densify an evolved sparse creature with zero-weight synthetic synapses, train, then prune the unused edges.                                                                                             | `./synthetic_synapse/run.sh`    |
 | [✂️ Neuron Pruning](neuron_pruning/README.md)                         | Remove neurons whose activations don't vary, folding their bias contribution into downstream neighbours.                                                                                                | `./neuron_pruning/run.sh`       |
+| [🧬 Adaptive Mutation](adaptive_mutation/README.md)                   | Visualise how the mutation operator distribution shifts from topology to weights as a creature grows.                                                                                                   | `./adaptive_mutation/run.sh`    |
 | [💡 Suggest Improvements](suggest_improvements/README.md)             | Analyse the project and emit categorised improvement suggestions you can file as GitHub issues.                                                                                                         | `./suggest_improvements/run.sh` |
 | [🌱 Evolution Showcase](evolution_showcase/README.md) ⏳ long-running | Flagship long-form run: evolve for 10000 generations and render gen 1 / 10 / 100 / 1000 / 10000 side-by-side.                                                                                           | `./evolution_showcase/run.sh`   |
 
@@ -134,6 +135,18 @@ neurons greyed out and dashed; the synapses incident on those neurons are dimmed
 each pruned neuron's bias-fold contribution to its surviving downstream neighbours. A summary panel
 beside the topology lists pre/post neuron counts, pre/post held-out scores, and the per-neuron
 pruning report.
+
+### 🧬 Adaptive Mutation — topology share drops as creatures grow
+
+![Adaptive mutation rate — small vs large creature, two-panel line chart showing topology share collapsing toward zero in the large run while the weight share dominates](docs/screenshots/adaptive_mutation.svg)
+
+Two evolution loops on the same synthetic task — left panel starts from a tiny seed creature (~5
+hidden neurons), right panel starts from a large creature (~256 hidden, ~10k synapses). The orange
+line is the share of mutations that targeted **topology** (add/remove neuron, add/remove synapse);
+the blue line is the share that targeted **weights/biases**. NEAT-AI's adaptive policy keeps
+topology mutations active for the small creature (it still has structural growing to do) but
+collapses the topology share toward zero on the large creature, where remaining error is dominated
+by weight tuning.
 
 ### 🌱 Evolution Showcase — gen 1 → 10000
 

--- a/adaptive_mutation/README.md
+++ b/adaptive_mutation/README.md
@@ -1,0 +1,117 @@
+# 🧬 Adaptive Mutation Rate — Topology vs Weight Shift
+
+`adaptive_mutation.ts` visualises one of NEAT-AI's hidden but important behaviours: as a creature
+grows, the mutation operator distribution shifts away from **topology mutations** (add/remove
+neuron, add/remove synapse) and toward **weight/bias mutations**. Tiny seed creatures need new
+structure — adding a hidden neuron is often the only way forward — but once a creature has hundreds
+of neurons and thousands of synapses, the remaining error is overwhelmingly down to weight tuning.
+This demo runs two evolution loops on the same synthetic task and renders the per-generation
+topology share for each so the auto-shift is visible at a glance.
+
+![Adaptive mutation rate — small vs large creature, two-panel line chart](../docs/screenshots/adaptive_mutation.svg)
+
+## 🚀 How to Run
+
+```bash
+./adaptive_mutation/run.sh
+```
+
+The runner prints the initial sizes, the mean topology share for each run, and the shift (small
+minus large) — the larger this number, the more aggressively the policy is favouring weights once
+the creature has grown. The whole run completes in well under a second on a developer machine.
+
+## 🧠 Why does NEAT-AI need this?
+
+NEAT-AI's evolutionary search picks one mutation operator per attempt. If every creature, regardless
+of size, had the same chance of receiving an `ADD_NEURON` mutation, big creatures would explode in
+size without ever finishing weight tuning. NEAT-AI's mutation policy reads the creature's current
+size and reduces the topology share as size grows, so:
+
+| Aspect         | Tiny seed (~5 hidden) | Large creature (~256 hidden, ~10k synapses)           |
+| -------------- | --------------------- | ----------------------------------------------------- |
+| Topology share | High — needs growth   | Near zero — structure already present                 |
+| Weight share   | Low                   | Near one — error is dominated by weight tuning        |
+| Why            | No capacity to fit    | Capacity is there; refine the weights                 |
+| Failure mode   | Stuck under-fit       | Bloat without refinement (if topology share stays up) |
+
+The acceptance criterion captured by the test suite is straightforward: **the mean topology share
+across the small-creature run must strictly exceed the mean topology share across the large-creature
+run**.
+
+## 🔧 How It Works
+
+```mermaid
+flowchart TD
+    SEED["🌱 Build seed populations<br/>small + large via buildLargeCreature"]
+    LOOP["🔁 For each generation:<br/>for each creature, draw K mutations"]
+    POLICY["⚖️ Adaptive policy<br/>p(topology) = base / (1 + size/scale)"]
+    APPLY["🛠️ Apply operator → update size"]
+    TALLY["📊 Tally topology vs weight per gen"]
+    SVG["🖼️ Render two-panel SVG line chart"]
+
+    SEED --> LOOP
+    LOOP --> POLICY
+    POLICY --> APPLY
+    APPLY --> LOOP
+    LOOP --> TALLY
+    TALLY --> SVG
+```
+
+### The synthetic task
+
+Both runs start from a creature produced by `buildLargeCreature` (issue #83):
+
+- The **small** run uses `initialHidden = 5` and `density = 0.5` — about a dozen synapses.
+- The **large** run uses the helper's defaults (~256 hidden, ~10,000 synapses).
+
+Beyond the seed creature size, the two runs share an identical configuration: same number of
+generations, same population size, same mutations per generation, same adaptive policy.
+
+### The adaptive policy
+
+For a creature with `size = hidden + synapses`, the probability of choosing a topology operator is
+
+```
+p(topology) = baseTopologyProb / (1 + size / sizeScale)
+```
+
+Default `baseTopologyProb = 0.6` and `sizeScale = 80`. For a tiny creature (size ≈ 13) that yields p
+≈ 0.52; for a large creature (size ≈ 10,256) it collapses to under 0.005. Given the topology bucket
+the operator is picked from `{add_neuron, add_synapse, remove_neuron, remove_synapse}` by
+configurable weight; given the weight bucket it is picked from `{mod_weight, mod_bias}`.
+
+### Why no actual NEAT-AI training pass?
+
+The mutation-rate adaptation is a **policy** behaviour, not a training step. The demo therefore
+tracks creature size as it would evolve under each operator (an `add_neuron` grows the synapse count
+by one, a `remove_synapse` shrinks it by one, weight/bias operators leave it alone) without running
+a full evolutionary fitness loop. That keeps the demo self-contained, byte-deterministic, and well
+under the 90-second budget while still illustrating the shift the library performs internally.
+
+## 📤 Output
+
+- `docs/screenshots/adaptive_mutation.svg` — a two-panel line chart. **Left** panel: small-creature
+  run, with the topology curve (orange) starting around 0.5 and gently drifting downward as the
+  network grows. **Right** panel: large-creature run, with the topology curve effectively pinned at
+  zero from generation 1 onward; the weight curve (blue) sits at one. Both panels share the same
+  `[0, 1]` Y axis so the diverging curves are directly comparable. A mirror copy is also written to
+  `.adaptive-mutation/output/adaptive_mutation.svg`.
+
+## 🧪 Tests
+
+`adaptive_mutation_test.ts` verifies:
+
+- `topologyProbability` decreases monotonically with size and rejects invalid policies.
+- `chooseOperator` is biased toward topology operators on tiny creatures and toward weight operators
+  on huge creatures.
+- `applyOperator` keeps neuron and synapse counts non-negative and updates them by the documented
+  deltas.
+- `runSingleEvolution` records exactly `generations` `GenerationRecord` entries; every record's
+  `topologyRate + weightRate` equals 1, and the total mutations per generation equals
+  `mutationsPerGeneration × populationSize`.
+- The end-to-end run satisfies the issue acceptance criterion — **mean topology share is strictly
+  lower in the large-creature run than in the small-creature run** — by a wide margin on the default
+  seed.
+- The whole run is byte-deterministic for the same config.
+- The rendered SVG is well-formed, embeds both panels, and references the topology / weight curve
+  CSS classes.

--- a/adaptive_mutation/adaptive_mutation.ts
+++ b/adaptive_mutation/adaptive_mutation.ts
@@ -1,0 +1,509 @@
+/**
+ * Adaptive Mutation Rate Demo (issue #86).
+ *
+ * Visualises one of NEAT-AI's hidden but important behaviours: the
+ * mutation operator distribution shifts away from topology mutations
+ * (add/remove neuron, add/remove synapse) and toward weight/bias
+ * mutations as a creature grows. Tiny seed creatures need new structure
+ * — adding a hidden neuron is often the only way forward — but once a
+ * creature has hundreds of neurons and thousands of synapses, the
+ * remaining error is overwhelmingly down to weight tuning, not extra
+ * topology. NEAT-AI exploits this and weights its operator selection
+ * accordingly.
+ *
+ * The demo runs two evolution loops on the same synthetic regression
+ * task with everything held constant except the seed creature size:
+ *
+ * - **Small run** — starts from a `buildLargeCreature` with 5 hidden
+ *   neurons and very low density (the smallest deterministic creature
+ *   the helper can produce while staying valid).
+ * - **Large run** — starts from `buildLargeCreature`'s defaults
+ *   (~256 hidden, ~10k synapses).
+ *
+ * At every generation the demo samples K mutation operators and asks
+ * the **adaptive policy** to pick each one. The policy reads each
+ * candidate creature's current size and reduces the topology share as
+ * size grows. We tally the chosen operators per generation and plot
+ * topology share versus weight/bias share for both runs side-by-side
+ * — the small-run topology share stays high while the large-run
+ * topology share collapses toward zero almost immediately.
+ *
+ * No actual NEAT-AI training pass is invoked. The "evolution" here is
+ * a deterministic mutation walk that updates each creature's neuron
+ * and synapse counts after each operator. That keeps the demo
+ * self-contained, byte-deterministic, and well under the 90-second
+ * budget while still illustrating the size-driven shift that the
+ * library performs internally.
+ */
+import { format } from "@std/fmt/duration";
+import { ensureDirSync } from "@std/fs";
+import { join } from "@std/path";
+
+import { buildLargeCreature } from "../common/large_creature.ts";
+import { createDeterministicRandom } from "../common/deterministic_random.ts";
+import { setupWorkingDirs } from "../common/working_dirs.ts";
+import { renderAdaptiveMutationSVG } from "./svg.ts";
+
+/** Working-directory root for artefacts produced by this demo. */
+export const WORKING_ROOT = ".adaptive-mutation";
+
+/** Path to the SVG snapshot the runner emits for the README. */
+export const SCREENSHOT_PATH = "docs/screenshots/adaptive_mutation.svg";
+
+/**
+ * Mirror copy of the SVG written under `WORKING_ROOT/output/` so the
+ * canonical "output/" location requested in issue #86 is also populated.
+ */
+export const WORKING_OUTPUT_PATH = join(WORKING_ROOT, "output", "adaptive_mutation.svg");
+
+/** Mutation operator categories tracked by this demo. */
+export type MutationCategory = "topology" | "weight";
+
+/** Concrete mutation operator names — sub-categorise the buckets above. */
+export type MutationOperator =
+  | "add_neuron"
+  | "remove_neuron"
+  | "add_synapse"
+  | "remove_synapse"
+  | "mod_weight"
+  | "mod_bias";
+
+/** Map every operator to one of the two top-level categories. */
+export const OPERATOR_CATEGORY: Record<MutationOperator, MutationCategory> = {
+  add_neuron: "topology",
+  remove_neuron: "topology",
+  add_synapse: "topology",
+  remove_synapse: "topology",
+  mod_weight: "weight",
+  mod_bias: "weight",
+};
+
+/** Lightweight creature surrogate — only what the policy needs. */
+export interface CreatureSize {
+  /** Number of hidden neurons. */
+  hidden: number;
+  /** Number of synapses (edges). */
+  synapses: number;
+}
+
+/** Configuration for the adaptive mutation policy. */
+export interface AdaptivePolicyConfig {
+  /**
+   * Topology-mutation probability for a vanishingly small creature
+   * (size → 0). Must lie in (0, 1]. Default 0.6.
+   */
+  baseTopologyProb: number;
+  /**
+   * Size scale at which the topology probability is halved. Larger
+   * values keep topology mutations active for bigger creatures.
+   * Must be > 0. Default 80.
+   */
+  sizeScale: number;
+  /**
+   * Per-topology-operator weights. Normalised internally so they
+   * always sum to 1. Defaults bias slightly toward additive operators.
+   */
+  topologyOperatorWeights: Record<
+    "add_neuron" | "remove_neuron" | "add_synapse" | "remove_synapse",
+    number
+  >;
+  /**
+   * Per-weight-operator weights. Normalised internally so they always
+   * sum to 1.
+   */
+  weightOperatorWeights: Record<"mod_weight" | "mod_bias", number>;
+}
+
+/** Sensible defaults for the size-driven shift. */
+export const DEFAULT_POLICY_CONFIG: AdaptivePolicyConfig = {
+  baseTopologyProb: 0.6,
+  sizeScale: 80,
+  topologyOperatorWeights: {
+    add_neuron: 0.30,
+    add_synapse: 0.40,
+    remove_neuron: 0.10,
+    remove_synapse: 0.20,
+  },
+  weightOperatorWeights: {
+    mod_weight: 0.7,
+    mod_bias: 0.3,
+  },
+};
+
+/**
+ * Probability the policy chooses a **topology** operator for a creature
+ * of the given size. Pure function of size; useful in tests and the
+ * SVG legend caption.
+ */
+export function topologyProbability(
+  size: CreatureSize,
+  policy: AdaptivePolicyConfig = DEFAULT_POLICY_CONFIG,
+): number {
+  if (policy.baseTopologyProb <= 0 || policy.baseTopologyProb > 1) {
+    throw new Error(
+      `baseTopologyProb must be in (0, 1], got ${policy.baseTopologyProb}`,
+    );
+  }
+  if (policy.sizeScale <= 0) {
+    throw new Error(`sizeScale must be > 0, got ${policy.sizeScale}`);
+  }
+  const total = Math.max(0, size.hidden) + Math.max(0, size.synapses);
+  return policy.baseTopologyProb / (1 + total / policy.sizeScale);
+}
+
+/**
+ * Pick a single mutation operator using `random` and the adaptive
+ * policy. The probability of returning a topology operator is
+ * `topologyProbability(size, policy)`; given that bucket, the operator
+ * is chosen by the corresponding weight map.
+ */
+export function chooseOperator(
+  size: CreatureSize,
+  random: () => number,
+  policy: AdaptivePolicyConfig = DEFAULT_POLICY_CONFIG,
+): MutationOperator {
+  const pTopology = topologyProbability(size, policy);
+  if (random() < pTopology) {
+    return weightedPick(policy.topologyOperatorWeights, random) as MutationOperator;
+  }
+  return weightedPick(policy.weightOperatorWeights, random) as MutationOperator;
+}
+
+function weightedPick(weights: Record<string, number>, random: () => number): string {
+  const entries = Object.entries(weights);
+  let total = 0;
+  for (const [, w] of entries) {
+    if (w < 0) throw new Error(`operator weight must be >= 0, got ${w}`);
+    total += w;
+  }
+  if (total <= 0) {
+    throw new Error("operator weights must contain at least one positive entry");
+  }
+  let r = random() * total;
+  for (const [name, w] of entries) {
+    r -= w;
+    if (r < 0) return name;
+  }
+  return entries[entries.length - 1][0];
+}
+
+/**
+ * Apply the size-changing effect of `op` to `size` in place. Bookkeeping
+ * only — the demo does not actually perturb weights, since the policy
+ * cares solely about creature size.
+ */
+export function applyOperator(size: CreatureSize, op: MutationOperator): void {
+  switch (op) {
+    case "add_neuron":
+      // A new hidden neuron typically lands on an existing edge, so
+      // one synapse is "split" into two.
+      size.hidden += 1;
+      size.synapses += 1;
+      return;
+    case "add_synapse":
+      size.synapses += 1;
+      return;
+    case "remove_neuron":
+      // Refuse to drop below one hidden neuron so the network stays
+      // capable of solving anything non-linear.
+      if (size.hidden > 1) {
+        size.hidden -= 1;
+        // Removing a neuron drops at least its incoming + outgoing
+        // synapses; we approximate by 2.
+        size.synapses = Math.max(1, size.synapses - 2);
+      }
+      return;
+    case "remove_synapse":
+      if (size.synapses > 1) size.synapses -= 1;
+      return;
+    case "mod_weight":
+    case "mod_bias":
+      // No size change.
+      return;
+  }
+}
+
+/** Per-generation tally for one evolution loop. */
+export interface GenerationRecord {
+  /** Zero-indexed generation. */
+  generation: number;
+  /** Mean creature size (hidden + synapses) at the START of this gen. */
+  meanSize: number;
+  /** Number of topology operators applied in this generation. */
+  topologyMutations: number;
+  /** Number of weight/bias operators applied in this generation. */
+  weightMutations: number;
+  /**
+   * Topology mutation share — `topologyMutations / (topologyMutations
+   * + weightMutations)`. Falls in [0, 1].
+   */
+  topologyRate: number;
+  /** Weight/bias mutation share — `1 - topologyRate`. */
+  weightRate: number;
+}
+
+/** Configuration for one of the two evolution loops. */
+export interface RunConfig {
+  /** Display label for the rendered chart panel. */
+  label: string;
+  /** Initial number of hidden neurons. */
+  initialHidden: number;
+  /** Connection density forwarded to `buildLargeCreature`. */
+  density: number;
+  /** Random seed for the deterministic creature constructor. */
+  seed: number;
+}
+
+/** Combined demo configuration. */
+export interface AdaptiveMutationConfig {
+  /** Generations per run. */
+  generations: number;
+  /** Mutation operators applied per generation per creature. */
+  mutationsPerGeneration: number;
+  /** Population size per run. */
+  populationSize: number;
+  /** PRNG seed driving operator selection. */
+  policySeed: number;
+  /** Tunable adaptive policy. */
+  policy: AdaptivePolicyConfig;
+  /** Configuration for the small-creature run. */
+  small: RunConfig;
+  /** Configuration for the large-creature run. */
+  large: RunConfig;
+}
+
+/**
+ * Defaults tuned so the demo runs end-to-end in well under a second on
+ * a developer machine while producing a clearly diverging two-panel
+ * chart.
+ */
+export const DEFAULT_ADAPTIVE_MUTATION_CONFIG: AdaptiveMutationConfig = {
+  generations: 60,
+  mutationsPerGeneration: 4,
+  populationSize: 8,
+  policySeed: 86086086,
+  policy: DEFAULT_POLICY_CONFIG,
+  small: {
+    label: "small (~5 hidden)",
+    initialHidden: 5,
+    density: 0.5,
+    seed: 86_001,
+  },
+  large: {
+    label: "large (~256 hidden, ~10k synapses)",
+    initialHidden: 256,
+    density: 0.3,
+    seed: 86_002,
+  },
+};
+
+/** Combined result of one run. */
+export interface RunResult {
+  /** Display label echoed from `RunConfig`. */
+  label: string;
+  /** Per-generation tallies for the run. */
+  records: GenerationRecord[];
+  /** Initial hidden + synapse counts at generation 0. */
+  initialSize: CreatureSize;
+  /** Final mean hidden + synapse counts after the last generation. */
+  finalMeanSize: CreatureSize;
+}
+
+/** Combined result of running both evolution loops. */
+export interface AdaptiveMutationResult {
+  small: RunResult;
+  large: RunResult;
+  /** Mean topology share across all generations of the small run. */
+  smallTopologyShareMean: number;
+  /** Mean topology share across all generations of the large run. */
+  largeTopologyShareMean: number;
+}
+
+/**
+ * Build the initial population for a run by cloning the size of the
+ * deterministic seed creature `populationSize` times. Per-creature
+ * mutation walks then diverge once the loop starts.
+ */
+export function buildInitialPopulation(
+  runConfig: RunConfig,
+  populationSize: number,
+): CreatureSize[] {
+  if (populationSize <= 0) {
+    throw new Error(`populationSize must be positive, got ${populationSize}`);
+  }
+  const creature = buildLargeCreature({
+    inputs: 4,
+    hidden: runConfig.initialHidden,
+    outputs: 2,
+    density: runConfig.density,
+    seed: runConfig.seed,
+  });
+  const initial: CreatureSize = {
+    hidden: runConfig.initialHidden,
+    synapses: creature.synapses.length,
+  };
+  return Array.from({ length: populationSize }, () => ({ ...initial }));
+}
+
+/**
+ * Run a single evolution loop. Each generation, every creature in the
+ * population receives `mutationsPerGeneration` operators, chosen by
+ * the adaptive policy from its current size. Returns one
+ * {@link GenerationRecord} per generation.
+ */
+export function runSingleEvolution(
+  runConfig: RunConfig,
+  generations: number,
+  mutationsPerGeneration: number,
+  populationSize: number,
+  policy: AdaptivePolicyConfig,
+  random: () => number,
+): RunResult {
+  if (generations <= 0) {
+    throw new Error(`generations must be positive, got ${generations}`);
+  }
+  if (mutationsPerGeneration <= 0) {
+    throw new Error(
+      `mutationsPerGeneration must be positive, got ${mutationsPerGeneration}`,
+    );
+  }
+  const population = buildInitialPopulation(runConfig, populationSize);
+  const initialSize: CreatureSize = { ...population[0] };
+  const records: GenerationRecord[] = [];
+
+  for (let g = 0; g < generations; g++) {
+    let topologyCount = 0;
+    let weightCount = 0;
+    let sizeSum = 0;
+    for (const creature of population) {
+      sizeSum += creature.hidden + creature.synapses;
+      for (let m = 0; m < mutationsPerGeneration; m++) {
+        const op = chooseOperator(creature, random, policy);
+        if (OPERATOR_CATEGORY[op] === "topology") topologyCount++;
+        else weightCount++;
+        applyOperator(creature, op);
+      }
+    }
+    const total = topologyCount + weightCount;
+    records.push({
+      generation: g,
+      meanSize: sizeSum / population.length,
+      topologyMutations: topologyCount,
+      weightMutations: weightCount,
+      topologyRate: total === 0 ? 0 : topologyCount / total,
+      weightRate: total === 0 ? 0 : weightCount / total,
+    });
+  }
+
+  let hiddenSum = 0;
+  let synapsesSum = 0;
+  for (const creature of population) {
+    hiddenSum += creature.hidden;
+    synapsesSum += creature.synapses;
+  }
+  return {
+    label: runConfig.label,
+    records,
+    initialSize,
+    finalMeanSize: {
+      hidden: hiddenSum / population.length,
+      synapses: synapsesSum / population.length,
+    },
+  };
+}
+
+/** Mean of the `topologyRate` field across `records`. */
+export function meanTopologyShare(records: readonly GenerationRecord[]): number {
+  if (records.length === 0) return 0;
+  let sum = 0;
+  for (const r of records) sum += r.topologyRate;
+  return sum / records.length;
+}
+
+/**
+ * Run both evolution loops with shared policy configuration. Both runs
+ * use independent PRNG streams seeded from `config.policySeed` so the
+ * two runs do not co-vary on later draws.
+ */
+export function runAdaptiveMutationDemo(
+  config: AdaptiveMutationConfig = DEFAULT_ADAPTIVE_MUTATION_CONFIG,
+): AdaptiveMutationResult {
+  if (config.generations <= 0) {
+    throw new Error(`generations must be positive, got ${config.generations}`);
+  }
+  if (config.populationSize <= 0) {
+    throw new Error(`populationSize must be positive, got ${config.populationSize}`);
+  }
+
+  const smallRandom = createDeterministicRandom(config.policySeed ^ 0x1111_1111);
+  const largeRandom = createDeterministicRandom(config.policySeed ^ 0x2222_2222);
+
+  const small = runSingleEvolution(
+    config.small,
+    config.generations,
+    config.mutationsPerGeneration,
+    config.populationSize,
+    config.policy,
+    smallRandom,
+  );
+  const large = runSingleEvolution(
+    config.large,
+    config.generations,
+    config.mutationsPerGeneration,
+    config.populationSize,
+    config.policy,
+    largeRandom,
+  );
+
+  return {
+    small,
+    large,
+    smallTopologyShareMean: meanTopologyShare(small.records),
+    largeTopologyShareMean: meanTopologyShare(large.records),
+  };
+}
+
+if (import.meta.main) {
+  const start = Date.now();
+
+  console.log("🧬 Adaptive Mutation Rate Demo (issue #86)");
+  console.log("");
+
+  setupWorkingDirs(WORKING_ROOT);
+
+  console.log("🧪 Running small-creature and large-creature evolution loops...");
+  const result = runAdaptiveMutationDemo(DEFAULT_ADAPTIVE_MUTATION_CONFIG);
+
+  console.log("");
+  console.log(
+    `   small initial size  hidden=${result.small.initialSize.hidden}  ` +
+      `synapses=${result.small.initialSize.synapses}`,
+  );
+  console.log(
+    `   large initial size  hidden=${result.large.initialSize.hidden}  ` +
+      `synapses=${result.large.initialSize.synapses}`,
+  );
+  console.log("");
+  console.log(`   small mean topology share = ${result.smallTopologyShareMean.toFixed(4)}`);
+  console.log(`   large mean topology share = ${result.largeTopologyShareMean.toFixed(4)}`);
+  console.log(
+    `   shift (small - large)     = ${
+      (result.smallTopologyShareMean - result.largeTopologyShareMean).toFixed(4)
+    }`,
+  );
+
+  const svg = renderAdaptiveMutationSVG({
+    small: result.small,
+    large: result.large,
+  });
+  ensureDirSync("docs/screenshots");
+  ensureDirSync(join(WORKING_ROOT, "output"));
+  await Deno.writeTextFile(SCREENSHOT_PATH, svg);
+  await Deno.writeTextFile(WORKING_OUTPUT_PATH, svg);
+  console.log(`\n🖼️  Wrote ${SCREENSHOT_PATH}`);
+  console.log(`🖼️  Mirror at ${WORKING_OUTPUT_PATH}`);
+
+  console.log(
+    `\n🏁 Example completed in ${format(Date.now() - start, { ignoreZero: true })}`,
+  );
+}

--- a/adaptive_mutation/adaptive_mutation_test.ts
+++ b/adaptive_mutation/adaptive_mutation_test.ts
@@ -1,0 +1,349 @@
+/**
+ * Unit tests for the adaptive mutation rate demo (issue #86).
+ *
+ * "What" tests only — every test calls a real function and asserts on
+ * observable outputs (record structure, summary statistics, SVG
+ * structure). No greps over source files.
+ */
+import {
+  assert,
+  assertAlmostEquals,
+  assertEquals,
+  assertGreater,
+  assertGreaterOrEqual,
+  assertLessOrEqual,
+  assertThrows,
+} from "@std/assert";
+
+import {
+  applyOperator,
+  buildInitialPopulation,
+  chooseOperator,
+  type CreatureSize,
+  DEFAULT_ADAPTIVE_MUTATION_CONFIG,
+  DEFAULT_POLICY_CONFIG,
+  meanTopologyShare,
+  OPERATOR_CATEGORY,
+  runAdaptiveMutationDemo,
+  runSingleEvolution,
+  topologyProbability,
+} from "./adaptive_mutation.ts";
+import {
+  PANEL_CLASS,
+  renderAdaptiveMutationSVG,
+  TOPOLOGY_CURVE_CLASS,
+  WEIGHT_CURVE_CLASS,
+} from "./svg.ts";
+import { createDeterministicRandom } from "../common/deterministic_random.ts";
+
+Deno.test("topologyProbability decreases monotonically as size grows", () => {
+  const sizes: CreatureSize[] = [
+    { hidden: 5, synapses: 8 },
+    { hidden: 50, synapses: 100 },
+    { hidden: 256, synapses: 10_000 },
+  ];
+  const probs = sizes.map((s) => topologyProbability(s));
+  for (const p of probs) {
+    assertGreaterOrEqual(p, 0);
+    assertLessOrEqual(p, DEFAULT_POLICY_CONFIG.baseTopologyProb);
+  }
+  // Strictly decreasing — bigger creature → smaller topology share.
+  assertGreater(probs[0], probs[1]);
+  assertGreater(probs[1], probs[2]);
+});
+
+Deno.test("topologyProbability rejects invalid policy", () => {
+  assertThrows(() =>
+    topologyProbability(
+      { hidden: 1, synapses: 1 },
+      { ...DEFAULT_POLICY_CONFIG, baseTopologyProb: 0 },
+    )
+  );
+  assertThrows(() =>
+    topologyProbability(
+      { hidden: 1, synapses: 1 },
+      { ...DEFAULT_POLICY_CONFIG, sizeScale: 0 },
+    )
+  );
+});
+
+Deno.test("chooseOperator returns operators consistent with the OPERATOR_CATEGORY map", () => {
+  const rng = createDeterministicRandom(123);
+  const size: CreatureSize = { hidden: 5, synapses: 8 };
+  for (let i = 0; i < 200; i++) {
+    const op = chooseOperator(size, rng);
+    assert(op in OPERATOR_CATEGORY, `unknown operator ${op}`);
+  }
+});
+
+Deno.test("chooseOperator on a tiny creature is biased toward topology operators", () => {
+  const rng = createDeterministicRandom(42);
+  const size: CreatureSize = { hidden: 5, synapses: 8 };
+  let topology = 0;
+  let weight = 0;
+  for (let i = 0; i < 1000; i++) {
+    // Use a fresh size each iteration so the operator does not actually
+    // mutate the size in the loop — we only want to sample the policy.
+    const op = chooseOperator({ ...size }, rng);
+    if (OPERATOR_CATEGORY[op] === "topology") topology++;
+    else weight++;
+  }
+  // For size = 13 and default policy: p(topology) ≈ 0.6 / (1 + 13/80)
+  // ≈ 0.516. Allow generous tolerance for sampling noise.
+  const share = topology / (topology + weight);
+  assertGreater(share, 0.4);
+});
+
+Deno.test("chooseOperator on a huge creature is biased toward weight operators", () => {
+  const rng = createDeterministicRandom(7);
+  const size: CreatureSize = { hidden: 256, synapses: 10_000 };
+  let topology = 0;
+  let weight = 0;
+  for (let i = 0; i < 1000; i++) {
+    const op = chooseOperator({ ...size }, rng);
+    if (OPERATOR_CATEGORY[op] === "topology") topology++;
+    else weight++;
+  }
+  const share = topology / (topology + weight);
+  // For size ≈ 10256 the topology probability is < 0.01 — anything
+  // approaching 0.1 would mean the policy is broken.
+  assertGreaterOrEqual(0.1, share);
+});
+
+Deno.test("applyOperator keeps creature sizes non-negative", () => {
+  const size: CreatureSize = { hidden: 1, synapses: 1 };
+  // remove_neuron must refuse to drop below 1 hidden.
+  applyOperator(size, "remove_neuron");
+  assertEquals(size.hidden, 1);
+  // remove_synapse must refuse to drop below 1 synapse.
+  applyOperator(size, "remove_synapse");
+  assertEquals(size.synapses, 1);
+});
+
+Deno.test("applyOperator add_neuron grows hidden by 1 and synapses by 1", () => {
+  const size: CreatureSize = { hidden: 5, synapses: 12 };
+  applyOperator(size, "add_neuron");
+  assertEquals(size.hidden, 6);
+  assertEquals(size.synapses, 13);
+});
+
+Deno.test("applyOperator add_synapse grows synapses by 1 only", () => {
+  const size: CreatureSize = { hidden: 5, synapses: 12 };
+  applyOperator(size, "add_synapse");
+  assertEquals(size.hidden, 5);
+  assertEquals(size.synapses, 13);
+});
+
+Deno.test("applyOperator weight/bias operators do not change size", () => {
+  const size: CreatureSize = { hidden: 5, synapses: 12 };
+  applyOperator(size, "mod_weight");
+  assertEquals(size, { hidden: 5, synapses: 12 });
+  applyOperator(size, "mod_bias");
+  assertEquals(size, { hidden: 5, synapses: 12 });
+});
+
+Deno.test("buildInitialPopulation returns the requested number of creatures", () => {
+  const pop = buildInitialPopulation(DEFAULT_ADAPTIVE_MUTATION_CONFIG.small, 5);
+  assertEquals(pop.length, 5);
+  for (const c of pop) {
+    assertEquals(c.hidden, DEFAULT_ADAPTIVE_MUTATION_CONFIG.small.initialHidden);
+    assertGreater(c.synapses, 0);
+  }
+});
+
+Deno.test("buildInitialPopulation rejects non-positive populationSize", () => {
+  assertThrows(() => buildInitialPopulation(DEFAULT_ADAPTIVE_MUTATION_CONFIG.small, 0));
+});
+
+Deno.test("runSingleEvolution records exactly `generations` GenerationRecords", () => {
+  const rng = createDeterministicRandom(1);
+  const result = runSingleEvolution(
+    DEFAULT_ADAPTIVE_MUTATION_CONFIG.small,
+    25,
+    3,
+    4,
+    DEFAULT_POLICY_CONFIG,
+    rng,
+  );
+  assertEquals(result.records.length, 25);
+  for (let g = 0; g < 25; g++) {
+    assertEquals(result.records[g].generation, g);
+    // topologyRate + weightRate must equal 1 (within float tolerance).
+    assertAlmostEquals(
+      result.records[g].topologyRate + result.records[g].weightRate,
+      1,
+      1e-9,
+    );
+    assertGreaterOrEqual(result.records[g].topologyRate, 0);
+    assertLessOrEqual(result.records[g].topologyRate, 1);
+    // The total mutations recorded must equal mutationsPerGeneration *
+    // populationSize.
+    assertEquals(
+      result.records[g].topologyMutations + result.records[g].weightMutations,
+      3 * 4,
+    );
+  }
+});
+
+Deno.test("runSingleEvolution rejects invalid args", () => {
+  const rng = createDeterministicRandom(1);
+  assertThrows(() =>
+    runSingleEvolution(
+      DEFAULT_ADAPTIVE_MUTATION_CONFIG.small,
+      0,
+      3,
+      4,
+      DEFAULT_POLICY_CONFIG,
+      rng,
+    )
+  );
+  assertThrows(() =>
+    runSingleEvolution(
+      DEFAULT_ADAPTIVE_MUTATION_CONFIG.small,
+      5,
+      0,
+      4,
+      DEFAULT_POLICY_CONFIG,
+      rng,
+    )
+  );
+});
+
+Deno.test("meanTopologyShare averages the per-generation topology rates", () => {
+  const records = [
+    {
+      generation: 0,
+      meanSize: 0,
+      topologyMutations: 0,
+      weightMutations: 0,
+      topologyRate: 1,
+      weightRate: 0,
+    },
+    {
+      generation: 1,
+      meanSize: 0,
+      topologyMutations: 0,
+      weightMutations: 0,
+      topologyRate: 0.5,
+      weightRate: 0.5,
+    },
+    {
+      generation: 2,
+      meanSize: 0,
+      topologyMutations: 0,
+      weightMutations: 0,
+      topologyRate: 0,
+      weightRate: 1,
+    },
+  ];
+  assertAlmostEquals(meanTopologyShare(records), 0.5, 1e-9);
+  assertEquals(meanTopologyShare([]), 0);
+});
+
+Deno.test("runAdaptiveMutationDemo: small topology share strictly exceeds large share", () => {
+  const result = runAdaptiveMutationDemo(DEFAULT_ADAPTIVE_MUTATION_CONFIG);
+  // The acceptance criterion from issue #86: topology share is lower
+  // in the large-creature run than in the small-creature run.
+  assertGreater(
+    result.smallTopologyShareMean,
+    result.largeTopologyShareMean,
+    `small topology share (${result.smallTopologyShareMean.toFixed(4)}) must exceed ` +
+      `large topology share (${result.largeTopologyShareMean.toFixed(4)})`,
+  );
+  // The small run should still spend a meaningful fraction on topology.
+  assertGreater(result.smallTopologyShareMean, 0.2);
+  // The large run should be essentially all weight/bias.
+  assertGreaterOrEqual(0.05, result.largeTopologyShareMean);
+});
+
+Deno.test("runAdaptiveMutationDemo produces matched-length records for both runs", () => {
+  const result = runAdaptiveMutationDemo({
+    ...DEFAULT_ADAPTIVE_MUTATION_CONFIG,
+    generations: 20,
+  });
+  assertEquals(result.small.records.length, 20);
+  assertEquals(result.large.records.length, 20);
+  // Numeric arrays — verify every entry is a finite number in [0, 1].
+  for (let g = 0; g < 20; g++) {
+    for (const run of [result.small, result.large]) {
+      const r = run.records[g];
+      assert(Number.isFinite(r.topologyRate));
+      assert(Number.isFinite(r.weightRate));
+      assert(Number.isFinite(r.meanSize));
+      assertGreaterOrEqual(r.topologyRate, 0);
+      assertLessOrEqual(r.topologyRate, 1);
+      assertGreaterOrEqual(r.weightRate, 0);
+      assertLessOrEqual(r.weightRate, 1);
+    }
+  }
+});
+
+Deno.test("runAdaptiveMutationDemo is deterministic for the same config", () => {
+  const a = runAdaptiveMutationDemo(DEFAULT_ADAPTIVE_MUTATION_CONFIG);
+  const b = runAdaptiveMutationDemo(DEFAULT_ADAPTIVE_MUTATION_CONFIG);
+  assertEquals(a.smallTopologyShareMean, b.smallTopologyShareMean);
+  assertEquals(a.largeTopologyShareMean, b.largeTopologyShareMean);
+  for (let g = 0; g < a.small.records.length; g++) {
+    assertEquals(a.small.records[g].topologyRate, b.small.records[g].topologyRate);
+    assertEquals(a.large.records[g].topologyRate, b.large.records[g].topologyRate);
+  }
+});
+
+Deno.test("runAdaptiveMutationDemo rejects invalid configs", () => {
+  assertThrows(() =>
+    runAdaptiveMutationDemo({ ...DEFAULT_ADAPTIVE_MUTATION_CONFIG, generations: 0 })
+  );
+  assertThrows(() =>
+    runAdaptiveMutationDemo({ ...DEFAULT_ADAPTIVE_MUTATION_CONFIG, populationSize: 0 })
+  );
+});
+
+Deno.test("renderAdaptiveMutationSVG produces a well-formed SVG with both panels", () => {
+  const result = runAdaptiveMutationDemo({
+    ...DEFAULT_ADAPTIVE_MUTATION_CONFIG,
+    generations: 16,
+  });
+  const svg = renderAdaptiveMutationSVG({
+    small: result.small,
+    large: result.large,
+  });
+  assert(svg.startsWith("<svg"), "must start with <svg>");
+  assert(svg.includes("</svg>"), "must contain </svg>");
+  assert(svg.includes(TOPOLOGY_CURVE_CLASS), "must include topology curve class");
+  assert(svg.includes(WEIGHT_CURVE_CLASS), "must include weight curve class");
+  assert(svg.includes(PANEL_CLASS), "must include the panel class");
+
+  // Expect 4 polylines: small {topology, weight} + large {topology, weight}.
+  const polylines = svg.match(/<polyline /g) ?? [];
+  assertGreaterOrEqual(polylines.length, 4);
+
+  // Width / height must be positive integers.
+  const widthMatch = svg.match(/width="(\d+)"/);
+  const heightMatch = svg.match(/height="(\d+)"/);
+  assert(widthMatch);
+  assert(heightMatch);
+  assertGreater(Number.parseInt(widthMatch![1], 10), 0);
+  assertGreater(Number.parseInt(heightMatch![1], 10), 0);
+});
+
+Deno.test("renderAdaptiveMutationSVG rejects empty record arrays", () => {
+  const empty = {
+    label: "x",
+    records: [],
+    initialSize: { hidden: 0, synapses: 0 },
+    finalMeanSize: { hidden: 0, synapses: 0 },
+  };
+  assertThrows(() => renderAdaptiveMutationSVG({ small: empty, large: empty }));
+});
+
+Deno.test("renderAdaptiveMutationSVG rejects mismatched record lengths", () => {
+  const result = runAdaptiveMutationDemo({
+    ...DEFAULT_ADAPTIVE_MUTATION_CONFIG,
+    generations: 10,
+  });
+  const trimmed = {
+    ...result.large,
+    records: result.large.records.slice(0, 5),
+  };
+  assertThrows(() => renderAdaptiveMutationSVG({ small: result.small, large: trimmed }));
+});

--- a/adaptive_mutation/run.sh
+++ b/adaptive_mutation/run.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -euo pipefail
+
+# Adaptive Mutation Rate Demo Runner (issue #86)
+#
+# Runs two evolution loops on the same synthetic task — one starting
+# from a small creature, one starting from a large creature — and
+# renders the dual-panel mutation-rate chart to
+# .adaptive-mutation/output/adaptive_mutation.svg (mirrored to
+# docs/screenshots/adaptive_mutation.svg).
+
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd -P)"
+cd "${REPO_ROOT}"
+
+if ! command -v deno &> /dev/null; then
+  export PATH="$HOME/.deno/bin:$PATH"
+fi
+
+echo "🧬 Adaptive Mutation Rate Demo"
+echo ""
+
+deno run \
+  --allow-read \
+  --allow-write \
+  --allow-env \
+  adaptive_mutation/adaptive_mutation.ts \
+  "$@"
+
+# Re-format the regenerated SVGs so subsequent `deno fmt --check` runs
+# stay clean — the renderer emits compact output for readability, and
+# `deno fmt` prefers attributes split across multiple lines.
+if [[ -f "docs/screenshots/adaptive_mutation.svg" ]]; then
+  deno fmt docs/screenshots/adaptive_mutation.svg > /dev/null
+fi
+if [[ -f ".adaptive-mutation/output/adaptive_mutation.svg" ]]; then
+  deno fmt .adaptive-mutation/output/adaptive_mutation.svg > /dev/null
+fi

--- a/adaptive_mutation/svg.ts
+++ b/adaptive_mutation/svg.ts
@@ -1,0 +1,265 @@
+/**
+ * SVG rendering helpers for the adaptive mutation rate demo.
+ *
+ * Produces a two-panel line chart:
+ *
+ * - **Left panel** — small-creature run. Topology share starts high
+ *   and stays high; weight share is its mirror image.
+ * - **Right panel** — large-creature run. Topology share collapses
+ *   toward zero almost immediately; weight share dominates.
+ *
+ * Both panels share a `[0, 1]` Y axis (rate) and a `[0, generations]`
+ * X axis so the eye can compare the two curves directly.
+ */
+import type { RunResult } from "./adaptive_mutation.ts";
+
+/** Width (in SVG user units) of the rendered chart. */
+export const PLOT_WIDTH = 960;
+
+/** Height (in SVG user units) of the rendered chart. */
+export const PLOT_HEIGHT = 460;
+
+/** CSS class assigned to each topology rate polyline. */
+export const TOPOLOGY_CURVE_CLASS = "topology-rate";
+
+/** CSS class assigned to each weight rate polyline. */
+export const WEIGHT_CURVE_CLASS = "weight-rate";
+
+/** CSS class assigned to the panel container groups. */
+export const PANEL_CLASS = "panel";
+
+const MARGIN_TOP = 64;
+const MARGIN_BOTTOM = 64;
+const MARGIN_OUTER = 56;
+const PANEL_GAP = 36;
+
+/** Inputs to {@link renderAdaptiveMutationSVG}. */
+export interface RenderAdaptiveMutationOptions {
+  /** Small-creature run result. */
+  small: RunResult;
+  /** Large-creature run result. */
+  large: RunResult;
+}
+
+/**
+ * Render the two-panel mutation-rate comparison as an SVG string.
+ * Both panels share the same Y range (rate ∈ [0, 1]) and X range
+ * (generation ∈ [0, generations - 1]) so the curves are directly
+ * comparable.
+ */
+export function renderAdaptiveMutationSVG(options: RenderAdaptiveMutationOptions): string {
+  const { small, large } = options;
+  if (small.records.length === 0 || large.records.length === 0) {
+    throw new Error("small and large records must be non-empty");
+  }
+  if (small.records.length !== large.records.length) {
+    throw new Error(
+      `small (${small.records.length}) and large (${large.records.length}) must have equal length`,
+    );
+  }
+
+  const totalGenerations = small.records.length;
+  const innerWidth = PLOT_WIDTH - MARGIN_OUTER * 2 - PANEL_GAP;
+  const panelWidth = innerWidth / 2;
+  const panelHeight = PLOT_HEIGHT - MARGIN_TOP - MARGIN_BOTTOM;
+
+  const leftPanel = renderPanel({
+    x: MARGIN_OUTER,
+    y: MARGIN_TOP,
+    width: panelWidth,
+    height: panelHeight,
+    title: "Small creature",
+    subtitle: small.label,
+    initialSize: `start: ${small.initialSize.hidden} hidden / ${small.initialSize.synapses} syn`,
+    finalSize: `end:   ${small.finalMeanSize.hidden.toFixed(0)} hidden / ` +
+      `${small.finalMeanSize.synapses.toFixed(0)} syn`,
+    run: small,
+    totalGenerations,
+  });
+
+  const rightPanel = renderPanel({
+    x: MARGIN_OUTER + panelWidth + PANEL_GAP,
+    y: MARGIN_TOP,
+    width: panelWidth,
+    height: panelHeight,
+    title: "Large creature",
+    subtitle: large.label,
+    initialSize: `start: ${large.initialSize.hidden} hidden / ${large.initialSize.synapses} syn`,
+    finalSize: `end:   ${large.finalMeanSize.hidden.toFixed(0)} hidden / ` +
+      `${large.finalMeanSize.synapses.toFixed(0)} syn`,
+    run: large,
+    totalGenerations,
+  });
+
+  return [
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${PLOT_WIDTH} ${PLOT_HEIGHT}" ` +
+    `width="${PLOT_WIDTH}" height="${PLOT_HEIGHT}" role="img" ` +
+    `aria-label="Adaptive mutation rate — small vs large creature">`,
+    `  <title>Adaptive Mutation Rate — Topology Share Drops as Creatures Grow</title>`,
+    `  <rect width="${PLOT_WIDTH}" height="${PLOT_HEIGHT}" fill="#fafafa"/>`,
+    `  <text x="${PLOT_WIDTH / 2}" y="28" text-anchor="middle" ` +
+    `font-family="sans-serif" font-size="16" font-weight="bold" fill="#222">` +
+    `Adaptive Mutation Rate — Topology vs Weight Share</text>`,
+    leftPanel,
+    rightPanel,
+    renderLegend(),
+    `</svg>`,
+    "",
+  ].join("\n");
+}
+
+interface PanelOptions {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  title: string;
+  subtitle: string;
+  initialSize: string;
+  finalSize: string;
+  run: RunResult;
+  totalGenerations: number;
+}
+
+function renderPanel(opts: PanelOptions): string {
+  const { x, y, width, height, title, subtitle, initialSize, finalSize, run } = opts;
+
+  const xScale = (gen: number) => x + (gen / Math.max(1, opts.totalGenerations - 1)) * width;
+  const yScale = (rate: number) => y + (1 - rate) * height;
+
+  const topologyPoints = run.records
+    .map((r) => `${xScale(r.generation).toFixed(2)},${yScale(r.topologyRate).toFixed(2)}`)
+    .join(" ");
+  const weightPoints = run.records
+    .map((r) => `${xScale(r.generation).toFixed(2)},${yScale(r.weightRate).toFixed(2)}`)
+    .join(" ");
+
+  const lines: string[] = [];
+  lines.push(`  <g class="${PANEL_CLASS}" font-family="sans-serif">`);
+  lines.push(
+    `    <text x="${(x + width / 2).toFixed(2)}" y="${(y - 22).toFixed(2)}" ` +
+      `text-anchor="middle" font-size="14" font-weight="bold" fill="#222">${title}</text>`,
+  );
+  lines.push(
+    `    <text x="${(x + width / 2).toFixed(2)}" y="${(y - 6).toFixed(2)}" ` +
+      `text-anchor="middle" font-size="11" fill="#555">${subtitle}</text>`,
+  );
+  lines.push(
+    `    <rect x="${x.toFixed(2)}" y="${y.toFixed(2)}" width="${width.toFixed(2)}" ` +
+      `height="${height.toFixed(2)}" fill="#ffffff" stroke="#333" stroke-width="1"/>`,
+  );
+  lines.push(renderYTicks(x, y, height));
+  lines.push(renderXTicks(x, y, width, height, opts.totalGenerations, xScale));
+  lines.push(
+    `    <polyline class="${WEIGHT_CURVE_CLASS}" fill="none" stroke="#2e86de" ` +
+      `stroke-width="2" points="${weightPoints}"/>`,
+  );
+  lines.push(
+    `    <polyline class="${TOPOLOGY_CURVE_CLASS}" fill="none" stroke="#e67e22" ` +
+      `stroke-width="2" points="${topologyPoints}"/>`,
+  );
+  lines.push(renderAxisLabels(x, y, width, height));
+  lines.push(
+    `    <text x="${(x + 8).toFixed(2)}" y="${(y + height - 30).toFixed(2)}" ` +
+      `font-size="10" fill="#666">${escapeXml(initialSize)}</text>`,
+  );
+  lines.push(
+    `    <text x="${(x + 8).toFixed(2)}" y="${(y + height - 16).toFixed(2)}" ` +
+      `font-size="10" fill="#666">${escapeXml(finalSize)}</text>`,
+  );
+  lines.push(`  </g>`);
+  return lines.join("\n");
+}
+
+function renderYTicks(panelX: number, panelY: number, panelHeight: number): string {
+  const ticks = 5;
+  const lines: string[] = [`    <g class="ticks-y">`];
+  for (let i = 0; i < ticks; i++) {
+    const t = i / (ticks - 1);
+    const value = t;
+    const yPos = panelY + (1 - t) * panelHeight;
+    lines.push(
+      `      <line x1="${panelX.toFixed(2)}" y1="${yPos.toFixed(2)}" ` +
+        `x2="${(panelX - 5).toFixed(2)}" y2="${yPos.toFixed(2)}" ` +
+        `stroke="#333" stroke-width="1"/>`,
+    );
+    lines.push(
+      `      <text x="${(panelX - 8).toFixed(2)}" y="${(yPos + 4).toFixed(2)}" ` +
+        `text-anchor="end" font-size="11" fill="#333">${value.toFixed(2)}</text>`,
+    );
+  }
+  lines.push(`    </g>`);
+  return lines.join("\n");
+}
+
+function renderXTicks(
+  _panelX: number,
+  panelY: number,
+  _panelWidth: number,
+  panelHeight: number,
+  totalGenerations: number,
+  xScale: (gen: number) => number,
+): string {
+  const ticks = 5;
+  const lines: string[] = [`    <g class="ticks-x">`];
+  const baseY = panelY + panelHeight;
+  for (let i = 0; i < ticks; i++) {
+    const t = i / (ticks - 1);
+    const gen = Math.round(t * (totalGenerations - 1));
+    const xPos = xScale(gen);
+    lines.push(
+      `      <line x1="${xPos.toFixed(2)}" y1="${baseY.toFixed(2)}" ` +
+        `x2="${xPos.toFixed(2)}" y2="${(baseY + 5).toFixed(2)}" ` +
+        `stroke="#333" stroke-width="1"/>`,
+    );
+    lines.push(
+      `      <text x="${xPos.toFixed(2)}" y="${(baseY + 18).toFixed(2)}" ` +
+        `text-anchor="middle" font-size="11" fill="#333">${gen}</text>`,
+    );
+  }
+  lines.push(`    </g>`);
+  return lines.join("\n");
+}
+
+function renderAxisLabels(
+  panelX: number,
+  panelY: number,
+  panelWidth: number,
+  panelHeight: number,
+): string {
+  const baseY = panelY + panelHeight;
+  const xMid = panelX + panelWidth / 2;
+  return [
+    `    <g class="axis-labels" font-size="11" fill="#333">`,
+    `      <text x="${xMid.toFixed(2)}" y="${(baseY + 36).toFixed(2)}" ` +
+    `text-anchor="middle">generation</text>`,
+    `      <text x="${(panelX - 36).toFixed(2)}" y="${(panelY + panelHeight / 2).toFixed(2)}" ` +
+    `text-anchor="middle" dominant-baseline="middle" ` +
+    `transform="rotate(-90 ${(panelX - 36).toFixed(2)} ` +
+    `${(panelY + panelHeight / 2).toFixed(2)})">mutation share</text>`,
+    `    </g>`,
+  ].join("\n");
+}
+
+function renderLegend(): string {
+  const x = PLOT_WIDTH / 2 - 200;
+  const y = PLOT_HEIGHT - 28;
+  return [
+    `  <g class="legend" font-family="sans-serif" font-size="11" fill="#333">`,
+    `    <line x1="${x}" y1="${y}" x2="${x + 22}" y2="${y}" ` +
+    `stroke="#e67e22" stroke-width="2"/>`,
+    `    <text x="${x + 28}" y="${y + 4}">topology mutations (add/remove neuron/synapse)</text>`,
+    `    <line x1="${x + 280}" y1="${y}" x2="${x + 302}" y2="${y}" ` +
+    `stroke="#2e86de" stroke-width="2"/>`,
+    `    <text x="${x + 308}" y="${y + 4}">weight/bias mutations</text>`,
+    `  </g>`,
+  ].join("\n");
+}
+
+function escapeXml(s: string): string {
+  return s
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}

--- a/docs/archive_test.ts
+++ b/docs/archive_test.ts
@@ -61,6 +61,7 @@ Deno.test("No PR summary files remain in docs/ root", () => {
       if (entry.name === "pr-summary-83.md") continue;
       if (entry.name === "pr-summary-84.md") continue;
       if (entry.name === "pr-summary-85.md") continue;
+      if (entry.name === "pr-summary-86.md") continue;
       if (entry.name === "pr-summary-87.md") continue;
       if (entry.name === "pr-summary-88.md") continue;
       if (entry.name === "pr-summary-89.md") continue;

--- a/docs/pr-summary-86.md
+++ b/docs/pr-summary-86.md
@@ -1,0 +1,77 @@
+## Summary
+
+Add an `adaptive_mutation/` example that visualises NEAT-AI's size-driven shift from topology
+mutations (add/remove neuron/synapse) toward weight/bias mutations as a creature grows. Two
+evolution loops run on the same synthetic task — one starting from a small creature (~5 hidden
+neurons via `buildLargeCreature`), one starting from a large creature (~256 hidden, ~10k synapses
+via `buildLargeCreature` defaults) — and each generation's topology vs weight share is rendered as a
+two-panel line chart. Closes #86.
+
+## Evidence
+
+The demo is a deterministic CLI; the rendered SVG is the visual evidence. Sample output from a local
+run on the default seed:
+
+```
+small initial size  hidden=5    synapses=24
+large initial size  hidden=256  synapses=10255
+small mean topology share = 0.3682
+large mean topology share = 0.0052
+shift (small - large)     = 0.3630
+```
+
+The mean topology share is **70× higher** in the small-creature run than in the large-creature run,
+satisfying the issue acceptance criterion that "topology share is lower in the large-creature run
+than in the small-creature run".
+
+![Adaptive mutation rate — small vs large creature, two-panel line chart](adaptive_mutation.svg)
+
+```mermaid
+flowchart TD
+    SEED["Build seed populations<br/>small + large via buildLargeCreature"]
+    LOOP["For each generation:<br/>for each creature, draw K mutations"]
+    POLICY["Adaptive policy<br/>p(topology) = base / (1 + size/scale)"]
+    APPLY["Apply operator → update size"]
+    TALLY["Tally topology vs weight per gen"]
+    SVG["Render two-panel SVG line chart"]
+
+    SEED --> LOOP
+    LOOP --> POLICY
+    POLICY --> APPLY
+    APPLY --> LOOP
+    LOOP --> TALLY
+    TALLY --> SVG
+```
+
+The whole demo runs in ~50ms — well under the 90-second budget specified in the issue.
+
+## Test Plan
+
+- Added `adaptive_mutation/adaptive_mutation_test.ts` with 21 tests covering:
+  - `topologyProbability` is monotonically decreasing in size and rejects invalid policies.
+  - `chooseOperator` is biased toward topology operators on tiny creatures and toward weight
+    operators on huge creatures (statistical sampling, 1000 draws).
+  - `applyOperator` updates hidden/synapse counts by the documented deltas and refuses to drop below
+    1 hidden / 1 synapse.
+  - `runSingleEvolution` records exactly `generations` records; `topologyRate + weightRate` always
+    equals 1; total mutations per generation equals `mutationsPerGeneration × populationSize`.
+  - `runAdaptiveMutationDemo` satisfies the acceptance criterion — small mean topology share
+    strictly exceeds large mean topology share — and is byte-deterministic across reruns.
+  - `renderAdaptiveMutationSVG` produces a well-formed SVG with both panels and four polylines
+    (small + large × topology + weight); rejects empty / mismatched record arrays.
+- Added `adaptive_mutation` to `EXAMPLE_DIRS` and the `Adaptive Mutation` example name to
+  `readme_structure_test.ts` so the existing README structure tests cover the new directory.
+- Wired the new runner into `quality.sh` (cleanup list + `run_example` call) so future quality runs
+  exercise the demo end-to-end.
+- Ran the new module's tests locally:
+  `deno test --no-check --allow-read --allow-write --allow-env adaptive_mutation/` → 21 passed.
+- Ran the example end-to-end: `./adaptive_mutation/run.sh` → completes in ~50ms; writes
+  `docs/screenshots/adaptive_mutation.svg` and `.adaptive-mutation/output/adaptive_mutation.svg`.
+
+## Notes
+
+The "evolution" here is a deterministic mutation walk over creature sizes — no actual NEAT-AI
+training pass is invoked. That keeps the demo self-contained, byte-deterministic, and well under the
+90-second budget while still illustrating the size-driven shift the library performs internally.
+This is the same approach used by `memetic_evolution/` and is consistent with the existing example
+pattern.

--- a/docs/screenshots/adaptive_mutation.svg
+++ b/docs/screenshots/adaptive_mutation.svg
@@ -1,0 +1,178 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 960 460"
+  width="960"
+  height="460"
+  role="img"
+  aria-label="Adaptive mutation rate — small vs large creature"
+>
+  <title>Adaptive Mutation Rate — Topology Share Drops as Creatures Grow</title>
+  <rect width="960" height="460" fill="#fafafa" />
+  <text
+    x="480"
+    y="28"
+    text-anchor="middle"
+    font-family="sans-serif"
+    font-size="16"
+    font-weight="bold"
+    fill="#222"
+  >Adaptive Mutation Rate — Topology vs Weight Share</text>
+  <g class="panel" font-family="sans-serif">
+    <text
+      x="259.00"
+      y="42.00"
+      text-anchor="middle"
+      font-size="14"
+      font-weight="bold"
+      fill="#222"
+    >Small creature</text>
+    <text
+      x="259.00"
+      y="58.00"
+      text-anchor="middle"
+      font-size="11"
+      fill="#555"
+    >small (~5 hidden)</text>
+    <rect
+      x="56.00"
+      y="64.00"
+      width="406.00"
+      height="332.00"
+      fill="#ffffff"
+      stroke="#333"
+      stroke-width="1"
+    />
+    <g class="ticks-y">
+      <line x1="56.00" y1="396.00" x2="51.00" y2="396.00" stroke="#333" stroke-width="1" />
+      <text x="48.00" y="400.00" text-anchor="end" font-size="11" fill="#333">0.00</text>
+      <line x1="56.00" y1="313.00" x2="51.00" y2="313.00" stroke="#333" stroke-width="1" />
+      <text x="48.00" y="317.00" text-anchor="end" font-size="11" fill="#333">0.25</text>
+      <line x1="56.00" y1="230.00" x2="51.00" y2="230.00" stroke="#333" stroke-width="1" />
+      <text x="48.00" y="234.00" text-anchor="end" font-size="11" fill="#333">0.50</text>
+      <line x1="56.00" y1="147.00" x2="51.00" y2="147.00" stroke="#333" stroke-width="1" />
+      <text x="48.00" y="151.00" text-anchor="end" font-size="11" fill="#333">0.75</text>
+      <line x1="56.00" y1="64.00" x2="51.00" y2="64.00" stroke="#333" stroke-width="1" />
+      <text x="48.00" y="68.00" text-anchor="end" font-size="11" fill="#333">1.00</text>
+    </g>
+    <g class="ticks-x">
+      <line x1="56.00" y1="396.00" x2="56.00" y2="401.00" stroke="#333" stroke-width="1" />
+      <text x="56.00" y="414.00" text-anchor="middle" font-size="11" fill="#333">0</text>
+      <line x1="159.22" y1="396.00" x2="159.22" y2="401.00" stroke="#333" stroke-width="1" />
+      <text x="159.22" y="414.00" text-anchor="middle" font-size="11" fill="#333">15</text>
+      <line x1="262.44" y1="396.00" x2="262.44" y2="401.00" stroke="#333" stroke-width="1" />
+      <text x="262.44" y="414.00" text-anchor="middle" font-size="11" fill="#333">30</text>
+      <line x1="358.78" y1="396.00" x2="358.78" y2="401.00" stroke="#333" stroke-width="1" />
+      <text x="358.78" y="414.00" text-anchor="middle" font-size="11" fill="#333">44</text>
+      <line x1="462.00" y1="396.00" x2="462.00" y2="401.00" stroke="#333" stroke-width="1" />
+      <text x="462.00" y="414.00" text-anchor="middle" font-size="11" fill="#333">59</text>
+    </g>
+    <polyline
+      class="weight-rate"
+      fill="none"
+      stroke="#2e86de"
+      stroke-width="2"
+      points="56.00,188.50 62.88,209.25 69.76,167.75 76.64,230.00 83.53,240.38 90.41,198.88 97.29,209.25 104.17,219.63 111.05,209.25 117.93,167.75 124.81,178.13 131.69,219.63 138.58,230.00 145.46,167.75 152.34,209.25 159.22,167.75 166.10,178.13 172.98,209.25 179.86,198.88 186.75,188.50 193.63,178.13 200.51,219.63 207.39,209.25 214.27,167.75 221.15,250.75 228.03,188.50 234.92,198.88 241.80,198.88 248.68,188.50 255.56,157.38 262.44,261.13 269.32,188.50 276.20,167.75 283.08,219.63 289.97,167.75 296.85,198.88 303.73,157.38 310.61,188.50 317.49,147.00 324.37,178.13 331.25,198.88 338.14,167.75 345.02,147.00 351.90,167.75 358.78,178.13 365.66,167.75 372.54,167.75 379.42,198.88 386.31,136.63 393.19,178.13 400.07,147.00 406.95,157.38 413.83,219.63 420.71,188.50 427.59,157.38 434.47,178.13 441.36,178.13 448.24,105.50 455.12,115.88 462.00,198.88"
+    />
+    <polyline
+      class="topology-rate"
+      fill="none"
+      stroke="#e67e22"
+      stroke-width="2"
+      points="56.00,271.50 62.88,250.75 69.76,292.25 76.64,230.00 83.53,219.63 90.41,261.13 97.29,250.75 104.17,240.38 111.05,250.75 117.93,292.25 124.81,281.88 131.69,240.38 138.58,230.00 145.46,292.25 152.34,250.75 159.22,292.25 166.10,281.88 172.98,250.75 179.86,261.13 186.75,271.50 193.63,281.88 200.51,240.38 207.39,250.75 214.27,292.25 221.15,209.25 228.03,271.50 234.92,261.13 241.80,261.13 248.68,271.50 255.56,302.63 262.44,198.88 269.32,271.50 276.20,292.25 283.08,240.38 289.97,292.25 296.85,261.13 303.73,302.63 310.61,271.50 317.49,313.00 324.37,281.88 331.25,261.13 338.14,292.25 345.02,313.00 351.90,292.25 358.78,281.88 365.66,292.25 372.54,292.25 379.42,261.13 386.31,323.38 393.19,281.88 400.07,313.00 406.95,302.63 413.83,240.38 420.71,271.50 427.59,302.63 434.47,281.88 441.36,281.88 448.24,354.50 455.12,344.13 462.00,261.13"
+    />
+    <g class="axis-labels" font-size="11" fill="#333">
+      <text x="259.00" y="432.00" text-anchor="middle">generation</text>
+      <text
+        x="20.00"
+        y="230.00"
+        text-anchor="middle"
+        dominant-baseline="middle"
+        transform="rotate(-90 20.00 230.00)"
+      >mutation share</text>
+    </g>
+    <text x="64.00" y="366.00" font-size="10" fill="#666">start: 5 hidden / 24 syn</text>
+    <text x="64.00" y="380.00" font-size="10" fill="#666">end:   22 hidden / 54 syn</text>
+  </g>
+  <g class="panel" font-family="sans-serif">
+    <text
+      x="701.00"
+      y="42.00"
+      text-anchor="middle"
+      font-size="14"
+      font-weight="bold"
+      fill="#222"
+    >Large creature</text>
+    <text
+      x="701.00"
+      y="58.00"
+      text-anchor="middle"
+      font-size="11"
+      fill="#555"
+    >large (~256 hidden, ~10k synapses)</text>
+    <rect
+      x="498.00"
+      y="64.00"
+      width="406.00"
+      height="332.00"
+      fill="#ffffff"
+      stroke="#333"
+      stroke-width="1"
+    />
+    <g class="ticks-y">
+      <line x1="498.00" y1="396.00" x2="493.00" y2="396.00" stroke="#333" stroke-width="1" />
+      <text x="490.00" y="400.00" text-anchor="end" font-size="11" fill="#333">0.00</text>
+      <line x1="498.00" y1="313.00" x2="493.00" y2="313.00" stroke="#333" stroke-width="1" />
+      <text x="490.00" y="317.00" text-anchor="end" font-size="11" fill="#333">0.25</text>
+      <line x1="498.00" y1="230.00" x2="493.00" y2="230.00" stroke="#333" stroke-width="1" />
+      <text x="490.00" y="234.00" text-anchor="end" font-size="11" fill="#333">0.50</text>
+      <line x1="498.00" y1="147.00" x2="493.00" y2="147.00" stroke="#333" stroke-width="1" />
+      <text x="490.00" y="151.00" text-anchor="end" font-size="11" fill="#333">0.75</text>
+      <line x1="498.00" y1="64.00" x2="493.00" y2="64.00" stroke="#333" stroke-width="1" />
+      <text x="490.00" y="68.00" text-anchor="end" font-size="11" fill="#333">1.00</text>
+    </g>
+    <g class="ticks-x">
+      <line x1="498.00" y1="396.00" x2="498.00" y2="401.00" stroke="#333" stroke-width="1" />
+      <text x="498.00" y="414.00" text-anchor="middle" font-size="11" fill="#333">0</text>
+      <line x1="601.22" y1="396.00" x2="601.22" y2="401.00" stroke="#333" stroke-width="1" />
+      <text x="601.22" y="414.00" text-anchor="middle" font-size="11" fill="#333">15</text>
+      <line x1="704.44" y1="396.00" x2="704.44" y2="401.00" stroke="#333" stroke-width="1" />
+      <text x="704.44" y="414.00" text-anchor="middle" font-size="11" fill="#333">30</text>
+      <line x1="800.78" y1="396.00" x2="800.78" y2="401.00" stroke="#333" stroke-width="1" />
+      <text x="800.78" y="414.00" text-anchor="middle" font-size="11" fill="#333">44</text>
+      <line x1="904.00" y1="396.00" x2="904.00" y2="401.00" stroke="#333" stroke-width="1" />
+      <text x="904.00" y="414.00" text-anchor="middle" font-size="11" fill="#333">59</text>
+    </g>
+    <polyline
+      class="weight-rate"
+      fill="none"
+      stroke="#2e86de"
+      stroke-width="2"
+      points="498.00,74.38 504.88,64.00 511.76,64.00 518.64,64.00 525.53,64.00 532.41,64.00 539.29,74.38 546.17,64.00 553.05,64.00 559.93,64.00 566.81,64.00 573.69,64.00 580.58,64.00 587.46,64.00 594.34,64.00 601.22,64.00 608.10,64.00 614.98,64.00 621.86,64.00 628.75,64.00 635.63,64.00 642.51,74.38 649.39,74.38 656.27,64.00 663.15,74.38 670.03,64.00 676.92,64.00 683.80,64.00 690.68,64.00 697.56,74.38 704.44,64.00 711.32,64.00 718.20,64.00 725.08,74.38 731.97,64.00 738.85,64.00 745.73,64.00 752.61,64.00 759.49,74.38 766.37,64.00 773.25,64.00 780.14,64.00 787.02,64.00 793.90,64.00 800.78,64.00 807.66,74.38 814.54,64.00 821.42,64.00 828.31,64.00 835.19,64.00 842.07,64.00 848.95,64.00 855.83,74.38 862.71,64.00 869.59,64.00 876.47,64.00 883.36,64.00 890.24,64.00 897.12,64.00 904.00,64.00"
+    />
+    <polyline
+      class="topology-rate"
+      fill="none"
+      stroke="#e67e22"
+      stroke-width="2"
+      points="498.00,385.63 504.88,396.00 511.76,396.00 518.64,396.00 525.53,396.00 532.41,396.00 539.29,385.63 546.17,396.00 553.05,396.00 559.93,396.00 566.81,396.00 573.69,396.00 580.58,396.00 587.46,396.00 594.34,396.00 601.22,396.00 608.10,396.00 614.98,396.00 621.86,396.00 628.75,396.00 635.63,396.00 642.51,385.63 649.39,385.63 656.27,396.00 663.15,385.63 670.03,396.00 676.92,396.00 683.80,396.00 690.68,396.00 697.56,385.63 704.44,396.00 711.32,396.00 718.20,396.00 725.08,385.63 731.97,396.00 738.85,396.00 745.73,396.00 752.61,396.00 759.49,385.63 766.37,396.00 773.25,396.00 780.14,396.00 787.02,396.00 793.90,396.00 800.78,396.00 807.66,385.63 814.54,396.00 821.42,396.00 828.31,396.00 835.19,396.00 842.07,396.00 848.95,396.00 855.83,385.63 862.71,396.00 869.59,396.00 876.47,396.00 883.36,396.00 890.24,396.00 897.12,396.00 904.00,396.00"
+    />
+    <g class="axis-labels" font-size="11" fill="#333">
+      <text x="701.00" y="432.00" text-anchor="middle">generation</text>
+      <text
+        x="462.00"
+        y="230.00"
+        text-anchor="middle"
+        dominant-baseline="middle"
+        transform="rotate(-90 462.00 230.00)"
+      >mutation share</text>
+    </g>
+    <text x="506.00" y="366.00" font-size="10" fill="#666">start: 256 hidden / 10255 syn</text>
+    <text x="506.00" y="380.00" font-size="10" fill="#666">end:   257 hidden / 10256 syn</text>
+  </g>
+  <g class="legend" font-family="sans-serif" font-size="11" fill="#333">
+    <line x1="280" y1="432" x2="302" y2="432" stroke="#e67e22" stroke-width="2" />
+    <text x="308" y="436">topology mutations (add/remove neuron/synapse)</text>
+    <line x1="560" y1="432" x2="582" y2="432" stroke="#2e86de" stroke-width="2" />
+    <text x="588" y="436">weight/bias mutations</text>
+  </g>
+</svg>

--- a/quality.sh
+++ b/quality.sh
@@ -106,7 +106,7 @@ fi
 # --- Example Programs ---
 # Clean up any previous synthetic data
 echo "Cleaning up previous runs..."
-rm -rf .synthetic-discovery .synthetic-intelligent-design .synthetic-suggest-improvements .synthetic-crossover .synthetic-crispr-injection .synthetic-cart-pole .synthetic-lunar-lander .synthetic-mountain-car .synthetic-snake .synthetic-maze .synthetic-xor .synthetic-stock .synthetic-mnist .synthetic-mcmc .synthetic-memetic-evolution .synthetic-synapse .neuron-pruning .discovery .discovery-at-scale
+rm -rf .synthetic-discovery .synthetic-intelligent-design .synthetic-suggest-improvements .synthetic-crossover .synthetic-crispr-injection .synthetic-cart-pole .synthetic-lunar-lander .synthetic-mountain-car .synthetic-snake .synthetic-maze .synthetic-xor .synthetic-stock .synthetic-mnist .synthetic-mcmc .synthetic-memetic-evolution .synthetic-synapse .neuron-pruning .adaptive-mutation .discovery .discovery-at-scale
 echo ""
 
 # Run the Intelligent Design example
@@ -159,6 +159,9 @@ run_example "Synthetic Synapse Training Demo" "./synthetic_synapse/run.sh"
 
 # Run the Neuron Pruning demo
 run_example "Neuron Pruning Demo" "./neuron_pruning/run.sh"
+
+# Run the Adaptive Mutation Rate demo
+run_example "Adaptive Mutation Rate Demo" "./adaptive_mutation/run.sh"
 
 # Run the Suggest Improvements example
 run_example "Suggest Improvements" "./suggest_improvements/run.sh"

--- a/readme_structure_test.ts
+++ b/readme_structure_test.ts
@@ -12,6 +12,7 @@ import { assertEquals, assertStringIncludes } from "@std/assert";
 const README_PATH = "README.md";
 
 const EXAMPLE_DIRS = [
+  "adaptive_mutation",
   "cart_pole",
   "crispr_injection",
   "crossover",
@@ -127,6 +128,7 @@ Deno.test("README.md introduces every example by name", () => {
     "Memetic Evolution",
     "Synthetic Synapse",
     "Neuron Pruning",
+    "Adaptive Mutation",
     "Evolution Showcase",
   ];
   for (const name of required) {


### PR DESCRIPTION
## Summary

Add an `adaptive_mutation/` example that visualises NEAT-AI's size-driven shift from topology
mutations (add/remove neuron/synapse) toward weight/bias mutations as a creature grows. Two
evolution loops run on the same synthetic task — one starting from a small creature (~5 hidden
neurons via `buildLargeCreature`), one starting from a large creature (~256 hidden, ~10k synapses
via `buildLargeCreature` defaults) — and each generation's topology vs weight share is rendered as a
two-panel line chart. Closes #86.

## Evidence

The demo is a deterministic CLI; the rendered SVG is the visual evidence. Sample output from a local
run on the default seed:

```
small initial size  hidden=5    synapses=24
large initial size  hidden=256  synapses=10255
small mean topology share = 0.3682
large mean topology share = 0.0052
shift (small - large)     = 0.3630
```

The mean topology share is **70× higher** in the small-creature run than in the large-creature run,
satisfying the issue acceptance criterion that "topology share is lower in the large-creature run
than in the small-creature run".

![Adaptive mutation rate — small vs large creature, two-panel line chart](adaptive_mutation.svg)

```mermaid
flowchart TD
    SEED["Build seed populations<br/>small + large via buildLargeCreature"]
    LOOP["For each generation:<br/>for each creature, draw K mutations"]
    POLICY["Adaptive policy<br/>p(topology) = base / (1 + size/scale)"]
    APPLY["Apply operator → update size"]
    TALLY["Tally topology vs weight per gen"]
    SVG["Render two-panel SVG line chart"]

    SEED --> LOOP
    LOOP --> POLICY
    POLICY --> APPLY
    APPLY --> LOOP
    LOOP --> TALLY
    TALLY --> SVG
```

The whole demo runs in ~50ms — well under the 90-second budget specified in the issue.

## Test Plan

- Added `adaptive_mutation/adaptive_mutation_test.ts` with 21 tests covering:
  - `topologyProbability` is monotonically decreasing in size and rejects invalid policies.
  - `chooseOperator` is biased toward topology operators on tiny creatures and toward weight
    operators on huge creatures (statistical sampling, 1000 draws).
  - `applyOperator` updates hidden/synapse counts by the documented deltas and refuses to drop below
    1 hidden / 1 synapse.
  - `runSingleEvolution` records exactly `generations` records; `topologyRate + weightRate` always
    equals 1; total mutations per generation equals `mutationsPerGeneration × populationSize`.
  - `runAdaptiveMutationDemo` satisfies the acceptance criterion — small mean topology share
    strictly exceeds large mean topology share — and is byte-deterministic across reruns.
  - `renderAdaptiveMutationSVG` produces a well-formed SVG with both panels and four polylines
    (small + large × topology + weight); rejects empty / mismatched record arrays.
- Added `adaptive_mutation` to `EXAMPLE_DIRS` and the `Adaptive Mutation` example name to
  `readme_structure_test.ts` so the existing README structure tests cover the new directory.
- Wired the new runner into `quality.sh` (cleanup list + `run_example` call) so future quality runs
  exercise the demo end-to-end.
- Ran the new module's tests locally:
  `deno test --no-check --allow-read --allow-write --allow-env adaptive_mutation/` → 21 passed.
- Ran the example end-to-end: `./adaptive_mutation/run.sh` → completes in ~50ms; writes
  `docs/screenshots/adaptive_mutation.svg` and `.adaptive-mutation/output/adaptive_mutation.svg`.

## Notes

The "evolution" here is a deterministic mutation walk over creature sizes — no actual NEAT-AI
training pass is invoked. That keeps the demo self-contained, byte-deterministic, and well under the
90-second budget while still illustrating the size-driven shift the library performs internally.
This is the same approach used by `memetic_evolution/` and is consistent with the existing example
pattern.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-86 -->