### PR TITLE
lunar_lander: explode on crash + outcome badge (#177)

### DIFF
--- a/docs/archive_test.ts
+++ b/docs/archive_test.ts
@@ -97,6 +97,8 @@ Deno.test("No PR summary files remain in docs/ root", () => {
       if (entry.name === "pr-summary-154.md") continue;
       if (entry.name === "pr-summary-155.md") continue;
       if (entry.name === "pr-summary-159.md") continue;
+      if (entry.name === "pr-summary-160.md") continue;
+      if (entry.name === "pr-summary-177.md") continue;
       throw new Error(
         `Found unexpected PR summary file in docs/ root: ${entry.name}`,
       );

--- a/docs/pr-summary-177.md
+++ b/docs/pr-summary-177.md
@@ -1,0 +1,62 @@
+## Summary
+
+The lunar-lander champion screenshot showed the lander resting calmly at the end of every run, even
+when the run had crashed off the pad — the viewer could not tell whether the descent succeeded.
+Reported in [issue #177](https://github.com/stSoftwareAU/NEAT-AI-Examples/issues/177) ("Rocket
+doesn't look like it's landing, should have exploded"), the request was: either evolve long enough
+to land, or **explode** if the run did not land — and surface the evolution statistics. Closes #177.
+
+The renderer (`lunar_lander/svg.ts`) now classifies the trace's final state and, when the outcome is
+`crashed` or `out_of_bounds`, replaces the resting-pose lander with a pulsing **starburst-and-debris
+explosion** plus an `EXPLODED` / `OUT OF BOUNDS` caption. A colour-coded **outcome badge**
+(`✓ LANDED` / `✗ CRASHED` / `✗ OUT OF BOUNDS` / `… TIMED OUT`) sits in the top-right of the canvas
+so the run result is unmistakable at a glance — including the timed-out case the title flagged. The
+evolution chart and multi-panel evolution-progress strip already capture the per-generation
+statistics requested in the issue, so no further chart work was required.
+
+```mermaid
+flowchart LR
+    REPLAY["replayController<br/>(canonical run)"]
+    CLASSIFY["classifyOutcome<br/>(landed / crashed / oob / flying)"]
+    EXPLODED{"crashed or<br/>out_of_bounds?"}
+    POSE["resting-pose lander<br/>+ ✓ LANDED badge"]
+    BOOM["starburst + debris<br/>+ EXPLODED caption<br/>+ ✗ outcome badge"]
+    SVG["docs/screenshots/<br/>lunar_lander.svg"]
+
+    REPLAY --> CLASSIFY
+    CLASSIFY --> EXPLODED
+    EXPLODED -- "no" --> POSE --> SVG
+    EXPLODED -- "yes" --> BOOM --> SVG
+```
+
+## Evidence
+
+- Re-running `./lunar_lander/run.sh` produced a champion that solved the task at gen 247
+  (`landed=60%`) and the canonical replay landed successfully — the regenerated
+  `docs/screenshots/lunar_lander.svg` now carries a `✓ LANDED` outcome badge in the top-right
+  corner.
+- For runs that don't land, four new unit tests cover the explosion branches:
+  - `renderRunSVG draws an explosion when the run crashed (issue #177)` — asserts the
+    `<g class="explosion">` group, `EXPLODED` caption, `class="starburst"` polygon, and `✗ CRASHED`
+    outcome badge are all emitted for a hard-crash trace.
+  - `renderRunSVG draws an out-of-bounds explosion when the lander
+    drifted off-world` — asserts
+    `OUT OF BOUNDS` caption and badge.
+  - `renderRunSVG does NOT draw an explosion on a clean landing` — confirms the explosion graphic is
+    omitted on safe touchdowns and the `✓ LANDED` badge is shown instead.
+  - `renderRunSVG accepts an explicit outcome override (issue #177)` — confirms the optional third
+    argument lets callers pin the outcome.
+
+This is a CLI/rendering change — the SVG is the user-visible artefact and is committed alongside the
+code so reviewers can inspect it directly.
+
+## Test Plan
+
+- `deno test --no-check --allow-read --allow-write --allow-env --allow-net
+  --allow-ffi lunar_lander/lunar_lander_test.ts`
+  — all 30 tests pass, including the four new explosion-rendering tests.
+- `deno lint`, `deno fmt --check`, `deno check **/*.ts` — clean.
+- Full `deno test` suite passes (`docs/archive_test.ts` allowlist updated to include
+  `pr-summary-177.md` and the pre-existing `pr-summary-160.md`).
+- `./lunar_lander/run.sh` re-ran end-to-end (6m 36s) and regenerated the screenshot, evolution
+  chart, and progress strip without errors.

--- a/docs/screenshots/lunar_lander.svg
+++ b/docs/screenshots/lunar_lander.svg
@@ -206,6 +206,7 @@
       fill="#cccccc"
     >step 129</text>
   </g>
+
   <g class="animated-lander" transform="translate(252.00 60.91)">
     <animateTransform
       attributeName="transform"
@@ -332,4 +333,16 @@
     font-size="11"
     fill="#9ad9ff"
   >animated · loops every 6s</text>
+  <g class="outcome-badge" data-outcome="landed">
+    <rect x="710.40" y="12" width="77.60" height="22" rx="4" fill="#7ed321" opacity="0.92" />
+    <text
+      x="749.20"
+      y="28.00"
+      text-anchor="middle"
+      font-family="monospace"
+      font-size="12"
+      font-weight="bold"
+      fill="#0b0b1a"
+    >✓ LANDED</text>
+  </g>
 </svg>

--- a/docs/screenshots/lunar_lander_evolution.svg
+++ b/docs/screenshots/lunar_lander_evolution.svg
@@ -262,6 +262,6 @@
       font-family="sans-serif"
       font-size="12"
       fill="#ffffff"
-    >final score 714.127 • 247 generations • 14.2min</text>
+    >final score 714.127 • 247 generations • 6.6min</text>
   </g>
 </svg>

--- a/lunar_lander/README.md
+++ b/lunar_lander/README.md
@@ -108,7 +108,12 @@ Artefacts:
   `TARGET` arrow, a polyline trace, the lander rendered at start, mid-descent, and touchdown, plus a
   moving lander icon that **tilts with the controller's angle** and lights its **main / left RCS /
   right RCS** flames as the thrusters fire. A shrinking `FUEL` HUD bar surfaces the fuel budget so
-  viewers can see the controller "fight gravity & fuel" while aiming for the pad.
+  viewers can see the controller "fight gravity & fuel" while aiming for the pad. **When the
+  champion crashes or drifts out of bounds**, the renderer replaces the resting lander with a
+  pulsing starburst-and-debris **explosion** plus an `EXPLODED` / `OUT OF BOUNDS` caption, and a
+  colour-coded outcome badge (`✓ LANDED` / `✗ CRASHED` / `✗ OUT OF BOUNDS` / `… TIMED OUT`) sits in
+  the top-right corner so the result is unmistakable
+  ([issue #177](https://github.com/stSoftwareAU/NEAT-AI-Examples/issues/177)).
 - `docs/screenshots/lunar_lander_evolution.svg` — multi-panel evolution-progression strip rendered
   from the captured snapshots
 - `docs/screenshots/lunar_lander/evolution.svg` — dual-axis evolution chart plotting best score and

--- a/lunar_lander/lunar_lander.ts
+++ b/lunar_lander/lunar_lander.ts
@@ -760,6 +760,9 @@ if (import.meta.main) {
   console.log(`💾 Saved champion to ${championPath}`);
 
   const trace = replayController(result.champion);
+  // Renderer defaults to classifying the trace's own final state, so
+  // the explosion graphic + outcome badge match what the trace shows
+  // rather than the multi-trial worst-case outcome (issue #177).
   const svg = renderRunSVG(trace);
   ensureDirSync("docs/screenshots");
   await Deno.writeTextFile(SCREENSHOT_PATH, svg);

--- a/lunar_lander/lunar_lander_test.ts
+++ b/lunar_lander/lunar_lander_test.ts
@@ -586,6 +586,181 @@ Deno.test(
   },
 );
 
+Deno.test(
+  "renderRunSVG draws an explosion when the run crashed (issue #177)",
+  () => {
+    // Hand-craft a trace whose final frame is a hard crash off the pad —
+    // the renderer must visualise the wreck rather than showing the
+    // resting-pose lander.
+    const trace = [
+      {
+        state: {
+          x: -20,
+          y: 80,
+          vx: 2,
+          vy: 0,
+          angle: 0,
+          angularV: 0,
+          fuel: 100,
+        } as LanderState,
+        action: { main: false, left: false, right: false },
+      },
+      {
+        state: {
+          // Far from the pad, fast horizontal speed, large tilt: classifies
+          // as `crashed`.
+          x: -30,
+          y: 0,
+          vx: 8,
+          vy: -15,
+          angle: 0.9,
+          angularV: 0,
+          fuel: 0,
+        } as LanderState,
+        action: { main: false, left: false, right: false },
+      },
+    ];
+    const svg = renderRunSVG(trace);
+    assert(
+      svg.includes('class="explosion"'),
+      "expected an explosion group on a crashed run",
+    );
+    assert(svg.includes(">EXPLODED<"), "expected an EXPLODED caption on the wreck");
+    assert(
+      svg.includes('class="starburst"'),
+      "expected a starburst polygon as part of the explosion",
+    );
+    assert(
+      svg.includes('class="outcome-badge"'),
+      "expected an outcome badge identifying the run result",
+    );
+    assert(svg.includes(">✗ CRASHED<"), "expected the badge to label the run as CRASHED");
+  },
+);
+
+Deno.test(
+  "renderRunSVG draws an out-of-bounds explosion when the lander drifted off-world",
+  () => {
+    // Final state outside the world half-width — classifies as
+    // `out_of_bounds`. The renderer should still show debris, but with
+    // an "OUT OF BOUNDS" caption on the wreck and a matching badge.
+    const trace = [
+      {
+        state: {
+          x: -20,
+          y: 80,
+          vx: 0,
+          vy: 0,
+          angle: 0,
+          angularV: 0,
+          fuel: 100,
+        } as LanderState,
+        action: { main: false, left: false, right: false },
+      },
+      {
+        state: {
+          // Beyond DEFAULT_TERRAIN.worldHalfWidth = 50.
+          x: -80,
+          y: 30,
+          vx: -10,
+          vy: -2,
+          angle: 0,
+          angularV: 0,
+          fuel: 0,
+        } as LanderState,
+        action: { main: false, left: false, right: false },
+      },
+    ];
+    const svg = renderRunSVG(trace);
+    assert(
+      svg.includes('class="explosion"'),
+      "expected an explosion group on out-of-bounds runs",
+    );
+    assert(
+      svg.includes(">OUT OF BOUNDS<"),
+      "expected an OUT OF BOUNDS caption on the wreck",
+    );
+    assert(
+      svg.includes(">✗ OUT OF BOUNDS<"),
+      "expected the outcome badge to label the run as OUT OF BOUNDS",
+    );
+  },
+);
+
+Deno.test(
+  "renderRunSVG does NOT draw an explosion on a clean landing",
+  () => {
+    // Final state inside the pad with all safe-landing limits met —
+    // classifies as `landed`. The renderer must keep the resting-pose
+    // lander and omit the wreck graphic.
+    const trace = [
+      {
+        state: {
+          x: -20,
+          y: 80,
+          vx: 2,
+          vy: 0,
+          angle: 0,
+          angularV: 0,
+          fuel: 100,
+        } as LanderState,
+        action: { main: false, left: false, right: false },
+      },
+      {
+        state: {
+          x: 0,
+          y: 0,
+          vx: 0,
+          vy: -0.5,
+          angle: 0,
+          angularV: 0,
+          fuel: 50,
+        } as LanderState,
+        action: { main: false, left: false, right: false },
+      },
+    ];
+    const svg = renderRunSVG(trace);
+    assert(
+      !svg.includes('class="explosion"'),
+      "expected no explosion group on a successful landing",
+    );
+    assert(
+      svg.includes(">✓ LANDED<"),
+      "expected the outcome badge to label the run as LANDED",
+    );
+  },
+);
+
+Deno.test(
+  "renderRunSVG accepts an explicit outcome override (issue #177)",
+  () => {
+    // The lunar-lander runner classifies the champion's run with the
+    // multi-trial `championOutcome` and forwards that to the renderer.
+    // The renderer must honour the override even if the trace's final
+    // frame would classify differently.
+    const trace = [
+      {
+        state: {
+          x: 0,
+          y: 0,
+          vx: 0,
+          vy: -0.5,
+          angle: 0,
+          angularV: 0,
+          fuel: 50,
+        } as LanderState,
+        action: { main: false, left: false, right: false },
+      },
+    ];
+    const svg = renderRunSVG(trace, DEFAULT_TERRAIN, "crashed");
+    assert(
+      svg.includes('class="explosion"'),
+      "expected an explosion group when the override outcome is `crashed`",
+    );
+    assert(svg.includes(">✗ CRASHED<"), "expected the badge to honour the override");
+  },
+);
+
 Deno.test("renderRunSVG marks the landing pad with a TARGET indicator", () => {
   // Issue #72: the lander must aim for a specific location — make the
   // pad's role as the destination unmistakable with an arrow + label.

--- a/lunar_lander/svg.ts
+++ b/lunar_lander/svg.ts
@@ -9,8 +9,10 @@
  * so the same trace produces byte-identical output across platforms.
  */
 import {
+  classifyOutcome,
   DEFAULT_TERRAIN,
   type LanderAction,
+  type LanderOutcome,
   type LanderState,
   type LanderTerrain,
 } from "./physics.ts";
@@ -72,14 +74,24 @@ function projectY(y: number, ceiling: number): number {
  * @param trace The trace frames from start to terminal state. Must be
  *   non-empty.
  * @param terrain Terrain layout (defaults to {@link DEFAULT_TERRAIN}).
+ * @param outcome Final classification of the run. When the controller
+ *   `crashed` or drifted `out_of_bounds`, the renderer draws a starburst
+ *   explosion at the final state and replaces the resting-pose lander
+ *   with debris so the failure is visually unmistakable (issue #177).
+ *   Defaults to classifying the last frame's state.
  */
 export function renderRunSVG(
   trace: TraceFrame[],
   terrain: LanderTerrain = DEFAULT_TERRAIN,
+  outcome?: LanderOutcome,
 ): string {
   if (trace.length === 0) {
     throw new Error("trace must contain at least one frame");
   }
+
+  const finalState = trace[trace.length - 1].state;
+  const resolvedOutcome: LanderOutcome = outcome ?? classifyOutcome(finalState, terrain);
+  const exploded = resolvedOutcome === "crashed" || resolvedOutcome === "out_of_bounds";
 
   // Determine the world-y ceiling for projection: include the highest
   // point reached plus some headroom so the trajectory always fits.
@@ -97,13 +109,23 @@ export function renderRunSVG(
     .join(" ");
 
   // Pose indices: start, midpoint, last (deduplicated for very short traces).
+  // When the run ended in an explosion, suppress the resting-pose lander at
+  // the touchdown point — the debris/starburst takes its place so the wreck
+  // is unmistakable (issue #177).
   const lastIdx = trace.length - 1;
   const midIdx = Math.floor(lastIdx / 2);
-  const poseIndices = Array.from(new Set([0, midIdx, lastIdx]));
+  const baseIndices = [0, midIdx, lastIdx];
+  const poseIndices = Array.from(
+    new Set(exploded ? baseIndices.filter((i) => i !== lastIdx) : baseIndices),
+  );
 
   const poseGroups = poseIndices
     .map((idx) => renderPose(trace[idx], idx, terrain, ceiling))
     .join("\n");
+
+  const finalCx = projectX(finalState.x, terrain);
+  const finalCy = projectY(finalState.y, ceiling);
+  const explosionGroup = exploded ? renderExplosion(finalCx, finalCy, resolvedOutcome) : "";
 
   // Build SMIL keyframes for an animated lander icon that follows the
   // entire trajectory. Sample at most 80 points so the value lists stay
@@ -194,6 +216,11 @@ export function renderRunSVG(
     `  <polyline class="trajectory" points="${trajectoryPoints}" ` +
     `fill="none" stroke="#9ad9ff" stroke-width="2" stroke-dasharray="4 3"/>`,
     poseGroups,
+    // Static debris + starburst when the run ended in a crash or
+    // out-of-bounds drift (issue #177). Drawn before the animated lander
+    // so the SMIL animation overlays during the descent and the debris
+    // is what remains when the loop ends.
+    explosionGroup,
     // Animated lander: a translate-then-rotate group lets us draw the
     // lander geometry (body, hull, three thruster flames) once in a
     // local frame at (0,0) and animate the whole package through the
@@ -262,6 +289,10 @@ export function renderRunSVG(
     `  <text x="${SVG_WIDTH - 12}" y="${SVG_HEIGHT - 12}" text-anchor="end" ` +
     `font-family="sans-serif" font-size="11" fill="#9ad9ff">animated · loops every ` +
     `${ANIMATION_DURATION_SECONDS}s</text>`,
+    // Outcome badge — top-right of the canvas. Colour-coded so a viewer
+    // can tell at a glance whether the run landed, crashed, drifted out
+    // of bounds, or timed out (issue #177).
+    renderOutcomeBadge(resolvedOutcome),
     `</svg>`,
     "",
   ].join("\n");
@@ -381,4 +412,127 @@ function renderStars(): string {
     stars.push(`  <circle cx="${x}" cy="${y}" r="1" fill="#ffffff" opacity="0.7"/>`);
   }
   return stars.join("\n");
+}
+
+/** Number of starburst rays drawn around an explosion. */
+const EXPLOSION_RAY_COUNT = 12;
+
+/** Outer radius (px) of the explosion starburst rays. */
+const EXPLOSION_OUTER_RADIUS = 38;
+
+/** Inner radius (px) of the explosion starburst rays. */
+const EXPLOSION_INNER_RADIUS = 14;
+
+/** Number of jagged debris fragments scattered around the impact point. */
+const EXPLOSION_DEBRIS_COUNT = 6;
+
+/**
+ * Render the wreck of a crashed lander as a `<g class="explosion">` group.
+ *
+ * The graphic combines four layers so the outcome reads at a glance:
+ *
+ *   1. A pulsing fireball circle.
+ *   2. A radial starburst (zig-zag polygon) in bright orange.
+ *   3. Several short "debris" line fragments scattered around the centre.
+ *   4. An "EXPLODED" or "OUT OF BOUNDS" caption above the wreck.
+ *
+ * All geometry is deterministic — no PRNG calls — so the same impact
+ * point produces byte-identical SVG output across runs.
+ */
+function renderExplosion(
+  cx: number,
+  cy: number,
+  outcome: LanderOutcome,
+): string {
+  const points: string[] = [];
+  for (let i = 0; i < EXPLOSION_RAY_COUNT * 2; i++) {
+    const angle = (i / (EXPLOSION_RAY_COUNT * 2)) * Math.PI * 2;
+    const r = i % 2 === 0 ? EXPLOSION_OUTER_RADIUS : EXPLOSION_INNER_RADIUS;
+    const px = cx + Math.cos(angle) * r;
+    const py = cy + Math.sin(angle) * r;
+    points.push(`${px.toFixed(2)},${py.toFixed(2)}`);
+  }
+  const burstPoints = points.join(" ");
+
+  // Debris fragments — short white-grey segments fanning outward at
+  // evenly-spaced angles with deterministic length variation so the
+  // output stays stable across runs.
+  const debrisLines: string[] = [];
+  for (let i = 0; i < EXPLOSION_DEBRIS_COUNT; i++) {
+    const angle = (i / EXPLOSION_DEBRIS_COUNT) * Math.PI * 2 + Math.PI / 7;
+    // Deterministic per-shard length jitter — alternating short/long.
+    const len = i % 2 === 0 ? 22 : 14;
+    const x1 = cx + Math.cos(angle) * 6;
+    const y1 = cy + Math.sin(angle) * 6;
+    const x2 = cx + Math.cos(angle) * (6 + len);
+    const y2 = cy + Math.sin(angle) * (6 + len);
+    debrisLines.push(
+      `    <line class="debris" x1="${x1.toFixed(2)}" y1="${y1.toFixed(2)}" ` +
+        `x2="${x2.toFixed(2)}" y2="${
+          y2.toFixed(2)
+        }" stroke="#cccccc" stroke-width="2" stroke-linecap="round"/>`,
+    );
+  }
+
+  const caption = outcome === "out_of_bounds" ? "OUT OF BOUNDS" : "EXPLODED";
+
+  return [
+    `  <g class="explosion" data-outcome="${outcome}">`,
+    // Outer fireball — pulsing radius drives the eye to the wreck.
+    `    <circle class="fireball" cx="${cx.toFixed(2)}" cy="${cy.toFixed(2)}" ` +
+    `r="${EXPLOSION_OUTER_RADIUS}" fill="#ff8c1a" opacity="0.55">`,
+    `      <animate attributeName="r" values="${EXPLOSION_OUTER_RADIUS};${
+      (EXPLOSION_OUTER_RADIUS * 1.15).toFixed(2)
+    };${EXPLOSION_OUTER_RADIUS}" dur="1.2s" repeatCount="indefinite"/>`,
+    `      <animate attributeName="opacity" values="0.55;0.85;0.55" ` +
+    `dur="1.2s" repeatCount="indefinite"/>`,
+    `    </circle>`,
+    // Starburst — jagged star polygon in bright orange/yellow.
+    `    <polygon class="starburst" points="${burstPoints}" ` +
+    `fill="#ffd166" stroke="#ff5722" stroke-width="2" opacity="0.92"/>`,
+    // Inner core — bright yellow centre.
+    `    <circle class="core" cx="${cx.toFixed(2)}" cy="${cy.toFixed(2)}" r="6" ` +
+    `fill="#fff7d6"/>`,
+    ...debrisLines,
+    // Caption above the wreck — anchored centre so it sits over the impact.
+    `    <text class="explosion-label" x="${cx.toFixed(2)}" y="${
+      (cy - EXPLOSION_OUTER_RADIUS - 8).toFixed(2)
+    }" text-anchor="middle" font-family="monospace" font-size="13" ` +
+    `font-weight="bold" fill="#ff5722" stroke="#0b0b1a" stroke-width="0.5">${caption}</text>`,
+    `  </g>`,
+  ].join("\n");
+}
+
+/**
+ * Render an outcome badge in the top-right corner of the canvas. Each
+ * outcome gets a colour and a short label so a viewer can tell at a
+ * glance whether the run landed, crashed, drifted out of bounds, or
+ * timed out (issue #177).
+ */
+function renderOutcomeBadge(outcome: LanderOutcome): string {
+  const styles: Record<LanderOutcome, { label: string; fill: string }> = {
+    landed: { label: "✓ LANDED", fill: "#7ed321" },
+    crashed: { label: "✗ CRASHED", fill: "#ff5722" },
+    out_of_bounds: { label: "✗ OUT OF BOUNDS", fill: "#ff5722" },
+    flying: { label: "… TIMED OUT", fill: "#cccccc" },
+  };
+  const style = styles[outcome];
+  const padX = 10;
+  const padY = 6;
+  // Estimate text width from the label length so the badge sizes nicely.
+  const charWidth = 7.2;
+  const textWidth = style.label.length * charWidth;
+  const w = textWidth + padX * 2;
+  const h = 22;
+  const x = SVG_WIDTH - w - 12;
+  const y = 12;
+  return [
+    `  <g class="outcome-badge" data-outcome="${outcome}">`,
+    `    <rect x="${x.toFixed(2)}" y="${y}" width="${w.toFixed(2)}" height="${h}" rx="4" ` +
+    `fill="${style.fill}" opacity="0.92"/>`,
+    `    <text x="${(x + w / 2).toFixed(2)}" y="${(y + h - padY).toFixed(2)}" ` +
+    `text-anchor="middle" font-family="monospace" font-size="12" font-weight="bold" ` +
+    `fill="#0b0b1a">${style.label}</text>`,
+    `  </g>`,
+  ].join("\n");
 }


### PR DESCRIPTION
## Summary

The lunar-lander champion screenshot showed the lander resting calmly at the end of every run, even
when the run had crashed off the pad — the viewer could not tell whether the descent succeeded.
Reported in [issue #177](https://github.com/stSoftwareAU/NEAT-AI-Examples/issues/177) ("Rocket
doesn't look like it's landing, should have exploded"), the request was: either evolve long enough
to land, or **explode** if the run did not land — and surface the evolution statistics. Closes #177.

The renderer (`lunar_lander/svg.ts`) now classifies the trace's final state and, when the outcome is
`crashed` or `out_of_bounds`, replaces the resting-pose lander with a pulsing **starburst-and-debris
explosion** plus an `EXPLODED` / `OUT OF BOUNDS` caption. A colour-coded **outcome badge**
(`✓ LANDED` / `✗ CRASHED` / `✗ OUT OF BOUNDS` / `… TIMED OUT`) sits in the top-right of the canvas
so the run result is unmistakable at a glance — including the timed-out case the title flagged. The
evolution chart and multi-panel evolution-progress strip already capture the per-generation
statistics requested in the issue, so no further chart work was required.

```mermaid
flowchart LR
    REPLAY["replayController<br/>(canonical run)"]
    CLASSIFY["classifyOutcome<br/>(landed / crashed / oob / flying)"]
    EXPLODED{"crashed or<br/>out_of_bounds?"}
    POSE["resting-pose lander<br/>+ ✓ LANDED badge"]
    BOOM["starburst + debris<br/>+ EXPLODED caption<br/>+ ✗ outcome badge"]
    SVG["docs/screenshots/<br/>lunar_lander.svg"]

    REPLAY --> CLASSIFY
    CLASSIFY --> EXPLODED
    EXPLODED -- "no" --> POSE --> SVG
    EXPLODED -- "yes" --> BOOM --> SVG
```

## Evidence

- Re-running `./lunar_lander/run.sh` produced a champion that solved the task at gen 247
  (`landed=60%`) and the canonical replay landed successfully — the regenerated
  `docs/screenshots/lunar_lander.svg` now carries a `✓ LANDED` outcome badge in the top-right
  corner.
- For runs that don't land, four new unit tests cover the explosion branches:
  - `renderRunSVG draws an explosion when the run crashed (issue #177)` — asserts the
    `<g class="explosion">` group, `EXPLODED` caption, `class="starburst"` polygon, and `✗ CRASHED`
    outcome badge are all emitted for a hard-crash trace.
  - `renderRunSVG draws an out-of-bounds explosion when the lander
    drifted off-world` — asserts
    `OUT OF BOUNDS` caption and badge.
  - `renderRunSVG does NOT draw an explosion on a clean landing` — confirms the explosion graphic is
    omitted on safe touchdowns and the `✓ LANDED` badge is shown instead.
  - `renderRunSVG accepts an explicit outcome override (issue #177)` — confirms the optional third
    argument lets callers pin the outcome.

This is a CLI/rendering change — the SVG is the user-visible artefact and is committed alongside the
code so reviewers can inspect it directly.

## Test Plan

- `deno test --no-check --allow-read --allow-write --allow-env --allow-net
  --allow-ffi lunar_lander/lunar_lander_test.ts`
  — all 30 tests pass, including the four new explosion-rendering tests.
- `deno lint`, `deno fmt --check`, `deno check **/*.ts` — clean.
- Full `deno test` suite passes (`docs/archive_test.ts` allowlist updated to include
  `pr-summary-177.md` and the pre-existing `pr-summary-160.md`).
- `./lunar_lander/run.sh` re-ran end-to-end (6m 36s) and regenerated the screenshot, evolution
  chart, and progress strip without errors.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-177 -->