### PR TITLE
Wire cart_pole to evolution chart

### DIFF
--- a/cart_pole/README.md
+++ b/cart_pole/README.md
@@ -71,10 +71,14 @@ Artefacts:
 - `docs/screenshots/cart_pole.svg` – an 8-frame strip showing the champion balancing
 - `docs/screenshots/cart_pole_evolution.svg` – multi-panel evolution-progression strip rendered from
   the captured snapshots
+- `docs/screenshots/cart_pole/evolution.svg` – dual-axis evolution chart plotting best score and
+  champion neuron / synapse counts against generation
 
 ## Evolution Progress
 
 ![Cart-Pole evolution-progression strip — one panel per checkpoint generation showing the running champion's topology and score, linked by a score-progression polyline](../docs/screenshots/cart_pole_evolution.svg)
+
+![Cart-Pole evolution chart — best score on the left axis with champion neuron and synapse counts on the right axis, plotted against generation](../docs/screenshots/cart_pole/evolution.svg)
 
 The runner captures a snapshot of the **running champion** at each of the canonical checkpoint
 generations `[1, 10, 100, 500]` (those that fall inside the configured `maxGenerations`).

--- a/cart_pole/cart_pole.ts
+++ b/cart_pole/cart_pole.ts
@@ -26,6 +26,7 @@ import {
   type SnapshotConfig,
 } from "../common/evolution_snapshot.ts";
 import { renderEvolutionProgressSvg } from "../common/evolution_progress_svg.ts";
+import { type EvolutionSample, renderEvolutionChartSVG } from "../common/evolution_chart.ts";
 import {
   type CartPoleState,
   encodeState,
@@ -101,6 +102,10 @@ export interface GenerationInfo {
   generation: number;
   bestScore: number;
   meanScore: number;
+  /** Neuron count of the champion creature for this generation. */
+  neurons: number;
+  /** Synapse count of the champion creature for this generation. */
+  synapses: number;
 }
 
 /** Result of the evolutionary search. */
@@ -369,6 +374,8 @@ export function evolveCartPoleController(
       generation,
       bestScore: generationBest.score,
       meanScore,
+      neurons: generationBest.json.neurons.length,
+      synapses: generationBest.json.synapses.length,
     });
 
     // Capture an evolution snapshot of the running champion at the
@@ -443,6 +450,9 @@ export const SNAPSHOTS_DIR = ".synthetic-cart-pole/snapshots";
 /** Path to the multi-panel evolution-progression SVG the runner emits. */
 export const EVOLUTION_PROGRESS_SVG_PATH = "docs/screenshots/cart_pole_evolution.svg";
 
+/** Path to the per-generation evolution-chart SVG the runner emits. */
+export const EVOLUTION_CHART_PATH = "docs/screenshots/cart_pole/evolution.svg";
+
 if (import.meta.main) {
   const start = Date.now();
 
@@ -460,6 +470,7 @@ if (import.meta.main) {
   for (const entry of Deno.readDirSync(SNAPSHOTS_DIR)) {
     if (entry.isFile) Deno.removeSync(join(SNAPSHOTS_DIR, entry.name));
   }
+  const evolutionSamples: EvolutionSample[] = [];
   const evolutionStart = Date.now();
   const result = evolveCartPoleController({
     ...DEFAULT_EVOLVE_OPTIONS,
@@ -467,12 +478,14 @@ if (import.meta.main) {
       checkpoints: [...EVOLUTION_CHECKPOINTS],
       outputDir: SNAPSHOTS_DIR,
     },
-    onGeneration: ({ generation, bestScore, meanScore }) => {
+    onGeneration: ({ generation, bestScore, meanScore, neurons, synapses }) => {
+      evolutionSamples.push({ generation, score: bestScore, neurons, synapses });
       if (generation % 5 === 0 || bestScore >= MAX_STEPS) {
         console.log(
           `   Gen ${generation.toString().padStart(3)}  best=${
             bestScore.toString().padStart(3)
-          }  mean=${meanScore.toFixed(1).padStart(6)}`,
+          }  mean=${meanScore.toFixed(1).padStart(6)}  ` +
+            `neurons=${neurons}  synapses=${synapses}`,
         );
       }
     },
@@ -495,6 +508,17 @@ if (import.meta.main) {
   ensureDirSync("docs/screenshots");
   await Deno.writeTextFile(SCREENSHOT_PATH, svg);
   console.log(`🖼️  Wrote screenshot ${SCREENSHOT_PATH} (${trace.length} frames captured)`);
+
+  // Render the per-generation evolution chart (score / neurons / synapses).
+  if (evolutionSamples.length > 0) {
+    const evolutionSvg = renderEvolutionChartSVG(evolutionSamples, {
+      title: "Cart-Pole — Evolution",
+      scoreLabel: "best score",
+    });
+    ensureDirSync("docs/screenshots/cart_pole");
+    await Deno.writeTextFile(EVOLUTION_CHART_PATH, evolutionSvg);
+    console.log(`📈 Wrote evolution chart ${EVOLUTION_CHART_PATH}`);
+  }
 
   // Render the multi-panel evolution-progression strip from the
   // checkpoint snapshots captured during the run.

--- a/cart_pole/cart_pole_test.ts
+++ b/cart_pole/cart_pole_test.ts
@@ -14,6 +14,7 @@ import {
   buildInitialCreatureJSON,
   DEFAULT_EVOLVE_OPTIONS,
   evolveCartPoleController,
+  type GenerationInfo,
   genesFromCreatureJSON,
   MAX_STEPS,
   mutateCreatureJSON,
@@ -301,6 +302,30 @@ Deno.test(
       assertEquals(panels.length, checkpoints.length);
     } finally {
       Deno.removeSync(tmp, { recursive: true });
+    }
+  },
+);
+
+Deno.test(
+  "evolveCartPoleController emits GenerationInfo with neurons and synapses counts",
+  () => {
+    const samples: GenerationInfo[] = [];
+    evolveCartPoleController({
+      seed: 1,
+      populationSize: 3,
+      maxGenerations: 3,
+      mutationStrength: 0.1,
+      mutationRate: 0.1,
+      onGeneration: (info) => samples.push(info),
+    });
+    assertGreater(samples.length, 0, "expected at least one onGeneration call");
+    for (const info of samples) {
+      // The fixed linear topology has 4 inputs + 1 output = 5 neurons and
+      // 4 input→output synapses, matching buildInitialCreatureJSON.
+      assertEquals(info.neurons, 5);
+      assertEquals(info.synapses, 4);
+      assertGreaterOrEqual(info.bestScore, 0);
+      assertGreaterOrEqual(info.meanScore, 0);
     }
   },
 );

--- a/cart_pole/run.sh
+++ b/cart_pole/run.sh
@@ -37,3 +37,6 @@ fi
 if [[ -f "docs/screenshots/cart_pole_evolution.svg" ]]; then
   deno fmt docs/screenshots/cart_pole_evolution.svg > /dev/null
 fi
+if [[ -f "docs/screenshots/cart_pole/evolution.svg" ]]; then
+  deno fmt docs/screenshots/cart_pole/evolution.svg > /dev/null
+fi

--- a/docs/pr-summary-107.md
+++ b/docs/pr-summary-107.md
@@ -1,28 +1,23 @@
 ## Summary
 
-Wired the cart-pole example to capture per-generation
-`{generation, score, neurons, synapses}` samples and render a
-dual-axis evolution chart at `docs/screenshots/cart_pole/evolution.svg`,
+Wired the cart-pole example to capture per-generation `{generation, score, neurons, synapses}`
+samples and render a dual-axis evolution chart at `docs/screenshots/cart_pole/evolution.svg`,
 embedded in `cart_pole/README.md`. Closes #107.
 
-- Extended `GenerationInfo` in `cart_pole/cart_pole.ts` with
-  `neurons` and `synapses` fields, populated from the generation's
-  champion creature.
-- Main runner now collects `EvolutionSample[]` via the existing
-  `onGeneration` callback and calls
+- Extended `GenerationInfo` in `cart_pole/cart_pole.ts` with `neurons` and `synapses` fields,
+  populated from the generation's champion creature.
+- Main runner now collects `EvolutionSample[]` via the existing `onGeneration` callback and calls
   `renderEvolutionChartSVG(...)` from `common/evolution_chart.ts`.
-- Added `EVOLUTION_CHART_PATH = "docs/screenshots/cart_pole/evolution.svg"`
-  and `ensureDirSync` for the output directory.
-- `cart_pole/run.sh` re-formats the new SVG so `deno fmt --check`
-  stays clean.
-- `cart_pole/README.md` lists the new artefact in the "Artefacts"
-  section and embeds the chart with descriptive alt-text.
+- Added `EVOLUTION_CHART_PATH = "docs/screenshots/cart_pole/evolution.svg"` and `ensureDirSync` for
+  the output directory.
+- `cart_pole/run.sh` re-formats the new SVG so `deno fmt --check` stays clean.
+- `cart_pole/README.md` lists the new artefact in the "Artefacts" section and embeds the chart with
+  descriptive alt-text.
 
 ## Evidence
 
-CLI/back-end change — no UI screenshot. Verified with the test
-suite and by running `./cart_pole/run.sh`, which produced
-`docs/screenshots/cart_pole/evolution.svg` (~31 KB).
+CLI/back-end change — no UI screenshot. Verified with the test suite and by running
+`./cart_pole/run.sh`, which produced `docs/screenshots/cart_pole/evolution.svg` (~31 KB).
 
 ```mermaid
 flowchart LR
@@ -43,9 +38,9 @@ flowchart LR
 ## Test Plan
 
 - Added `evolveCartPoleController emits GenerationInfo with neurons
-  and synapses counts` in `cart_pole/cart_pole_test.ts`. The test
-  asserts the new shape (5 neurons, 4 synapses for the fixed linear
-  topology) and non-negative scores.
+  and synapses counts` in
+  `cart_pole/cart_pole_test.ts`. The test asserts the new shape (5 neurons, 4 synapses for the fixed
+  linear topology) and non-negative scores.
 - Existing `cart_pole_test.ts` tests continue to pass (19/19).
 - Full suite passes: `deno test ... 747 passed | 0 failed`.
 - `deno lint`, `deno fmt --check`, and `deno check` all clean.

--- a/docs/pr-summary-107.md
+++ b/docs/pr-summary-107.md
@@ -1,0 +1,51 @@
+## Summary
+
+Wired the cart-pole example to capture per-generation
+`{generation, score, neurons, synapses}` samples and render a
+dual-axis evolution chart at `docs/screenshots/cart_pole/evolution.svg`,
+embedded in `cart_pole/README.md`. Closes #107.
+
+- Extended `GenerationInfo` in `cart_pole/cart_pole.ts` with
+  `neurons` and `synapses` fields, populated from the generation's
+  champion creature.
+- Main runner now collects `EvolutionSample[]` via the existing
+  `onGeneration` callback and calls
+  `renderEvolutionChartSVG(...)` from `common/evolution_chart.ts`.
+- Added `EVOLUTION_CHART_PATH = "docs/screenshots/cart_pole/evolution.svg"`
+  and `ensureDirSync` for the output directory.
+- `cart_pole/run.sh` re-formats the new SVG so `deno fmt --check`
+  stays clean.
+- `cart_pole/README.md` lists the new artefact in the "Artefacts"
+  section and embeds the chart with descriptive alt-text.
+
+## Evidence
+
+CLI/back-end change — no UI screenshot. Verified with the test
+suite and by running `./cart_pole/run.sh`, which produced
+`docs/screenshots/cart_pole/evolution.svg` (~31 KB).
+
+```mermaid
+flowchart LR
+    GEN["evolveCartPoleController"]
+    INFO["GenerationInfo<br/>{generation, bestScore, meanScore,<br/>neurons, synapses}"]
+    SAMPLES["EvolutionSample[]"]
+    CHART["renderEvolutionChartSVG"]
+    SVG["docs/screenshots/cart_pole/evolution.svg"]
+    README["cart_pole/README.md"]
+
+    GEN -- onGeneration --> INFO
+    INFO --> SAMPLES
+    SAMPLES --> CHART
+    CHART --> SVG
+    SVG --> README
+```
+
+## Test Plan
+
+- Added `evolveCartPoleController emits GenerationInfo with neurons
+  and synapses counts` in `cart_pole/cart_pole_test.ts`. The test
+  asserts the new shape (5 neurons, 4 synapses for the fixed linear
+  topology) and non-negative scores.
+- Existing `cart_pole_test.ts` tests continue to pass (19/19).
+- Full suite passes: `deno test ... 747 passed | 0 failed`.
+- `deno lint`, `deno fmt --check`, and `deno check` all clean.

--- a/docs/pr-summary-89.md
+++ b/docs/pr-summary-89.md
@@ -39,6 +39,7 @@ This is a backend/CLI example with no web UI. Verified by:
   moving-average correctness and edge cases, SVG well-formedness, target-line presence, and
   empty-input rejection.
 - Sample run summary (default seed):
+
   ```
   iterations          = 4000
   target acceptance   = 23.4%
@@ -46,6 +47,7 @@ This is a backend/CLI example with no web UI. Verified by:
   best fitness        = -0.3309
   final temperature   = 0.8548
   ```
+
 - The committed SVG `docs/screenshots/mcmc_acceptance.svg` shows the blue moving-average acceptance
   line settling onto the green dashed 23.4% target while the orange temperature curve climbs from
   `T₀ = 0.01` toward equilibrium.

--- a/docs/screenshots/cart_pole/evolution.svg
+++ b/docs/screenshots/cart_pole/evolution.svg
@@ -1,0 +1,441 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 800 400"
+  width="800"
+  height="400"
+  role="img"
+  aria-label="Cart-Pole — Evolution dual-axis chart"
+>
+  <title>Cart-Pole — Evolution</title>
+  <rect width="800" height="400" fill="#fafafa" />
+  <text
+    x="400"
+    y="24"
+    text-anchor="middle"
+    font-family="sans-serif"
+    font-size="16"
+    font-weight="bold"
+    fill="#222"
+  >Cart-Pole — Evolution</text>
+  <rect x="70" y="40" width="660" height="300" fill="#ffffff" stroke="#333333" stroke-width="1" />
+  <g class="x-axis" font-family="sans-serif" font-size="11" fill="#333333">
+    <line x1="70" y1="340" x2="70" y2="344" stroke="#333333" stroke-width="1" />
+    <text x="70" y="358" text-anchor="middle">0</text>
+    <line x1="150" y1="340" x2="150" y2="344" stroke="#333333" stroke-width="1" />
+    <text x="150" y="358" text-anchor="middle">12</text>
+    <line x1="230" y1="340" x2="230" y2="344" stroke="#333333" stroke-width="1" />
+    <text x="230" y="358" text-anchor="middle">24</text>
+    <line x1="310" y1="340" x2="310" y2="344" stroke="#333333" stroke-width="1" />
+    <text x="310" y="358" text-anchor="middle">36</text>
+    <line x1="390" y1="340" x2="390" y2="344" stroke="#333333" stroke-width="1" />
+    <text x="390" y="358" text-anchor="middle">48</text>
+    <line x1="470" y1="340" x2="470" y2="344" stroke="#333333" stroke-width="1" />
+    <text x="470" y="358" text-anchor="middle">60</text>
+    <line x1="550" y1="340" x2="550" y2="344" stroke="#333333" stroke-width="1" />
+    <text x="550" y="358" text-anchor="middle">72</text>
+    <line x1="630" y1="340" x2="630" y2="344" stroke="#333333" stroke-width="1" />
+    <text x="630" y="358" text-anchor="middle">84</text>
+    <line x1="710" y1="340" x2="710" y2="344" stroke="#333333" stroke-width="1" />
+    <text x="710" y="358" text-anchor="middle">96</text>
+    <line x1="730" y1="340" x2="730" y2="344" stroke="#333333" stroke-width="1" />
+    <text x="730" y="358" text-anchor="middle">99</text>
+    <text x="400" y="376" text-anchor="middle" font-weight="bold">generation</text>
+  </g>
+  <g class="left-axis" font-family="sans-serif" font-size="11" fill="#1f77b4">
+    <line x1="66" y1="340" x2="70" y2="340" stroke="#1f77b4" stroke-width="1" />
+    <text x="62" y="340" text-anchor="end" dominant-baseline="middle">498.3</text>
+    <line x1="66" y1="251.76" x2="70" y2="251.76" stroke="#1f77b4" stroke-width="1" />
+    <text x="62" y="251.76" text-anchor="end" dominant-baseline="middle">498.8</text>
+    <line x1="66" y1="163.53" x2="70" y2="163.53" stroke="#1f77b4" stroke-width="1" />
+    <text x="62" y="163.53" text-anchor="end" dominant-baseline="middle">499.3</text>
+    <line x1="66" y1="75.29" x2="70" y2="75.29" stroke="#1f77b4" stroke-width="1" />
+    <text x="62" y="75.29" text-anchor="end" dominant-baseline="middle">499.8</text>
+    <line x1="66" y1="40" x2="70" y2="40" stroke="#1f77b4" stroke-width="1" />
+    <text x="62" y="40" text-anchor="end" dominant-baseline="middle">500</text>
+    <text
+      x="22"
+      y="190"
+      text-anchor="middle"
+      dominant-baseline="middle"
+      font-weight="bold"
+      transform="rotate(-90 22 190)"
+    >best score</text>
+  </g>
+  <g class="right-axis" font-family="sans-serif" font-size="11" fill="#333333">
+    <line x1="730" y1="340" x2="734" y2="340" stroke="#333333" stroke-width="1" />
+    <text x="738" y="340" text-anchor="start" dominant-baseline="middle">0</text>
+    <line x1="730" y1="280" x2="734" y2="280" stroke="#333333" stroke-width="1" />
+    <text x="738" y="280" text-anchor="start" dominant-baseline="middle">1</text>
+    <line x1="730" y1="220" x2="734" y2="220" stroke="#333333" stroke-width="1" />
+    <text x="738" y="220" text-anchor="start" dominant-baseline="middle">2</text>
+    <line x1="730" y1="160" x2="734" y2="160" stroke="#333333" stroke-width="1" />
+    <text x="738" y="160" text-anchor="start" dominant-baseline="middle">3</text>
+    <line x1="730" y1="100" x2="734" y2="100" stroke="#333333" stroke-width="1" />
+    <text x="738" y="100" text-anchor="start" dominant-baseline="middle">4</text>
+    <line x1="730" y1="40" x2="734" y2="40" stroke="#333333" stroke-width="1" />
+    <text x="738" y="40" text-anchor="start" dominant-baseline="middle">5</text>
+    <text
+      x="778"
+      y="190"
+      text-anchor="middle"
+      dominant-baseline="middle"
+      font-weight="bold"
+      transform="rotate(90 778 190)"
+    >neurons / synapses</text>
+  </g>
+  <g class="score-line">
+    <polyline
+      fill="none"
+      stroke="#1f77b4"
+      stroke-width="1.5"
+      points="70,340 76.67,40 83.33,40 90,40 96.67,40 103.33,40 110,40 116.67,40 123.33,40 130,40 136.67,40 143.33,40 150,40 156.67,40 163.33,40 170,40 176.67,40 183.33,40 190,40 196.67,40 203.33,40 210,40 216.67,40 223.33,40 230,40 236.67,40 243.33,40 250,40 256.67,40 263.33,40 270,40 276.67,40 283.33,40 290,40 296.67,40 303.33,40 310,40 316.67,40 323.33,40 330,40 336.67,40 343.33,40 350,40 356.67,40 363.33,40 370,40 376.67,40 383.33,40 390,40 396.67,40 403.33,40 410,40 416.67,40 423.33,40 430,40 436.67,40 443.33,40 450,40 456.67,40 463.33,40 470,40 476.67,40 483.33,40 490,40 496.67,40 503.33,40 510,40 516.67,40 523.33,40 530,40 536.67,40 543.33,40 550,40 556.67,40 563.33,40 570,40 576.67,40 583.33,40 590,40 596.67,40 603.33,40 610,40 616.67,40 623.33,40 630,40 636.67,40 643.33,40 650,40 656.67,40 663.33,40 670,40 676.67,40 683.33,40 690,40 696.67,40 703.33,40 710,40 716.67,40 723.33,40 730,40"
+    />
+    <circle class="score-point" cx="70" cy="340" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="76.67" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="83.33" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="90" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="96.67" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="103.33" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="110" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="116.67" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="123.33" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="130" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="136.67" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="143.33" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="150" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="156.67" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="163.33" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="170" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="176.67" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="183.33" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="190" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="196.67" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="203.33" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="210" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="216.67" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="223.33" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="230" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="236.67" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="243.33" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="250" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="256.67" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="263.33" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="270" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="276.67" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="283.33" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="290" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="296.67" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="303.33" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="310" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="316.67" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="323.33" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="330" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="336.67" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="343.33" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="350" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="356.67" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="363.33" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="370" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="376.67" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="383.33" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="390" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="396.67" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="403.33" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="410" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="416.67" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="423.33" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="430" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="436.67" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="443.33" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="450" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="456.67" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="463.33" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="470" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="476.67" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="483.33" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="490" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="496.67" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="503.33" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="510" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="516.67" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="523.33" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="530" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="536.67" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="543.33" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="550" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="556.67" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="563.33" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="570" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="576.67" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="583.33" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="590" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="596.67" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="603.33" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="610" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="616.67" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="623.33" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="630" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="636.67" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="643.33" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="650" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="656.67" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="663.33" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="670" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="676.67" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="683.33" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="690" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="696.67" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="703.33" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="710" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="716.67" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="723.33" cy="40" r="1.8" fill="#1f77b4" />
+    <circle class="score-point" cx="730" cy="40" r="1.8" fill="#1f77b4" />
+  </g>
+  <g class="neurons-line">
+    <polyline
+      fill="none"
+      stroke="#2ca02c"
+      stroke-width="1.5"
+      points="70,40 76.67,40 83.33,40 90,40 96.67,40 103.33,40 110,40 116.67,40 123.33,40 130,40 136.67,40 143.33,40 150,40 156.67,40 163.33,40 170,40 176.67,40 183.33,40 190,40 196.67,40 203.33,40 210,40 216.67,40 223.33,40 230,40 236.67,40 243.33,40 250,40 256.67,40 263.33,40 270,40 276.67,40 283.33,40 290,40 296.67,40 303.33,40 310,40 316.67,40 323.33,40 330,40 336.67,40 343.33,40 350,40 356.67,40 363.33,40 370,40 376.67,40 383.33,40 390,40 396.67,40 403.33,40 410,40 416.67,40 423.33,40 430,40 436.67,40 443.33,40 450,40 456.67,40 463.33,40 470,40 476.67,40 483.33,40 490,40 496.67,40 503.33,40 510,40 516.67,40 523.33,40 530,40 536.67,40 543.33,40 550,40 556.67,40 563.33,40 570,40 576.67,40 583.33,40 590,40 596.67,40 603.33,40 610,40 616.67,40 623.33,40 630,40 636.67,40 643.33,40 650,40 656.67,40 663.33,40 670,40 676.67,40 683.33,40 690,40 696.67,40 703.33,40 710,40 716.67,40 723.33,40 730,40"
+    />
+    <circle class="neurons-point" cx="70" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="76.67" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="83.33" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="90" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="96.67" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="103.33" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="110" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="116.67" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="123.33" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="130" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="136.67" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="143.33" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="150" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="156.67" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="163.33" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="170" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="176.67" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="183.33" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="190" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="196.67" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="203.33" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="210" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="216.67" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="223.33" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="230" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="236.67" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="243.33" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="250" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="256.67" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="263.33" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="270" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="276.67" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="283.33" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="290" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="296.67" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="303.33" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="310" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="316.67" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="323.33" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="330" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="336.67" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="343.33" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="350" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="356.67" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="363.33" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="370" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="376.67" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="383.33" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="390" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="396.67" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="403.33" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="410" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="416.67" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="423.33" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="430" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="436.67" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="443.33" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="450" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="456.67" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="463.33" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="470" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="476.67" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="483.33" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="490" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="496.67" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="503.33" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="510" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="516.67" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="523.33" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="530" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="536.67" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="543.33" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="550" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="556.67" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="563.33" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="570" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="576.67" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="583.33" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="590" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="596.67" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="603.33" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="610" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="616.67" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="623.33" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="630" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="636.67" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="643.33" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="650" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="656.67" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="663.33" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="670" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="676.67" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="683.33" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="690" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="696.67" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="703.33" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="710" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="716.67" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="723.33" cy="40" r="1.8" fill="#2ca02c" />
+    <circle class="neurons-point" cx="730" cy="40" r="1.8" fill="#2ca02c" />
+  </g>
+  <g class="synapses-line">
+    <polyline
+      fill="none"
+      stroke="#d62728"
+      stroke-width="1.5"
+      points="70,100 76.67,100 83.33,100 90,100 96.67,100 103.33,100 110,100 116.67,100 123.33,100 130,100 136.67,100 143.33,100 150,100 156.67,100 163.33,100 170,100 176.67,100 183.33,100 190,100 196.67,100 203.33,100 210,100 216.67,100 223.33,100 230,100 236.67,100 243.33,100 250,100 256.67,100 263.33,100 270,100 276.67,100 283.33,100 290,100 296.67,100 303.33,100 310,100 316.67,100 323.33,100 330,100 336.67,100 343.33,100 350,100 356.67,100 363.33,100 370,100 376.67,100 383.33,100 390,100 396.67,100 403.33,100 410,100 416.67,100 423.33,100 430,100 436.67,100 443.33,100 450,100 456.67,100 463.33,100 470,100 476.67,100 483.33,100 490,100 496.67,100 503.33,100 510,100 516.67,100 523.33,100 530,100 536.67,100 543.33,100 550,100 556.67,100 563.33,100 570,100 576.67,100 583.33,100 590,100 596.67,100 603.33,100 610,100 616.67,100 623.33,100 630,100 636.67,100 643.33,100 650,100 656.67,100 663.33,100 670,100 676.67,100 683.33,100 690,100 696.67,100 703.33,100 710,100 716.67,100 723.33,100 730,100"
+    />
+    <circle class="synapses-point" cx="70" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="76.67" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="83.33" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="90" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="96.67" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="103.33" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="110" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="116.67" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="123.33" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="130" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="136.67" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="143.33" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="150" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="156.67" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="163.33" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="170" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="176.67" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="183.33" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="190" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="196.67" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="203.33" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="210" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="216.67" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="223.33" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="230" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="236.67" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="243.33" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="250" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="256.67" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="263.33" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="270" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="276.67" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="283.33" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="290" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="296.67" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="303.33" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="310" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="316.67" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="323.33" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="330" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="336.67" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="343.33" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="350" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="356.67" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="363.33" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="370" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="376.67" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="383.33" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="390" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="396.67" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="403.33" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="410" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="416.67" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="423.33" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="430" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="436.67" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="443.33" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="450" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="456.67" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="463.33" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="470" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="476.67" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="483.33" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="490" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="496.67" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="503.33" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="510" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="516.67" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="523.33" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="530" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="536.67" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="543.33" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="550" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="556.67" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="563.33" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="570" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="576.67" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="583.33" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="590" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="596.67" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="603.33" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="610" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="616.67" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="623.33" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="630" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="636.67" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="643.33" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="650" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="656.67" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="663.33" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="670" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="676.67" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="683.33" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="690" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="696.67" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="703.33" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="710" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="716.67" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="723.33" cy="100" r="1.8" fill="#d62728" />
+    <circle class="synapses-point" cx="730" cy="100" r="1.8" fill="#d62728" />
+  </g>
+  <g class="legend" font-family="sans-serif" font-size="11" fill="#222222">
+    <rect
+      x="76"
+      y="42"
+      width="130"
+      height="56"
+      fill="#ffffff"
+      fill-opacity="0.85"
+      stroke="#cccccc"
+      stroke-width="0.5"
+    />
+    <line x1="82" y1="52" x2="100" y2="52" stroke="#1f77b4" stroke-width="2" />
+    <text x="106" y="56">best score</text>
+    <line x1="82" y1="68" x2="100" y2="68" stroke="#2ca02c" stroke-width="2" />
+    <text x="106" y="72">neurons</text>
+    <line x1="82" y1="84" x2="100" y2="84" stroke="#d62728" stroke-width="2" />
+    <text x="106" y="88">synapses</text>
+  </g>
+  <g class="final-annotation" font-family="sans-serif" font-size="12" fill="#222222">
+    <line
+      x1="730"
+      y1="40"
+      x2="718"
+      y2="52"
+      stroke="#666666"
+      stroke-width="0.8"
+      stroke-dasharray="2,2"
+    />
+    <circle cx="730" cy="40" r="3.5" fill="#222222" />
+    <text x="718" y="52" text-anchor="end">gen 99: 500, 5 neurons, 4 synapses</text>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary

Wired the cart-pole example to capture per-generation `{generation, score, neurons, synapses}` samples and render a dual-axis evolution chart at `docs/screenshots/cart_pole/evolution.svg`, embedded in `cart_pole/README.md`. Closes #107.

- Extended `GenerationInfo` in `cart_pole/cart_pole.ts` with `neurons` and `synapses` fields, populated from the generation's champion creature.
- Main runner collects `EvolutionSample[]` via the existing `onGeneration` callback and calls `renderEvolutionChartSVG(...)` from `common/evolution_chart.ts`.
- `cart_pole/README.md` lists the new artefact and embeds the chart with descriptive alt-text.
- `cart_pole/run.sh` formats the new SVG so `deno fmt --check` stays clean.

## Test Plan

- Added `evolveCartPoleController emits GenerationInfo with neurons and synapses counts` in `cart_pole/cart_pole_test.ts`.
- 19/19 cart_pole tests pass; full suite 747 passed, 0 failed.
- `deno lint`, `deno fmt --check`, `deno check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)