### PR TITLE
Acronyms should be spelled out or linked to definitions first time you use them on a page (Issue #178)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,19 @@
 [![Licence](https://img.shields.io/badge/licence-Apache%202.0-blue.svg)](LICENSE)
 [![Deno](https://img.shields.io/badge/Deno-2.x-black?logo=deno)](https://deno.land/)
 
-Worked examples for [`NEAT-AI`](https://github.com/stSoftwareAU/NEAT-AI). Each example is a small,
-self-contained program that generates its own synthetic data, so you can run it immediately with no
-external dependencies beyond Deno (and, for Discovery, the NEAT-AI-Discovery Rust library).
+Worked examples for [`NEAT-AI`](https://github.com/stSoftwareAU/NEAT-AI) — short for
+**NeuroEvolution of Augmenting Topologies** (the algorithm popularised by Stanley & Miikkulainen,
+2002, that grows neural-network topology and weights together with an evolutionary search). Each
+example is a small, self-contained program that generates its own synthetic data, so you can run it
+immediately with no external dependencies beyond Deno (and, for Discovery, the NEAT-AI-Discovery
+Rust library).
 
 This page is the **what** and **how** at a glance. Follow the link in each row for the full
 walkthrough — the per-example README explains the workflow, options, and output artefacts.
 
-> 🌱 **Random noise → competent network.** The control and classification examples here (XOR,
-> Cart-Pole, Lunar Lander, Mountain Car, Snake, Maze Navigation, MNIST, Stock Market) all start
+> 🌱 **Random noise → competent network.** The control and classification examples here (XOR
+> [exclusive OR], Cart-Pole, Lunar Lander, Mountain Car, Snake, Maze Navigation, MNIST [Modified
+> National Institute of Standards and Technology handwritten-digit dataset], Stock Market) all start
 > evolution from uniform-random noise. Generation 1 is barely better than chance; the captured
 > checkpoint snapshots (typically gen 1, 10, 100, 1000, 10000) show the network climbing from there
 > to a working solution. That arc — noise → competent — _is_ the demo. A handful of examples (CRISPR
@@ -203,7 +207,7 @@ panel plots best fitness per generation across the experiment; a dashed red mark
 generation at which the gene was spliced into the population, after which fitness lifts sharply as
 the gene's incoming weights are tuned.
 
-### 🌡️ MCMC Acceptance — cooling toward 23.4%
+### 🌡️ MCMC (Markov chain Monte Carlo) Acceptance — cooling toward 23.4%
 
 ![MCMC mutation acceptance rate cooling toward the 23.4% optimal target with the temperature schedule overlaid](docs/screenshots/mcmc_acceptance.svg)
 
@@ -314,8 +318,8 @@ flowchart TD
 
 The [`common/`](common/) module provides the building blocks every example reuses:
 
-- 🎲 **`deterministic_random.ts`** — splitmix32-style seeded PRNG so runs are reproducible across
-  machines.
+- 🎲 **`deterministic_random.ts`** — splitmix32-style seeded PRNG (pseudorandom number generator) so
+  runs are reproducible across machines.
 - 📊 **`synthetic_data.ts`** — `generateSyntheticData` and `scoreCreature`. Each example picks its
   own seed so data sets are independent but deterministic.
 - 📁 **`working_dirs.ts`** — `setupWorkingDirs` creates `data/`, `creatures/`, and `output/`
@@ -421,8 +425,8 @@ A GitHub Actions workflow ([`.github/workflows/quality.yml`](.github/workflows/q
 the same pipeline on every push and pull request to `Develop`. Failing checks block merges.
 
 > [!NOTE]
-> The Discovery example needs a native Rust FFI library that is not yet available in CI, so its step
-> is allowed to fail gracefully there.
+> The Discovery example needs a native Rust FFI (Foreign Function Interface) library that is not yet
+> available in CI, so its step is allowed to fail gracefully there.
 
 <details>
 <summary>🧪 Running tests, lint, fmt, and benchmarks independently</summary>
@@ -457,7 +461,7 @@ composes with the others as shown below.
 
 | Repository                                                             | Role                                                                                                              |
 | ---------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| [NEAT-AI](https://github.com/stSoftwareAU/NEAT-AI)                     | Primary Deno/TypeScript neural-network engine (evolution, training, WASM activation).                             |
+| [NEAT-AI](https://github.com/stSoftwareAU/NEAT-AI)                     | Primary Deno/TypeScript neural-network engine (evolution, training, WebAssembly (WASM) activation).               |
 | [NEAT-AI-core](https://github.com/stSoftwareAU/NEAT-AI-core)           | Shared native Rust library (`neat-core`) with numerics, topology helpers, and the chunked `.bin` training stream. |
 | [NEAT-AI-Discovery](https://github.com/stSoftwareAU/NEAT-AI-Discovery) | Rust discovery module invoked by NEAT-AI via Deno FFI to search architectures and hyper-parameters.               |
 | [NEAT-AI-Snapshot](https://github.com/stSoftwareAU/NEAT-AI-Snapshot)   | Creature/genome snapshot format and fixtures produced by NEAT-AI and consumed by downstream tools.                |

--- a/adaptive_mutation/README.md
+++ b/adaptive_mutation/README.md
@@ -1,5 +1,8 @@
 # 🧬 Adaptive Mutation Rate — Topology vs Weight Shift
 
+**Acronym.** _NEAT_ = NeuroEvolution of Augmenting Topologies — the algorithm that grows neural
+network topology and weights together with an evolutionary search.
+
 `adaptive_mutation.ts` visualises one of NEAT-AI's hidden but important behaviours: as a creature
 grows, the mutation operator distribution shifts away from **topology mutations** (add/remove
 neuron, add/remove synapse) and toward **weight/bias mutations**. Tiny seed creatures need new

--- a/cart_pole/README.md
+++ b/cart_pole/README.md
@@ -6,6 +6,9 @@
 > the controller climbing from population-mean noise to a network that balances every perturbed
 > trial under wobble.
 
+**Acronyms.** _NEAT_ = NeuroEvolution of Augmenting Topologies. _PRNG_ = pseudorandom number
+generator.
+
 `cart_pole.ts` evolves a NEAT-AI controller that balances an inverted pole on a moving cart — the
 classic neuroevolution control benchmark. Both the simulator and the evolutionary loop run entirely
 in pure TypeScript, with the only external dependency being NEAT-AI's `Creature.activate` to compute

--- a/crispr_injection/README.md
+++ b/crispr_injection/README.md
@@ -1,5 +1,10 @@
 # 🧬 CRISPR Gene Injection — Hand-Crafted Subgraph Splicing
 
+**Acronym.** _NEAT_ = NeuroEvolution of Augmenting Topologies. (CRISPR is borrowed as a metaphor
+from molecular biology — Clustered Regularly Interspaced Short Palindromic Repeats — where it
+describes a precise gene-editing technique. Here it stands for the same idea applied to neural
+network topology.)
+
 `crispr_injection.ts` demonstrates a structural intervention that is unique to NEAT-style
 neuroevolution: a hand-crafted **edit gene** — a small subgraph of neurons and synapses with
 known-good behaviour — is spliced directly into a stalled population, then evolution continues.

--- a/discovery/README.md
+++ b/discovery/README.md
@@ -1,5 +1,8 @@
 # 🔍 Discovery — Recover a Missing Neuron
 
+**Acronyms.** _NEAT_ = NeuroEvolution of Augmenting Topologies. _FFI_ = Foreign Function Interface
+(Deno's mechanism for calling native libraries from TypeScript).
+
 `discover_missing_neuron.ts` demonstrates the neuron discovery workflow. It creates a simple
 creature, generates synthetic training data, removes a hidden neuron to "cripple" the creature, and
 then runs discovery to attempt to recover the missing functionality.

--- a/discovery_at_scale/README.md
+++ b/discovery_at_scale/README.md
@@ -1,5 +1,8 @@
 # 🔬 Discovery at Scale — Multi-Defect Detection on Large Creatures
 
+**Acronyms.** _NEAT_ = NeuroEvolution of Augmenting Topologies. _FFI_ = Foreign Function Interface
+(Deno's mechanism for calling native libraries from TypeScript).
+
 `discovery_at_scale.ts` is the flagship demo for the "discovering structures at size and speed"
 thesis (parent issue [#75](https://github.com/stSoftwareAU/NEAT-AI-Examples/issues/75)).
 

--- a/docs/pr-summary-178.md
+++ b/docs/pr-summary-178.md
@@ -1,0 +1,54 @@
+## Summary
+
+Spell out (or briefly define) every learning-blocker acronym the first time it appears on each
+README page in the repository, so a beginner reader is not asked to know what _NEAT_, _MNIST_,
+_MLP_, _SGD_, _MCMC_, _MH_, _PRNG_, _FFI_, _WASM_, _RL_, _CTRNN_, _BCE_, _RCS_, or _XOR_ stand for.
+Each per-example README now opens with a short **Acronyms** line that defines the terms used on that
+page; the top-level README likewise expands _NEAT_, _MNIST_, _XOR_, _MCMC_, _PRNG_, _FFI_, and
+_WASM_ at first use. A new "what" test (`readme_acronym_glossary_test.ts`) keeps the rule from
+regressing — every README must contain the plain-English expansion of every glossary acronym it
+uses. Closes #178.
+
+## Evidence
+
+This is a documentation change with a content-only test, so no UI screenshot or benchmark applies.
+The new test is the executable evidence:
+
+- `deno test --no-check --allow-read readme_acronym_glossary_test.ts` — 21 README files checked, all
+  pass.
+- Running the test against `main` (before the README edits) reports 18 failing READMEs with the
+  exact list of unexpanded acronyms each, demonstrating that the test would have caught the pre-fix
+  state.
+- Full repository test suite:
+  `deno test --no-check --allow-read --allow-write --allow-env
+  --allow-net --allow-ffi` — **896
+  passed | 0 failed (1 m 2 s)**.
+- `deno lint`, `deno fmt --check`, and `deno check **/*.ts` all clean.
+
+```mermaid
+flowchart LR
+    READER["📖 New reader<br/>opens a per-example README"]
+    INTRO["🧾 Acronyms.<br/>NEAT = NeuroEvolution of Augmenting Topologies,<br/>MLP = multi-layer perceptron, …"]
+    BODY["📚 Rest of the page<br/>uses the acronyms freely"]
+    TEST["🧪 readme_acronym_glossary_test.ts<br/>fails if any glossary acronym is used<br/>without its expansion present"]
+
+    READER --> INTRO --> BODY
+    BODY -.guarded by.-> TEST
+
+    style READER fill:#3498db,stroke:#333,color:#fff
+    style INTRO fill:#f5a623,stroke:#333,color:#fff
+    style BODY fill:#27ae60,stroke:#333,color:#fff
+    style TEST fill:#e74c3c,stroke:#333,color:#fff
+```
+
+## Test Plan
+
+- [x] Add `readme_acronym_glossary_test.ts` — for every README in the repo, every glossary acronym
+      it uses must also have a plain-English expansion present in the same file (whitespace and
+      Markdown blockquote prefixes normalised so wrapped expansions match).
+- [x] Update top-level `README.md` and every per-example README that uses one of the glossary
+      acronyms to include an **Acronyms** definition at the top of the page.
+- [x] `deno lint` clean.
+- [x] `deno fmt --check` clean.
+- [x] `deno check **/*.ts` clean.
+- [x] Full test suite passes (896 / 896).

--- a/evolution_showcase/README.md
+++ b/evolution_showcase/README.md
@@ -1,5 +1,7 @@
 # 🧬 Evolution Showcase — long-running flagship
 
+**Acronym.** _PRNG_ = pseudorandom number generator.
+
 A deliberately long-running example whose purpose is to make the **gen-1-vs-gen-10000 contrast**
 visible. Most other examples in this repository target "under five minutes on CI" so they fit normal
 quality gates; this one fills the missing gap by evolving for ten thousand generations on a

--- a/lunar_lander/README.md
+++ b/lunar_lander/README.md
@@ -5,6 +5,11 @@
 > controller evolving from chaotic crashes into a network that throttles, orients, and lands softly
 > on the pad.
 
+**Acronyms.** _NEAT_ = NeuroEvolution of Augmenting Topologies. _RCS_ = reaction control system
+(small attitude-control thrusters that apply torque without changing translation). _CTRNN_ =
+continuous-time recurrent neural network — the temporal-memory style NEAT-AI uses for stateful
+controllers.
+
 `lunar_lander.ts` evolves a NEAT-AI controller that lands a simplified 2D lunar lander on a marked
 landing pad. The simulator and the evolutionary loop run entirely in pure TypeScript, so the only
 external dependency is NEAT-AI's `Creature.activate` to compute each step's thruster commands.

--- a/maze_navigation/README.md
+++ b/maze_navigation/README.md
@@ -5,6 +5,9 @@
 > init**. Structural mutation grows hidden neurons during evolution; the captured milestones show
 > the agent climbing from a gen-1 wall-bumper to a network that walks straight from start to goal.
 
+**Acronyms.** _NEAT_ = NeuroEvolution of Augmenting Topologies. _PRNG_ = pseudorandom number
+generator.
+
 `maze_navigation.ts` evolves a NEAT-AI controller that navigates a fixed 12×12 grid maze from a
 start cell to a goal cell using only local sensor inputs (wall distances plus a packed
 heading-to-goal). The simulator (`maze.ts`), evolutionary loop, and animated SVG renderer (`svg.ts`)

--- a/mcmc_acceptance/README.md
+++ b/mcmc_acceptance/README.md
@@ -1,5 +1,10 @@
 # 🌡️ MCMC Mutation Acceptance — Cooling Toward 23.4%
 
+**Acronyms.** _MCMC_ = Markov chain Monte Carlo — a family of sampling algorithms that explore a
+target distribution by walking a probability-weighted chain of proposals. _MH_ = Metropolis-Hastings
+— the canonical MCMC accept/reject rule, defined inline below. _NEAT_ = NeuroEvolution of Augmenting
+Topologies (the algorithm whose mutation operator borrows this acceptance pattern).
+
 `mcmc_acceptance.ts` demonstrates the Metropolis-Hastings (MH) acceptance pattern that underpins
 NEAT-AI's mutation-acceptance strategy: probabilistically accepting worse-fitness moves with a
 cooling temperature schedule. The temperature is updated after every proposal so that the empirical

--- a/mnist_classification/README.md
+++ b/mnist_classification/README.md
@@ -7,6 +7,13 @@
 > captured milestones show the network climbing from ~10 % chance accuracy to a competent digit
 > recogniser.
 
+**Acronyms.** _MNIST_ = Modified National Institute of Standards and Technology — the 70 000-image
+handwritten-digit dataset that has been the default vision benchmark since LeCun et al. 1998. _NEAT_
+= NeuroEvolution of Augmenting Topologies. _MLP_ = multi-layer perceptron — the classical
+fully-connected feed-forward network. _SGD_ = stochastic gradient descent — backpropagation that
+updates weights from a small random sample (mini-batch) of the training data each step. _BCE_ =
+binary cross-entropy, the standard per-output loss for sigmoid (LOGISTIC) classifiers.
+
 `mnist_classification.ts` ships **two** classifiers, both operating over the canonical MNIST dataset
 (60 000-image training file + 10 000-image test file) downloaded once into `.synthetic-mnist/data/`
 (with SHA-256 digests pinned so runs are byte-stable), down-sampled from 28 × 28 to 14 × 14:

--- a/mountain_car/README.md
+++ b/mountain_car/README.md
@@ -6,6 +6,9 @@
 > controller learning to swing back-and-forth across the bowl until the final champion crests the
 > goal flag.
 
+**Acronyms.** _NEAT_ = NeuroEvolution of Augmenting Topologies. _RL_ = reinforcement learning (the
+agent-and-reward paradigm Mountain Car comes from). _PRNG_ = pseudorandom number generator.
+
 `mountain_car.ts` evolves a NEAT-AI controller that drives an under-powered car up a sinusoidal hill
 — the second canonical OpenAI-Gym RL benchmark. The engine is too weak to climb the slope directly,
 so the controller has to learn to swing back-and-forth across the valley to build enough momentum to

--- a/neuron_pruning/README.md
+++ b/neuron_pruning/README.md
@@ -1,5 +1,8 @@
 # ✂️ Neuron Pruning — Constant-Activation Removal With Bias Fold
 
+**Acronyms.** _NEAT_ = NeuroEvolution of Augmenting Topologies. _SGD_ = stochastic gradient descent
+(backpropagation that updates weights from a small mini-batch each step).
+
 `neuron_pruning.ts` demonstrates one of NEAT-AI's simplest, most effective tricks for keeping large
 creatures lean: removing hidden neurons whose activations don't vary across the held-out dataset and
 folding their bias contribution into the surviving downstream neurons. Because the pruned neurons

--- a/readme_acronym_glossary_test.ts
+++ b/readme_acronym_glossary_test.ts
@@ -1,0 +1,111 @@
+/**
+ * Tests for issue #178 — acronyms must be spelled out (or linked to a
+ * definition) the first time they appear on a page. The audience is
+ * people who are learning, so we should not assume they know what
+ * "MLP", "SGD", "NEAT" or similar mean.
+ *
+ * The test enforces a weaker but objective property: for every README
+ * in the repository, every acronym from the curated glossary that
+ * appears in the file must also have its plain-English expansion
+ * present somewhere in the same file. Authors are expected to put the
+ * expansion at the first use, but the test is content-only — it does
+ * not police order so that the rule remains a simple "what" check on
+ * the document rather than a brittle proximity scan.
+ */
+
+import { assert } from "@std/assert";
+
+/**
+ * Acronyms whose expansion (case-insensitive) must appear in any
+ * README that uses them. Keep entries focused on terms a beginner
+ * would not be expected to know — common web/file acronyms (HTML,
+ * JSON, SVG, CSS) are intentionally excluded because expanding them
+ * everywhere would harm readability.
+ */
+const GLOSSARY: Record<string, readonly string[]> = {
+  NEAT: ["NeuroEvolution of Augmenting Topologies"],
+  MNIST: ["Modified National Institute of Standards and Technology"],
+  XOR: ["exclusive OR", "exclusive-or"],
+  MLP: ["multi-layer perceptron", "multilayer perceptron"],
+  SGD: ["stochastic gradient descent"],
+  MCMC: ["Markov chain Monte Carlo"],
+  MH: ["Metropolis-Hastings"],
+  PRNG: ["pseudorandom number generator", "pseudo-random number generator"],
+  FFI: ["Foreign Function Interface"],
+  WASM: ["WebAssembly"],
+  RL: ["reinforcement learning"],
+  CTRNN: ["continuous-time recurrent neural network"],
+  BCE: ["binary cross-entropy"],
+  RCS: ["reaction control system"],
+};
+
+const READMES = [
+  "README.md",
+  "adaptive_mutation/README.md",
+  "cart_pole/README.md",
+  "crispr_injection/README.md",
+  "crossover/README.md",
+  "discovery/README.md",
+  "discovery_at_scale/README.md",
+  "evolution_showcase/README.md",
+  "intelligent_design/README.md",
+  "lunar_lander/README.md",
+  "maze_navigation/README.md",
+  "mcmc_acceptance/README.md",
+  "memetic_evolution/README.md",
+  "mnist_classification/README.md",
+  "mountain_car/README.md",
+  "neuron_pruning/README.md",
+  "snake_game/README.md",
+  "stock_market/README.md",
+  "suggest_improvements/README.md",
+  "synthetic_synapse/README.md",
+  "xor_classification/README.md",
+] as const;
+
+/**
+ * Strip fenced code blocks and inline code spans so an acronym that
+ * appears only inside a code identifier (e.g. `evolveMLPClassifier`)
+ * does not trigger the glossary requirement.
+ */
+function stripCode(markdown: string): string {
+  // Remove fenced code blocks first (greedy across lines)
+  const fenceless = markdown.replace(/```[\s\S]*?```/g, " ");
+  // Then inline code spans
+  return fenceless.replace(/`[^`]*`/g, " ");
+}
+
+/** Match the acronym only as a standalone token (so MNIST doesn't fire on "MNIST_NEAT"). */
+function usesAcronym(text: string, acronym: string): boolean {
+  const re = new RegExp(`(^|[^A-Za-z0-9_])${acronym}(?![A-Za-z0-9_])`);
+  return re.test(text);
+}
+
+function containsExpansion(text: string, expansions: readonly string[]): boolean {
+  // Strip Markdown blockquote prefixes (`> `) at the start of any line and
+  // then collapse all runs of whitespace to a single space so an expansion
+  // that wraps across two lines in the source still matches.
+  const unquoted = text.replace(/^[ \t]*>+[ \t]?/gm, "");
+  const flattened = unquoted.replace(/\s+/g, " ").toLowerCase();
+  return expansions.some((e) => flattened.includes(e.toLowerCase()));
+}
+
+for (const path of READMES) {
+  Deno.test(`README ${path} expands every glossary acronym it uses`, async () => {
+    const markdown = await Deno.readTextFile(path);
+    const prose = stripCode(markdown);
+
+    const missing: string[] = [];
+    for (const [acronym, expansions] of Object.entries(GLOSSARY)) {
+      if (!usesAcronym(prose, acronym)) continue;
+      if (!containsExpansion(prose, expansions)) {
+        missing.push(`${acronym} (expected one of: ${expansions.join(" | ")})`);
+      }
+    }
+
+    assert(
+      missing.length === 0,
+      `${path} uses these acronyms without spelling them out:\n  - ${missing.join("\n  - ")}`,
+    );
+  });
+}

--- a/snake_game/README.md
+++ b/snake_game/README.md
@@ -5,6 +5,10 @@
 > biases drawn by the library's RNG. **No hand-crafted topology, no tuned weight init.** Hidden
 > neurons emerge only from the add-neuron structural mutation operator during evolution.
 
+**Acronyms.** _NEAT_ = NeuroEvolution of Augmenting Topologies. _RL_ = reinforcement learning. _XOR_
+= exclusive OR. _MNIST_ = Modified National Institute of Standards and Technology handwritten-digit
+dataset (referenced from the supervised-vs-agent comparison).
+
 `snake_game.ts` evolves a NEAT-AI controller that plays the classic Snake grid game on a 12×12
 board. The snake starts three segments long, must eat food cells to grow, and dies the moment it
 runs into a wall or its own body. Both the simulator (`snake.ts`) and the evolutionary loop run

--- a/stock_market/README.md
+++ b/stock_market/README.md
@@ -6,6 +6,8 @@
 > captured milestones show the predictor climbing from population-mean chance toward a network that
 > beats the chance baseline on direction.
 
+**Acronyms.** _NEAT_ = NeuroEvolution of Augmenting Topologies.
+
 `stock_market.ts` evolves a NEAT-AI network from uniform-random noise to predict next-period
 direction (up vs. down) on the public S&P 500 monthly-close dataset. The dataset is downloaded once
 into `.synthetic-stock/data/prices.csv` (with a SHA-256 digest pinned to a specific upstream commit

--- a/suggest_improvements/README.md
+++ b/suggest_improvements/README.md
@@ -1,5 +1,8 @@
 # 💡 Suggest Improvements — Project Analyser
 
+**Acronym.** _NEAT_ = NeuroEvolution of Augmenting Topologies (the algorithm whose example
+repository this script analyses).
+
 `suggest_improvements.ts` analyses the NEAT-AI-Examples project structure and produces actionable
 improvement suggestions. These suggestions can be filed as GitHub issues using the `gh` CLI.
 

--- a/synthetic_synapse/README.md
+++ b/synthetic_synapse/README.md
@@ -1,5 +1,10 @@
 # 🧬 Synthetic Synapse Training — Densify Then Prune
 
+**Acronyms.** _NEAT_ = NeuroEvolution of Augmenting Topologies. _SGD_ = stochastic gradient descent
+(backpropagation that updates weights from a small mini-batch each step). _WASM_ = WebAssembly (the
+sandboxed binary instruction format NEAT-AI uses to run activation functions natively in the browser
+or Deno).
+
 `synthetic_synapse_example.ts` demonstrates one of NEAT-AI's most distinctive techniques for keeping
 large creatures trainable: **synthetic-synapse training**. The example temporarily densifies the
 inter-layer connectivity of an evolved sparse creature, trains every weight (existing and synthetic)

--- a/xor_classification/README.md
+++ b/xor_classification/README.md
@@ -3,6 +3,10 @@
 > 🌱 **Generation 1 starts from random noise** — the captured milestones show the network evolving
 > from there to a working XOR classifier.
 
+**Acronyms.** _NEAT_ = NeuroEvolution of Augmenting Topologies (the Stanley & Miikkulainen 2002
+algorithm that grows topology and weights together). _XOR_ = exclusive OR (the two-input boolean
+that returns true when exactly one input is true). _PRNG_ = pseudorandom number generator.
+
 `xor_classification.ts` evolves a tiny NEAT-AI network that learns the XOR truth table — the
 canonical "Hello World" of neuroevolution. The initial creature is built by the NEAT-AI library's
 uniform-random `new Creature(2, 1)` constructor — direct input → output synapses with random weights


### PR DESCRIPTION
## Summary

Spell out (or briefly define) every learning-blocker acronym the first time it appears on each
README page in the repository, so a beginner reader is not asked to know what _NEAT_, _MNIST_,
_MLP_, _SGD_, _MCMC_, _MH_, _PRNG_, _FFI_, _WASM_, _RL_, _CTRNN_, _BCE_, _RCS_, or _XOR_ stand for.
Each per-example README now opens with a short **Acronyms** line that defines the terms used on that
page; the top-level README likewise expands _NEAT_, _MNIST_, _XOR_, _MCMC_, _PRNG_, _FFI_, and
_WASM_ at first use. A new "what" test (`readme_acronym_glossary_test.ts`) keeps the rule from
regressing — every README must contain the plain-English expansion of every glossary acronym it
uses. Closes #178.

## Evidence

This is a documentation change with a content-only test, so no UI screenshot or benchmark applies.
The new test is the executable evidence:

- `deno test --no-check --allow-read readme_acronym_glossary_test.ts` — 21 README files checked, all
  pass.
- Running the test against `main` (before the README edits) reports 18 failing READMEs with the
  exact list of unexpanded acronyms each, demonstrating that the test would have caught the pre-fix
  state.
- Full repository test suite:
  `deno test --no-check --allow-read --allow-write --allow-env
  --allow-net --allow-ffi` — **896
  passed | 0 failed (1 m 2 s)**.
- `deno lint`, `deno fmt --check`, and `deno check **/*.ts` all clean.

```mermaid
flowchart LR
    READER["📖 New reader<br/>opens a per-example README"]
    INTRO["🧾 Acronyms.<br/>NEAT = NeuroEvolution of Augmenting Topologies,<br/>MLP = multi-layer perceptron, …"]
    BODY["📚 Rest of the page<br/>uses the acronyms freely"]
    TEST["🧪 readme_acronym_glossary_test.ts<br/>fails if any glossary acronym is used<br/>without its expansion present"]

    READER --> INTRO --> BODY
    BODY -.guarded by.-> TEST

    style READER fill:#3498db,stroke:#333,color:#fff
    style INTRO fill:#f5a623,stroke:#333,color:#fff
    style BODY fill:#27ae60,stroke:#333,color:#fff
    style TEST fill:#e74c3c,stroke:#333,color:#fff
```

## Test Plan

- [x] Add `readme_acronym_glossary_test.ts` — for every README in the repo, every glossary acronym
      it uses must also have a plain-English expansion present in the same file (whitespace and
      Markdown blockquote prefixes normalised so wrapped expansions match).
- [x] Update top-level `README.md` and every per-example README that uses one of the glossary
      acronyms to include an **Acronyms** definition at the top of the page.
- [x] `deno lint` clean.
- [x] `deno fmt --check` clean.
- [x] `deno check **/*.ts` clean.
- [x] Full test suite passes (896 / 896).



---

🤖 Processed by: stservice<!-- vibe-worker-issue-178 -->