### PR TITLE
Top-level README: explain supervised batch vs RL/episode-based evolution (Issue #126)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,30 +22,89 @@ walkthrough — the per-example README explains the workflow, options, and outpu
 > [AGENTS.md](AGENTS.md#-no-warm-starts--evolution-must-start-from-random-noise) for the full
 > policy.
 
+## 🧭 Two Training Paradigms — Supervised vs Agent Evolution
+
+NEAT-AI runs the same evolutionary loop two very different ways. Knowing which applies to your
+problem is the difference between "this library fits" and "this library fits the next-door problem."
+
+- **📊 Batch supervised** — the dataset is `(input, target)` rows that are independent of each
+  other. Every creature scores against the **same** rows; fitness is aggregated error or accuracy.
+  Used by XOR, MNIST, Stock Market, and the long-form Evolution Showcase.
+- **🎮 Agent / episode-based** — each creature plays its own episode. The next observation depends
+  on the creature's previous action, so once two creatures diverge they see entirely different
+  observation streams. Fitness is the cumulative reward (or survival score) for the rollout. Used by
+  `snake_game`, `cart_pole`, `lunar_lander`, `mountain_car`, and `maze_navigation`.
+
+Both paradigms parallelise trivially: each creature's score (whether a sweep through rows or a fresh
+episode rollout) is independent of every other creature's. The only state that has to be shared
+across the population is the per-generation seed, so that fairness is preserved.
+
+> **"Does NEAT-AI handle stream-of-observation games like Snake?"** Yes — see
+> [`snake_game/README.md`](snake_game/README.md) for the canonical demonstration. Cart-Pole, Lunar
+> Lander, Mountain Car, and Maze Navigation follow the same agent loop with different physics.
+
+```mermaid
+flowchart LR
+    subgraph supervised ["📊 Batch supervised loop"]
+        direction TB
+        S1["dataset:<br/>fixed (input, target) rows"]
+        S2["score(creature, all rows)<br/>= aggregate error"]
+        S3["select &amp; mutate<br/>population"]
+        S1 --> S2 --> S3 --> S2
+    end
+
+    subgraph agent ["🎮 Agent / episode loop"]
+        direction TB
+        A1["population:<br/>for each creature"]
+        A2["rollout episode:<br/>for tick in episode"]
+        A3["observe → activate → step"]
+        A4["fitness =<br/>cumulative reward"]
+        A5["select &amp; mutate<br/>population"]
+        A1 --> A2 --> A3 --> A3
+        A3 --> A4 --> A5 --> A1
+    end
+
+    style supervised fill:#fff3cd,stroke:#f5a623,color:#333
+    style agent fill:#d4edda,stroke:#28a745,color:#333
+    style S1 fill:#3498db,stroke:#333,color:#fff
+    style S2 fill:#3498db,stroke:#333,color:#fff
+    style S3 fill:#3498db,stroke:#333,color:#fff
+    style A1 fill:#27ae60,stroke:#333,color:#fff
+    style A2 fill:#27ae60,stroke:#333,color:#fff
+    style A3 fill:#27ae60,stroke:#333,color:#fff
+    style A4 fill:#27ae60,stroke:#333,color:#fff
+    style A5 fill:#27ae60,stroke:#333,color:#fff
+```
+
+The remaining examples (`intelligent_design`, `discovery`, `discovery_at_scale`, `crossover`,
+`crispr_injection`, `mcmc_acceptance`, `memetic_evolution`, `synthetic_synapse`, `neuron_pruning`,
+`adaptive_mutation`, `suggest_improvements`) are tagged **🛠 technique** — they demonstrate a single
+operator or algorithm rather than a complete training paradigm.
+
 ## 🧬 Examples at a Glance
 
-| Example                                                               | What it shows                                                                                                                                                                                           | How to run                      |
-| --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
-| [🧠 XOR](xor_classification/README.md)                                | The "Hello World" of neuroevolution — evolve a tiny network that learns the XOR truth table, plus a multi-panel evolution-progression strip showing the running champion at each checkpoint generation. | `./xor_classification/run.sh`   |
-| [🎢 Cart-Pole](cart_pole/README.md)                                   | Evolve a controller that balances an inverted pole on a moving cart, render the run as an SVG strip, and emit a multi-panel evolution-progression strip linking the captured checkpoint generations.    | `./cart_pole/run.sh`            |
-| [🚀 Lunar Lander](lunar_lander/README.md)                             | Evolve a controller that lands a 2D lunar lander softly on a marked pad with limited fuel, plus a multi-panel evolution-progression strip showing the running champion at each checkpoint generation.   | `./lunar_lander/run.sh`         |
-| [🚗 Mountain Car](mountain_car/README.md)                             | Evolve a swing-up controller that drives an under-powered car up a sinusoidal hill to the goal flag.                                                                                                    | `./mountain_car/run.sh`         |
-| [🐍 Snake](snake_game/README.md)                                      | Evolve a controller that plays the classic Snake grid game and render the playthrough as an animated SVG.                                                                                               | `./snake_game/run.sh`           |
-| [🗺️ Maze Navigation](maze_navigation/README.md)                       | Evolve an agent to navigate a fixed grid maze from start to goal using local wall + heading sensors.                                                                                                    | `./maze_navigation/run.sh`      |
-| [🧬 Intelligent Design](intelligent_design/README.md)                 | Systematically swap activation functions on hidden neurons to find better squashes than random mutation.                                                                                                | `./intelligent_design/run.sh`   |
-| [🔍 Discovery](discovery/README.md)                                   | Cripple a creature by removing a neuron, then use evolutionary search to recover its behaviour.                                                                                                         | `./discovery/run.sh`            |
-| [🔬 Discovery at Scale](discovery_at_scale/README.md)                 | Inject saturated, dead, dormant, and bottleneck defects into a ~200-neuron creature; run discovery; render before/after topology with a defect-category legend.                                         | `./discovery_at_scale/run.sh`   |
-| [🔀 Crossover](crossover/README.md)                                   | Breed two parents with different architectures into an offspring and (optionally) evolve it further.                                                                                                    | `./crossover/run.sh`            |
-| [🧬 CRISPR Injection](crispr_injection/README.md)                     | Splice a hand-crafted "edit gene" into a stalled population mid-evolution and visualise the fitness lift.                                                                                               | `./crispr_injection/run.sh`     |
-| [📈 Stock Market](stock_market/README.md)                             | Evolve a tiny network that predicts next-period S&P 500 direction from a window of recent returns.                                                                                                      | `./stock_market/run.sh`         |
-| [🔢 MNIST](mnist_classification/README.md)                            | Evolve a 196 → 10 logistic classifier on a small MNIST subset and render an animated grid of predictions.                                                                                               | `./mnist_classification/run.sh` |
-| [🌡️ MCMC Acceptance](mcmc_acceptance/README.md)                       | Visualise Metropolis-Hastings mutation acceptance cooling toward the 23.4% optimal target.                                                                                                              | `./mcmc_acceptance/run.sh`      |
-| [🧠 Memetic Evolution](memetic_evolution/README.md)                   | Compare evolutions with and without seeding from an archive of the fittest creatures' weights.                                                                                                          | `./memetic_evolution/run.sh`    |
-| [🧬 Synthetic Synapse](synthetic_synapse/README.md)                   | Densify an evolved sparse creature with zero-weight synthetic synapses, train, then prune the unused edges.                                                                                             | `./synthetic_synapse/run.sh`    |
-| [✂️ Neuron Pruning](neuron_pruning/README.md)                         | Remove neurons whose activations don't vary, folding their bias contribution into downstream neighbours.                                                                                                | `./neuron_pruning/run.sh`       |
-| [🧬 Adaptive Mutation](adaptive_mutation/README.md)                   | Visualise how the mutation operator distribution shifts from topology to weights as a creature grows.                                                                                                   | `./adaptive_mutation/run.sh`    |
-| [💡 Suggest Improvements](suggest_improvements/README.md)             | Analyse the project and emit categorised improvement suggestions you can file as GitHub issues.                                                                                                         | `./suggest_improvements/run.sh` |
-| [🌱 Evolution Showcase](evolution_showcase/README.md) ⏳ long-running | Flagship long-form run: evolve for 10000 generations and render gen 1 / 10 / 100 / 1000 / 10000 side-by-side.                                                                                           | `./evolution_showcase/run.sh`   |
+| Example                                                               | Paradigm      | What it shows                                                                                                                                                                                           | How to run                      |
+| --------------------------------------------------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| [🧠 XOR](xor_classification/README.md)                                | 📊 supervised | The "Hello World" of neuroevolution — evolve a tiny network that learns the XOR truth table, plus a multi-panel evolution-progression strip showing the running champion at each checkpoint generation. | `./xor_classification/run.sh`   |
+| [🎢 Cart-Pole](cart_pole/README.md)                                   | 🎮 agent      | Evolve a controller that balances an inverted pole on a moving cart, render the run as an SVG strip, and emit a multi-panel evolution-progression strip linking the captured checkpoint generations.    | `./cart_pole/run.sh`            |
+| [🚀 Lunar Lander](lunar_lander/README.md)                             | 🎮 agent      | Evolve a controller that lands a 2D lunar lander softly on a marked pad with limited fuel, plus a multi-panel evolution-progression strip showing the running champion at each checkpoint generation.   | `./lunar_lander/run.sh`         |
+| [🚗 Mountain Car](mountain_car/README.md)                             | 🎮 agent      | Evolve a swing-up controller that drives an under-powered car up a sinusoidal hill to the goal flag.                                                                                                    | `./mountain_car/run.sh`         |
+| [🐍 Snake](snake_game/README.md)                                      | 🎮 agent      | Evolve a controller that plays the classic Snake grid game and render the playthrough as an animated SVG.                                                                                               | `./snake_game/run.sh`           |
+| [🗺️ Maze Navigation](maze_navigation/README.md)                       | 🎮 agent      | Evolve an agent to navigate a fixed grid maze from start to goal using local wall + heading sensors.                                                                                                    | `./maze_navigation/run.sh`      |
+| [🧬 Intelligent Design](intelligent_design/README.md)                 | 🛠 technique   | Systematically swap activation functions on hidden neurons to find better squashes than random mutation.                                                                                                | `./intelligent_design/run.sh`   |
+| [🔍 Discovery](discovery/README.md)                                   | 🛠 technique   | Cripple a creature by removing a neuron, then use evolutionary search to recover its behaviour.                                                                                                         | `./discovery/run.sh`            |
+| [🔬 Discovery at Scale](discovery_at_scale/README.md)                 | 🛠 technique   | Inject saturated, dead, dormant, and bottleneck defects into a ~200-neuron creature; run discovery; render before/after topology with a defect-category legend.                                         | `./discovery_at_scale/run.sh`   |
+| [🔀 Crossover](crossover/README.md)                                   | 🛠 technique   | Breed two parents with different architectures into an offspring and (optionally) evolve it further.                                                                                                    | `./crossover/run.sh`            |
+| [🧬 CRISPR Injection](crispr_injection/README.md)                     | 🛠 technique   | Splice a hand-crafted "edit gene" into a stalled population mid-evolution and visualise the fitness lift.                                                                                               | `./crispr_injection/run.sh`     |
+| [📈 Stock Market](stock_market/README.md)                             | 📊 supervised | Evolve a tiny network that predicts next-period S&P 500 direction from a window of recent returns.                                                                                                      | `./stock_market/run.sh`         |
+| [🔢 MNIST](mnist_classification/README.md)                            | 📊 supervised | Evolve a 196 → 10 logistic classifier on a small MNIST subset and render an animated grid of predictions.                                                                                               | `./mnist_classification/run.sh` |
+| [🌡️ MCMC Acceptance](mcmc_acceptance/README.md)                       | 🛠 technique   | Visualise Metropolis-Hastings mutation acceptance cooling toward the 23.4% optimal target.                                                                                                              | `./mcmc_acceptance/run.sh`      |
+| [🧠 Memetic Evolution](memetic_evolution/README.md)                   | 🛠 technique   | Compare evolutions with and without seeding from an archive of the fittest creatures' weights.                                                                                                          | `./memetic_evolution/run.sh`    |
+| [🧬 Synthetic Synapse](synthetic_synapse/README.md)                   | 🛠 technique   | Densify an evolved sparse creature with zero-weight synthetic synapses, train, then prune the unused edges.                                                                                             | `./synthetic_synapse/run.sh`    |
+| [✂️ Neuron Pruning](neuron_pruning/README.md)                         | 🛠 technique   | Remove neurons whose activations don't vary, folding their bias contribution into downstream neighbours.                                                                                                | `./neuron_pruning/run.sh`       |
+| [🧬 Adaptive Mutation](adaptive_mutation/README.md)                   | 🛠 technique   | Visualise how the mutation operator distribution shifts from topology to weights as a creature grows.                                                                                                   | `./adaptive_mutation/run.sh`    |
+| [💡 Suggest Improvements](suggest_improvements/README.md)             | 🛠 technique   | Analyse the project and emit categorised improvement suggestions you can file as GitHub issues.                                                                                                         | `./suggest_improvements/run.sh` |
+| [🌱 Evolution Showcase](evolution_showcase/README.md) ⏳ long-running | 📊 supervised | Flagship long-form run: evolve for 10000 generations and render gen 1 / 10 / 100 / 1000 / 10000 side-by-side.                                                                                           | `./evolution_showcase/run.sh`   |
 
 ## 📸 Screenshots
 

--- a/docs/archive_test.ts
+++ b/docs/archive_test.ts
@@ -76,6 +76,8 @@ Deno.test("No PR summary files remain in docs/ root", () => {
       if (entry.name === "pr-summary-108.md") continue;
       if (entry.name === "pr-summary-109.md") continue;
       if (entry.name === "pr-summary-110.md") continue;
+      if (entry.name === "pr-summary-111.md") continue;
+      if (entry.name === "pr-summary-126.md") continue;
       if (entry.name === "pr-summary-131.md") continue;
       if (entry.name === "pr-summary-137.md") continue;
       if (entry.name === "pr-summary-138.md") continue;

--- a/docs/pr-summary-126.md
+++ b/docs/pr-summary-126.md
@@ -1,0 +1,45 @@
+## Summary
+
+Adds a top-level **🧭 Two Training Paradigms — Supervised vs Agent Evolution** section to
+`README.md` so readers can answer "does NEAT-AI handle stream-of- observation games like Snake?"
+without trawling every example. The new section contrasts batch supervised evolution (XOR, MNIST,
+Stock Market, Evolution Showcase) with episode-based agent evolution (Snake, Cart-Pole, Lunar
+Lander, Mountain Car, Maze Navigation), explains why population × episode-length still parallelises
+trivially, and includes a side-by-side Mermaid diagram of both loops. Every row in the existing
+**Examples at a Glance** table now carries a paradigm badge — `📊 supervised`, `🎮 agent`, or
+`🛠 technique` — so readers can sort. Closes #126.
+
+## Evidence
+
+This is a documentation-only change — no UI to screenshot. The structural requirements are verified
+by tests in `readme_paradigms_test.ts` (see Test Plan below). The new section sits between the noise
+→ competent callout and the Examples at a Glance table:
+
+```mermaid
+flowchart LR
+    Q["Issue #125 — 'Can NEAT-AI play Snake?'"] --> R["🧭 Two Training Paradigms"]
+    R --> A["📊 Supervised loop:<br/>rows → fitness"]
+    R --> B["🎮 Agent loop:<br/>tick → observe → activate → step"]
+    R --> X["Tagged Examples table"]
+    style R fill:#fff3cd,stroke:#f5a623,color:#333
+    style A fill:#3498db,stroke:#333,color:#fff
+    style B fill:#27ae60,stroke:#333,color:#fff
+    style X fill:#9b59b6,stroke:#333,color:#fff
+```
+
+## Test Plan
+
+- New test file `readme_paradigms_test.ts` covers:
+  - The `Two Training Paradigms` heading exists and sits before `Examples at a Glance`.
+  - The section names XOR / MNIST / Stock Market on the supervised side and Snake / Cart-Pole /
+    Lunar Lander / Maze Navigation on the agent side.
+  - The pointer paragraph links to `snake_game/README.md`.
+  - At least one Mermaid diagram inside the section, covering both `dataset` (supervised) and
+    `observe` / `activate` / `step` (agent).
+  - Every example row in the `Examples at a Glance` table carries the correct emoji-prefixed badge
+    (`📊 supervised`, `🎮 agent`, or `🛠 technique`).
+- Existing `readme_structure_test.ts` and `mermaid_diagrams_test.ts` continue to pass — the new
+  section adds a fourth Mermaid diagram and the example links / screenshots are preserved.
+- `docs/archive_test.ts` updated to allowlist the new `pr-summary-126.md` and the pre-existing
+  `pr-summary-111.md`, which had been merged without an archive-allowlist update.
+- `deno lint`, `deno fmt --check`, and `deno check **/*.ts` pass cleanly.

--- a/readme_paradigms_test.ts
+++ b/readme_paradigms_test.ts
@@ -1,0 +1,229 @@
+/**
+ * Tests for the supervised-vs-agent paradigms section in README.md (issue #126).
+ *
+ * The top-level README must explain the difference between batch supervised
+ * evolution (XOR, MNIST, Stock Market) and episode-based agent evolution
+ * (Snake, Cart-Pole, Lunar Lander, Mountain Car, Maze Navigation), and tag
+ * every row in the Examples at a Glance table so readers can tell which
+ * paradigm an example belongs to.
+ *
+ * These are "what" tests — they read README.md and verify the structural
+ * elements the issue requires, not the implementation.
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+
+const README_PATH = "README.md";
+
+function loadReadme(): string {
+  return Deno.readTextFileSync(README_PATH);
+}
+
+/* ------------------------------------------------------------------ */
+/*  Section exists and sits before "Examples at a Glance"             */
+/* ------------------------------------------------------------------ */
+
+Deno.test("README.md has a Two Training Paradigms section", () => {
+  const content = loadReadme();
+  assertEquals(
+    /^##\s+.*(Two Training Paradigms|Supervised vs Agent)/im.test(content),
+    true,
+    "README.md should have a Two Training Paradigms / Supervised vs Agent heading",
+  );
+});
+
+Deno.test("paradigms section appears before Examples at a Glance", () => {
+  const content = loadReadme();
+  const paradigmMatch = content.match(/^##\s+.*(Two Training Paradigms|Supervised vs Agent).*$/im);
+  const examplesMatch = content.match(/^##\s+.*Examples at a Glance.*$/im);
+  assertEquals(paradigmMatch !== null, true, "paradigms section must exist");
+  assertEquals(examplesMatch !== null, true, "Examples at a Glance section must exist");
+  if (paradigmMatch && examplesMatch) {
+    const paradigmIndex = content.indexOf(paradigmMatch[0]);
+    const examplesIndex = content.indexOf(examplesMatch[0]);
+    assertEquals(
+      paradigmIndex < examplesIndex,
+      true,
+      "paradigms section should appear before Examples at a Glance",
+    );
+  }
+});
+
+/* ------------------------------------------------------------------ */
+/*  Section content covers both paradigms                             */
+/* ------------------------------------------------------------------ */
+
+function paradigmSection(content: string): string {
+  // Extract the text between the paradigms heading and the next H2.
+  const start = content.search(/^##\s+.*(Two Training Paradigms|Supervised vs Agent).*$/im);
+  if (start < 0) return "";
+  const after = content.slice(start + 1);
+  const nextHeadingOffset = after.search(/^##\s+/m);
+  return nextHeadingOffset < 0
+    ? content.slice(start)
+    : content.slice(start, start + 1 + nextHeadingOffset);
+}
+
+Deno.test("paradigms section explains batch supervised training", () => {
+  const section = paradigmSection(loadReadme());
+  for (const term of ["supervised", "XOR", "MNIST", "Stock Market"]) {
+    assertStringIncludes(
+      section.toLowerCase(),
+      term.toLowerCase(),
+      `paradigms section should mention ${term}`,
+    );
+  }
+});
+
+Deno.test("paradigms section explains episode-based agent evolution", () => {
+  const section = paradigmSection(loadReadme()).toLowerCase();
+  for (const term of ["agent", "episode", "snake", "cart", "lunar", "maze"]) {
+    assertStringIncludes(
+      section,
+      term,
+      `paradigms section should mention ${term}`,
+    );
+  }
+});
+
+Deno.test("paradigms section answers the Snake question", () => {
+  const section = paradigmSection(loadReadme()).toLowerCase();
+  // The pointer paragraph must point readers to snake_game/README.md.
+  assertStringIncludes(
+    section,
+    "snake_game/readme.md",
+    "paradigms section should link to snake_game/README.md as the canonical agent demo",
+  );
+});
+
+/* ------------------------------------------------------------------ */
+/*  Section contains a Mermaid diagram covering both loops            */
+/* ------------------------------------------------------------------ */
+
+function extractMermaidBlocks(content: string): string[] {
+  const blocks: string[] = [];
+  const regex = /```mermaid\n([\s\S]*?)```/g;
+  let m: RegExpExecArray | null;
+  while ((m = regex.exec(content)) !== null) blocks.push(m[1]);
+  return blocks;
+}
+
+Deno.test("paradigms section contains a Mermaid diagram", () => {
+  const section = paradigmSection(loadReadme());
+  const blocks = extractMermaidBlocks(section);
+  assertEquals(
+    blocks.length >= 1,
+    true,
+    "paradigms section should contain at least one mermaid diagram",
+  );
+});
+
+Deno.test("paradigms diagram covers both loops", () => {
+  const section = paradigmSection(loadReadme());
+  const diagrams = extractMermaidBlocks(section).join("\n").toLowerCase();
+  // Supervised loop keywords.
+  assertStringIncludes(diagrams, "dataset", "supervised loop should mention the dataset/rows");
+  // Episode loop keywords.
+  for (const term of ["observe", "activate", "step"]) {
+    assertStringIncludes(
+      diagrams,
+      term,
+      `episode loop should mention ${term}`,
+    );
+  }
+});
+
+/* ------------------------------------------------------------------ */
+/*  Examples at a Glance table tags every row                         */
+/* ------------------------------------------------------------------ */
+
+const SUPERVISED_EXAMPLES = [
+  "XOR",
+  "MNIST",
+  "Stock Market",
+  "Evolution Showcase",
+] as const;
+
+const AGENT_EXAMPLES = [
+  "Cart-Pole",
+  "Lunar Lander",
+  "Mountain Car",
+  "Snake",
+  "Maze Navigation",
+] as const;
+
+const TECHNIQUE_EXAMPLES = [
+  "Intelligent Design",
+  "Discovery",
+  "Discovery at Scale",
+  "Crossover",
+  "CRISPR Injection",
+  "MCMC Acceptance",
+  "Memetic Evolution",
+  "Synthetic Synapse",
+  "Neuron Pruning",
+  "Adaptive Mutation",
+  "Suggest Improvements",
+] as const;
+
+function examplesAtAGlanceTable(content: string): string {
+  const start = content.search(/^##\s+.*Examples at a Glance.*$/im);
+  if (start < 0) return "";
+  const after = content.slice(start + 1);
+  const nextHeadingOffset = after.search(/^##\s+/m);
+  return nextHeadingOffset < 0
+    ? content.slice(start)
+    : content.slice(start, start + 1 + nextHeadingOffset);
+}
+
+// Badge tokens must be the explicit emoji + word so they cannot be
+// satisfied by the word appearing inside an example's description prose.
+const SUPERVISED_BADGE = "📊 supervised";
+const AGENT_BADGE = "🎮 agent";
+const TECHNIQUE_BADGE = "🛠 technique";
+
+function rowsForExample(table: string, name: string): string[] {
+  return table.split("\n").filter((l) => l.includes("[") && l.includes(name));
+}
+
+for (const name of SUPERVISED_EXAMPLES) {
+  Deno.test(`Examples table tags ${name} as supervised`, () => {
+    const table = examplesAtAGlanceTable(loadReadme());
+    const lines = rowsForExample(table, name);
+    assertEquals(lines.length >= 1, true, `Examples table should contain a row for ${name}`);
+    const tagged = lines.filter((l) => l.includes(SUPERVISED_BADGE));
+    assertEquals(
+      tagged.length >= 1,
+      true,
+      `Examples table row for ${name} should include the "${SUPERVISED_BADGE}" badge`,
+    );
+  });
+}
+
+for (const name of AGENT_EXAMPLES) {
+  Deno.test(`Examples table tags ${name} as agent`, () => {
+    const table = examplesAtAGlanceTable(loadReadme());
+    const lines = rowsForExample(table, name);
+    assertEquals(lines.length >= 1, true, `Examples table should contain a row for ${name}`);
+    const tagged = lines.filter((l) => l.includes(AGENT_BADGE));
+    assertEquals(
+      tagged.length >= 1,
+      true,
+      `Examples table row for ${name} should include the "${AGENT_BADGE}" badge`,
+    );
+  });
+}
+
+for (const name of TECHNIQUE_EXAMPLES) {
+  Deno.test(`Examples table tags ${name} as technique`, () => {
+    const table = examplesAtAGlanceTable(loadReadme());
+    const lines = rowsForExample(table, name);
+    assertEquals(lines.length >= 1, true, `Examples table should contain a row for ${name}`);
+    const tagged = lines.filter((l) => l.includes(TECHNIQUE_BADGE));
+    assertEquals(
+      tagged.length >= 1,
+      true,
+      `Examples table row for ${name} should include the "${TECHNIQUE_BADGE}" badge`,
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Adds a top-level **🧭 Two Training Paradigms — Supervised vs Agent Evolution** section to
`README.md` so readers can answer "does NEAT-AI handle stream-of- observation games like Snake?"
without trawling every example. The new section contrasts batch supervised evolution (XOR, MNIST,
Stock Market, Evolution Showcase) with episode-based agent evolution (Snake, Cart-Pole, Lunar
Lander, Mountain Car, Maze Navigation), explains why population × episode-length still parallelises
trivially, and includes a side-by-side Mermaid diagram of both loops. Every row in the existing
**Examples at a Glance** table now carries a paradigm badge — `📊 supervised`, `🎮 agent`, or
`🛠 technique` — so readers can sort. Closes #126.

## Evidence

This is a documentation-only change — no UI to screenshot. The structural requirements are verified
by tests in `readme_paradigms_test.ts` (see Test Plan below). The new section sits between the noise
→ competent callout and the Examples at a Glance table:

```mermaid
flowchart LR
    Q["Issue #125 — 'Can NEAT-AI play Snake?'"] --> R["🧭 Two Training Paradigms"]
    R --> A["📊 Supervised loop:<br/>rows → fitness"]
    R --> B["🎮 Agent loop:<br/>tick → observe → activate → step"]
    R --> X["Tagged Examples table"]
    style R fill:#fff3cd,stroke:#f5a623,color:#333
    style A fill:#3498db,stroke:#333,color:#fff
    style B fill:#27ae60,stroke:#333,color:#fff
    style X fill:#9b59b6,stroke:#333,color:#fff
```

## Test Plan

- New test file `readme_paradigms_test.ts` covers:
  - The `Two Training Paradigms` heading exists and sits before `Examples at a Glance`.
  - The section names XOR / MNIST / Stock Market on the supervised side and Snake / Cart-Pole /
    Lunar Lander / Maze Navigation on the agent side.
  - The pointer paragraph links to `snake_game/README.md`.
  - At least one Mermaid diagram inside the section, covering both `dataset` (supervised) and
    `observe` / `activate` / `step` (agent).
  - Every example row in the `Examples at a Glance` table carries the correct emoji-prefixed badge
    (`📊 supervised`, `🎮 agent`, or `🛠 technique`).
- Existing `readme_structure_test.ts` and `mermaid_diagrams_test.ts` continue to pass — the new
  section adds a fourth Mermaid diagram and the example links / screenshots are preserved.
- `docs/archive_test.ts` updated to allowlist the new `pr-summary-126.md` and the pre-existing
  `pr-summary-111.md`, which had been merged without an archive-allowlist update.
- `deno lint`, `deno fmt --check`, and `deno check **/*.ts` pass cleanly.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-126 -->