### PR TITLE
docs: audit READMEs against NEAT-AI COMPARISON.md (#184)

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,6 +488,16 @@ graph TD
     Examples -->|depends on| Main
 ```
 
+### Cross-repository documentation audit
+
+[`docs/neat_ai_feature_audit.md`](docs/neat_ai_feature_audit.md) cross-references every README in
+this repository against upstream
+[`NEAT-AI/COMPARISON.md`](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md). It is
+the source of truth for which capabilities are demonstrated by which example, and which README
+passages need rewording so they no longer read as if NEAT-AI were "just textbook NEAT" (issue
+[#184](https://github.com/stSoftwareAU/NEAT-AI-Examples/issues/184), parent
+[#182](https://github.com/stSoftwareAU/NEAT-AI-Examples/issues/182)).
+
 ## 🤝 Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, how to add new examples, coding

--- a/docs/neat_ai_feature_audit.md
+++ b/docs/neat_ai_feature_audit.md
@@ -1,0 +1,241 @@
+# 📋 NEAT-AI Feature Audit — README Cross-Reference
+
+> **Status.** Source-of-truth audit produced for issue
+> [#184](https://github.com/stSoftwareAU/NEAT-AI-Examples/issues/184) (parent
+> [#182](https://github.com/stSoftwareAU/NEAT-AI-Examples/issues/182)). This file does **not**
+> rewrite any README; it lists every gap, inaccuracy, and opportunity so that the follow-up
+> sub-issues can fix the documentation consistently rather than one passage at a time.
+
+## 🎯 Why this audit exists
+
+The reporter on issue #182 pointed out that several READMEs in this repository read as if NEAT-AI
+were "just textbook NEAT" — e.g. that
+[`mnist_classification/README.md`](../mnist_classification/README.md) reads as if NEAT-AI lacks back
+propagation, when in fact backprop is one of many training features inside NEAT-AI (see the upstream
+[COMPARISON.md](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md)). The reporter's
+three concrete points:
+
+1. **Back propagation** is implemented in NEAT-AI; the MNIST README should not imply otherwise.
+2. **Binary training data** is one of the speed-up vectors NEAT-AI uses — the production training
+   pipeline expects on-disk `.bin` chunks rather than CSV, which is materially faster than the
+   analytical SGD some examples use.
+3. [**NEAT-AI-Discovery**](https://github.com/stSoftwareAU/NEAT-AI-Discovery) "applies a bit of
+   science to the structural changes" — beneficial mutations are searched for using GPU-accelerated
+   activation analysis (saturated, dead, dormant, bottleneck neurons) rather than purely random
+   structural mutation.
+
+This audit is the foundation; the follow-up sub-issues consume it.
+
+## 🗺️ Capability map (search · training · structure · scale · interop)
+
+The Mermaid summary groups every NEAT-AI capability from upstream `COMPARISON.md` into the five
+categories called out in the issue. Categories are deliberately broad — many features (e.g.
+`Synthetic Synapse Training`) sit at the boundary between _training_ and _structure_ and are placed
+where their primary effect lies.
+
+```mermaid
+flowchart TD
+    subgraph search [🔎 Search]
+        SP[Speciation]
+        HM[Historical Marking]
+        MCMC[MCMC Mutation Acceptance]
+        ME[Memetic Evolution]
+        BR[Advanced Breeding]
+        FS[Fitness Sharing]
+        SS[Stagnant Species Retirement]
+        SQ[Fitness-Driven Squash Mutation]
+        APS[Adaptive Population Sizing]
+        EN[Ensemble Diversity]
+        AQ[Adaptive Quantum Steps]
+    end
+    subgraph training [🎓 Training]
+        BP[Backpropagation]
+        SPT[Sparse Training]
+        BAT[Batch Processing]
+        ES[Early Stopping]
+        PC[Predictive Coding]
+        DR[Dropout]
+        L12[L1/L2 Regularisation]
+        KF[K-Fold Cross-Validation]
+        SY[Synthetic Synapse Training]
+        MUON[Muon-Style Orthogonalised Updates]
+        HSA[Hyperparameter Self-Adaptation]
+    end
+    subgraph structure [🧱 Structure]
+        DISC[GPU-Accelerated Discovery]
+        DCACHE[Discovery Caching]
+        CRIS[CRISPR Gene Injection]
+        GR[Grafting]
+        NP[Neuron Pruning]
+        UAF[Unique Activation Functions]
+        AGG[Improved Aggregate Gradient Flow]
+        FOT[Forward-Only Topology Enforcement]
+        NUM[Numerical Stability Clamps]
+    end
+    subgraph scale [⚡ Scale]
+        UUID[UUID-Based Indexing]
+        DE[Distributed Evolution]
+        PB[Parallel Batch Creature Evaluation]
+        BIN[Binary `.bin` Training Stream]
+        DSM[Disk Space Monitoring]
+        WPR[WASM Panic Recovery]
+        LL[Lifelong Learning]
+        RUST[Optional Rust CLI Scorer]
+    end
+    subgraph interop [🔌 Interop]
+        ONNX[ONNX Format Export]
+        TL[Transfer Learning]
+        DNA[DNA-Sharing Primitives]
+        CORE[NEAT-AI-core Pin & Parity Gate]
+    end
+
+    search --> training
+    training --> structure
+    structure --> scale
+    scale --> interop
+```
+
+## 🚦 NEAT-AI capability vs example coverage
+
+This table is the central artefact of the audit. Every capability listed in upstream `COMPARISON.md`
+("What We've Implemented") is included; for each capability we record whether an example currently
+demonstrates it, which README mentions it, and whether any README misrepresents the capability as
+absent.
+
+| Capability                                         | Demonstrated by                                                  | Mentioned in README                                                                                            | Misrepresented as absent in NEAT-AI?                                                                                                                                              |
+| -------------------------------------------------- | ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Evolutionary Topology Search                       | every in-scope example                                           | most READMEs                                                                                                   | No.                                                                                                                                                                               |
+| Speciation                                         | not yet demonstrated                                             | none                                                                                                           | No, but no example explains it either — opportunity for a callout.                                                                                                                |
+| Historical Marking                                 | implicit in `crossover/`                                         | [crossover/README.md](../crossover/README.md)                                                                  | No.                                                                                                                                                                               |
+| Backpropagation                                    | demonstrated by `synthetic_synapse/`                             | [synthetic_synapse/README.md](../synthetic_synapse/README.md)                                                  | **Yes — [`mnist_classification/README.md`](../mnist_classification/README.md) reads as if NEAT-AI lacks backprop.** "SGD beats NEAT" should be "SGD beats _evolutionary search_". |
+| Sparse Training                                    | not yet demonstrated                                             | none                                                                                                           | No.                                                                                                                                                                               |
+| Batch Processing                                   | not yet demonstrated                                             | [mnist_classification/README.md](../mnist_classification/README.md) (mini-batch SGD)                           | No.                                                                                                                                                                               |
+| Early Stopping                                     | implicit in many examples (accuracy targets)                     | [mnist_classification/README.md](../mnist_classification/README.md), and others                                | No.                                                                                                                                                                               |
+| Memetic Evolution                                  | demonstrated by `memetic_evolution/`                             | [memetic_evolution/README.md](../memetic_evolution/README.md)                                                  | No.                                                                                                                                                                               |
+| Error-Guided Structural Evolution                  | demonstrated by `discovery_at_scale/`                            | [discovery_at_scale/README.md](../discovery_at_scale/README.md)                                                | The "science-driven" framing from issue #182 is **missing** — see callout below.                                                                                                  |
+| Predictive Coding                                  | not yet demonstrated                                             | none                                                                                                           | No, but no example explains it.                                                                                                                                                   |
+| Dropout                                            | not yet demonstrated                                             | none                                                                                                           | No.                                                                                                                                                                               |
+| L1/L2 Weight & Bias Regularisation                 | not yet demonstrated                                             | none                                                                                                           | No.                                                                                                                                                                               |
+| K-Fold Cross-Validation                            | not yet demonstrated                                             | none                                                                                                           | No.                                                                                                                                                                               |
+| Gradient Accumulation Normalisation                | not yet demonstrated                                             | none                                                                                                           | No.                                                                                                                                                                               |
+| Synthetic Synapse Training                         | demonstrated by `synthetic_synapse/`                             | [synthetic_synapse/README.md](../synthetic_synapse/README.md)                                                  | The "Pure NEAT" column in the comparison table reads as a NEAT-AI limitation; should be "Vanilla NEAT" or "textbook NEAT".                                                        |
+| MCMC Mutation Acceptance                           | demonstrated by `mcmc_acceptance/`                               | [mcmc_acceptance/README.md](../mcmc_acceptance/README.md)                                                      | No.                                                                                                                                                                               |
+| Muon-Style Orthogonalised Gradient Updates         | not yet demonstrated                                             | none                                                                                                           | No.                                                                                                                                                                               |
+| UUID-Based Indexing                                | implicit in `crispr_injection/`                                  | [crispr_injection/README.md](../crispr_injection/README.md)                                                    | No.                                                                                                                                                                               |
+| Distributed Evolution                              | not yet demonstrated                                             | none                                                                                                           | No.                                                                                                                                                                               |
+| Lifelong Learning                                  | not yet demonstrated                                             | none                                                                                                           | No.                                                                                                                                                                               |
+| CRISPR Gene Injection                              | demonstrated by `crispr_injection/`                              | [crispr_injection/README.md](../crispr_injection/README.md)                                                    | No.                                                                                                                                                                               |
+| Grafting                                           | not yet demonstrated                                             | none                                                                                                           | No.                                                                                                                                                                               |
+| Neuron Pruning                                     | demonstrated by `neuron_pruning/`                                | [neuron_pruning/README.md](../neuron_pruning/README.md)                                                        | No.                                                                                                                                                                               |
+| GPU-Accelerated Discovery                          | demonstrated by `discovery/`, `discovery_at_scale/`              | [discovery/README.md](../discovery/README.md), [discovery_at_scale/README.md](../discovery_at_scale/README.md) | The READMEs describe Discovery as "search for replacement" without surfacing the _science-driven_ framing the reporter highlighted.                                               |
+| Discovery Caching                                  | not yet demonstrated                                             | none                                                                                                           | No.                                                                                                                                                                               |
+| Disk Space Monitoring                              | not yet demonstrated                                             | none                                                                                                           | No.                                                                                                                                                                               |
+| Ensemble Diversity                                 | not yet demonstrated                                             | none                                                                                                           | No.                                                                                                                                                                               |
+| Adaptive Quantum Steps                             | not yet demonstrated                                             | none                                                                                                           | No.                                                                                                                                                                               |
+| Unique Activation Functions (IF, MAX, MIN)         | demonstrated by `intelligent_design/`                            | [intelligent_design/README.md](../intelligent_design/README.md)                                                | No.                                                                                                                                                                               |
+| Improved Aggregate Gradient Flow (MAXIMUM/MINIMUM) | not yet demonstrated                                             | none                                                                                                           | No.                                                                                                                                                                               |
+| Transfer Learning                                  | not yet demonstrated                                             | none                                                                                                           | No.                                                                                                                                                                               |
+| ONNX Format Export                                 | not yet demonstrated                                             | none                                                                                                           | No.                                                                                                                                                                               |
+| Hyperparameter Self-Adaptation                     | partially — `adaptive_mutation/` shows topology-share auto-shift | [adaptive_mutation/README.md](../adaptive_mutation/README.md)                                                  | No.                                                                                                                                                                               |
+| Adaptive Population Sizing                         | not yet demonstrated                                             | none                                                                                                           | No.                                                                                                                                                                               |
+| Parallel Batch Creature Evaluation                 | not yet demonstrated                                             | none                                                                                                           | No.                                                                                                                                                                               |
+| Advanced Breeding Strategies                       | partially — `crossover/` shows the basic operator                | [crossover/README.md](../crossover/README.md)                                                                  | The README only describes mother-keep + father-50 % blending, not subgraph transplantation, cosine-similarity alignment, or diversity-driven cross-population pairing.            |
+| WASM Panic Recovery                                | not yet demonstrated                                             | none                                                                                                           | No.                                                                                                                                                                               |
+| Forward-Only Topology Enforcement                  | not yet demonstrated                                             | none                                                                                                           | No.                                                                                                                                                                               |
+| Numerical Stability Clamps                         | not yet demonstrated                                             | none                                                                                                           | No.                                                                                                                                                                               |
+| Fitness Sharing & Per-Species Breeding Quotas      | not yet demonstrated                                             | none                                                                                                           | No.                                                                                                                                                                               |
+| Stagnant Species Detection and Retirement          | not yet demonstrated                                             | none                                                                                                           | No.                                                                                                                                                                               |
+| Soft Compatibility-Gated Cross-Species Breeding    | not yet demonstrated                                             | none                                                                                                           | No.                                                                                                                                                                               |
+| Fitness-Driven Squash Mutation                     | indirectly via `intelligent_design/`                             | [intelligent_design/README.md](../intelligent_design/README.md)                                                | No.                                                                                                                                                                               |
+| DNA-Sharing Primitives                             | not yet demonstrated                                             | none                                                                                                           | No.                                                                                                                                                                               |
+| Optional Rust CLI Scorer with WASM Fallback        | not yet demonstrated                                             | none                                                                                                           | No.                                                                                                                                                                               |
+| NEAT-AI-core Pinning and Parity Gate               | not yet demonstrated                                             | none                                                                                                           | No.                                                                                                                                                                               |
+| Binary `.bin` Training Stream                      | not yet demonstrated                                             | [synthetic_synapse/README.md](../synthetic_synapse/README.md) sidesteps it explicitly                          | The reporter's binary-data-format speed-up is mentioned only in passing; no example exhibits it.                                                                                  |
+
+## 📚 Per-README accuracy register
+
+Every README under `<example>/README.md` is listed here. The "current accuracy" column is the
+audit's verdict on whether the README's NEAT-vs-NEAT-AI framing is accurate, in need of
+qualification, or makes no NEAT-vs-NEAT-AI claim at all.
+
+| README path                                                         | NEAT-vs-NEAT-AI claim?                                                                                                                | Current accuracy                                                                                                                                                                                                      |
+| ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [adaptive_mutation/README.md](../adaptive_mutation/README.md)       | Describes adaptive mutation as one of NEAT-AI's "hidden but important behaviours".                                                    | Accurate — explicitly frames the feature as NEAT-AI policy, not NEAT in the abstract.                                                                                                                                 |
+| [cart_pole/README.md](../cart_pole/README.md)                       | "Textbook cart-pole is famously trivial for random NEAT" — explicit qualification.                                                    | Accurate. Good model of how to phrase NEAT-vs-NEAT-AI distinctions.                                                                                                                                                   |
+| [crispr_injection/README.md](../crispr_injection/README.md)         | Calls CRISPR injection "unique to NEAT-style neuroevolution". Mentions "NEAT-AI's UUID-keyed neurons".                                | Accurate.                                                                                                                                                                                                             |
+| [crossover/README.md](../crossover/README.md)                       | No NEAT-vs-NEAT-AI claim made; describes one breeding strategy.                                                                       | Accurate but **incomplete** — only one of NEAT-AI's "Advanced Breeding Strategies" is shown, with no callout that more exist. Candidate for a "Further reading" pointer.                                              |
+| [discovery/README.md](../discovery/README.md)                       | No NEAT-vs-NEAT-AI claim made.                                                                                                        | Accurate, but the "science-driven" framing for NEAT-AI-Discovery from issue #182 is **absent**.                                                                                                                       |
+| [discovery_at_scale/README.md](../discovery_at_scale/README.md)     | "thesis: discovering structures at size and speed".                                                                                   | Accurate; same gap as `discovery/README.md`. The "applies a bit of science" framing from issue #182 should be added so readers see Discovery as targeted, not random.                                                 |
+| [evolution_showcase/README.md](../evolution_showcase/README.md)     | No NEAT-vs-NEAT-AI claim made.                                                                                                        | Accurate; flagship long-form run.                                                                                                                                                                                     |
+| [intelligent_design/README.md](../intelligent_design/README.md)     | No NEAT-vs-NEAT-AI claim made.                                                                                                        | Accurate.                                                                                                                                                                                                             |
+| [lunar_lander/README.md](../lunar_lander/README.md)                 | "this is exactly the kind of task where NEAT-AI's CTRNN-style temporal memory shines". Links to NEAT-AI #-key-features.               | Accurate — does the right thing, links upstream for breadth.                                                                                                                                                          |
+| [maze_navigation/README.md](../maze_navigation/README.md)           | No NEAT-vs-NEAT-AI claim made; calls out NEAT-AI's `Creature.activate`.                                                               | Accurate.                                                                                                                                                                                                             |
+| [mcmc_acceptance/README.md](../mcmc_acceptance/README.md)           | "NEAT-AI's mutation-acceptance strategy".                                                                                             | Accurate.                                                                                                                                                                                                             |
+| [memetic_evolution/README.md](../memetic_evolution/README.md)       | No NEAT-vs-NEAT-AI claim made.                                                                                                        | Accurate.                                                                                                                                                                                                             |
+| [mnist_classification/README.md](../mnist_classification/README.md) | "SGD beats NEAT by orders of magnitude in wall-clock"; "Backprop + mini-batch SGD with momentum hits 95 % in roughly a dozen epochs". | **Misleading.** Reads as if NEAT-AI lacks back propagation. The MLP/SGD baseline is contrasted with "NEAT" rather than with "evolutionary topology search" — a reader could infer NEAT-AI is purely evolutionary.     |
+| [mountain_car/README.md](../mountain_car/README.md)                 | No NEAT-vs-NEAT-AI claim made.                                                                                                        | Accurate.                                                                                                                                                                                                             |
+| [neuron_pruning/README.md](../neuron_pruning/README.md)             | "one of NEAT-AI's simplest, most effective tricks".                                                                                   | Accurate.                                                                                                                                                                                                             |
+| [snake_game/README.md](../snake_game/README.md)                     | "Is the NEAT-AI API set up for a stream of observations?" Discusses NEAT-AI as the toolkit.                                           | Accurate.                                                                                                                                                                                                             |
+| [stock_market/README.md](../stock_market/README.md)                 | "evolves a NEAT-AI network from uniform-random noise".                                                                                | Accurate.                                                                                                                                                                                                             |
+| [suggest_improvements/README.md](../suggest_improvements/README.md) | No NEAT-vs-NEAT-AI claim made (utility script).                                                                                       | Accurate.                                                                                                                                                                                                             |
+| [synthetic_synapse/README.md](../synthetic_synapse/README.md)       | "Pure NEAT" column heading in the comparison table; "Vanilla NEAT struggles at scale".                                                | **Mostly accurate** — it explicitly calls the limitation "Vanilla NEAT" and "Pure NEAT", which is correct. But the "Pure NEAT" column heading reads as a generic NEAT-AI shortcoming if skimmed; consider clarifying. |
+| [xor_classification/README.md](../xor_classification/README.md)     | "the canonical 'Hello World' of neuroevolution"; cites Stanley & Miikkulainen 2002.                                                   | Accurate — describes the algorithm's lineage and uses NEAT-AI elsewhere.                                                                                                                                              |
+
+## 🚩 Unqualified-NEAT phrasings to fix
+
+The following passages use the bare word "NEAT" where the surrounding context needs the qualifier
+**standard NEAT** / **textbook NEAT** / **vanilla NEAT** / **evolutionary search** so a reader does
+not infer the limitation applies to NEAT-AI itself.
+
+| README                                                                                                  | Passage                                                                                                                | Suggested rewording                                                                                                                                               |
+| ------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [mnist_classification/README.md](../mnist_classification/README.md) — "Tacit Knowledge" bullet          | "**SGD beats NEAT by orders of magnitude in wall-clock.**"                                                             | "**SGD beats _evolutionary structural search_ by orders of magnitude in wall-clock**" — backprop is part of NEAT-AI's training pipeline.                          |
+| [mnist_classification/README.md](../mnist_classification/README.md) — "Architecture & Training" intro   | "NEAT evolution from uniform-random noise"                                                                             | Fine as-is, but the surrounding chapter should also note that NEAT-AI offers backprop, dropout, L1/L2, K-fold, synthetic synapses, etc. as training-time options. |
+| [synthetic_synapse/README.md](../synthetic_synapse/README.md) — comparison table                        | "Pure NEAT" column heading                                                                                             | "Vanilla NEAT (no synthetic-synapse step)" — already done in prose; keep the same phrasing in the heading.                                                        |
+| [synthetic_synapse/README.md](../synthetic_synapse/README.md) — "Why does NEAT-AI need this?" paragraph | "Vanilla NEAT struggles at scale because evolutionary search is unlikely to stumble on every useful inter-layer edge." | Already qualified — leave as-is.                                                                                                                                  |
+| [discovery/README.md](../discovery/README.md) — flow description                                        | "Search for replacement"                                                                                               | "**Science-driven search for a replacement neuron** (saturated/dead/dormant detection, GPU-accelerated)" — reflects issue #182 framing.                           |
+| [discovery_at_scale/README.md](../discovery_at_scale/README.md) — top-of-file thesis                    | "discovering structures at size and speed"                                                                             | Add a sentence: "Unlike random structural mutation in textbook NEAT, NEAT-AI's Discovery applies activation analysis to _target_ the changes worth making."       |
+| Top-level [README.md](../README.md) — examples gallery                                                  | Many examples described without a one-liner on which NEAT-AI feature they exercise.                                    | Add a "Feature exercised" column or per-example callout, citing this audit.                                                                                       |
+
+## 🛣️ Specific reporter points (issue #182)
+
+These are the three points the reporter made explicitly. They are extracted here so each follow-up
+sub-issue can cite them verbatim.
+
+1. **Back propagation framing in MNIST.** From issue #182:
+   > "Our implementation does have back propagation and many other features." The MNIST README's
+   > `SGD beats NEAT` line reads as if NEAT-AI is NEAT-only; rewrite to contrast SGD with
+   > _evolutionary topology search_ and link to upstream `COMPARISON.md` for breadth.
+2. **Binary training data speed advantage.** From issue #182:
+   > "if the training data is prepared in a binary format that would be very fast indeed." NEAT-AI's
+   > production pipeline expects on-disk `.bin` chunks, which is materially faster than CSV. None of
+   > the examples currently demonstrate this — `synthetic_synapse/README.md` even calls the binary
+   > pipeline "overkill" for its demo. Worth a dedicated callout in the top-level README.
+3. **NEAT-AI-Discovery's "science-driven" structural mutation.** From issue #182:
+   > "Look at NEAT-AI-Discovery for example, this applies a bit of science to the structural changes
+   > in the network instead of just random mutations." Both `discovery/README.md` and
+   > `discovery_at_scale/README.md` should adopt this framing prominently.
+
+## 🧭 Follow-up sub-issues this audit feeds
+
+```mermaid
+flowchart LR
+    AUDIT[#184 Documentation audit] --> MNIST[MNIST README rewrite]
+    AUDIT --> TOP[Top-level README breadth section]
+    AUDIT --> CALLOUT[Per-example feature callouts]
+    AUDIT --> SYN[Synthetic Synapse clarification]
+    AUDIT --> DISC[Discovery 'applies science' framing]
+    AUDIT --> BIN[Binary `.bin` training callout]
+```
+
+## 🔗 References
+
+- Upstream
+  [stSoftwareAU/NEAT-AI/COMPARISON.md](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md)
+  — "What We've Implemented" section drives the capability list above.
+- Issue [#182](https://github.com/stSoftwareAU/NEAT-AI-Examples/issues/182) — reporter's original
+  prompt about back propagation, binary data, and Discovery.
+- Issue [#184](https://github.com/stSoftwareAU/NEAT-AI-Examples/issues/184) — the umbrella audit
+  issue this file resolves.
+- [NEAT-AI-Discovery](https://github.com/stSoftwareAU/NEAT-AI-Discovery) — the Rust library that
+  delivers the "science-driven" structural mutation framing.

--- a/docs/neat_ai_feature_audit_test.ts
+++ b/docs/neat_ai_feature_audit_test.ts
@@ -1,0 +1,162 @@
+/**
+ * Tests for docs/neat_ai_feature_audit.md (issue #184).
+ *
+ * Verifies that the audit file:
+ *   1. Exists and is non-empty.
+ *   2. Contains a non-empty Mermaid diagram block.
+ *   3. References every per-example README path that currently lives in the
+ *      repository (i.e. every per-example README under a top-level directory).
+ *   4. Lists each canonical NEAT-AI capability called out in the upstream
+ *      `COMPARISON.md`.
+ *   5. Captures the user's specific points from issue #182 (back-propagation
+ *      framing in MNIST, the binary-data-format speed advantage, and
+ *      NEAT-AI-Discovery's "science-driven" structural mutation).
+ *   6. Is referenced from the parent README's "Related Repositories" section.
+ */
+
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+
+const AUDIT_PATH = "docs/neat_ai_feature_audit.md";
+const README_PATH = "README.md";
+
+function loadAudit(): string {
+  return Deno.readTextFileSync(AUDIT_PATH);
+}
+
+function loadReadme(): string {
+  return Deno.readTextFileSync(README_PATH);
+}
+
+/** Return every `<dir>/README.md` path in the repo root, sorted. */
+function listExampleReadmes(): string[] {
+  const out: string[] = [];
+  for (const entry of Deno.readDirSync(".")) {
+    if (!entry.isDirectory) continue;
+    if (entry.name.startsWith(".")) continue;
+    if (entry.name === "common" || entry.name === "docs") continue;
+    const path = `${entry.name}/README.md`;
+    try {
+      const stat = Deno.statSync(path);
+      if (stat.isFile) out.push(path);
+    } catch (_) {
+      // No README in this directory — skip.
+    }
+  }
+  return out.sort();
+}
+
+Deno.test("audit file exists and is non-trivially sized", () => {
+  const stat = Deno.statSync(AUDIT_PATH);
+  assertEquals(stat.isFile, true);
+  assert(stat.size > 2000, `Expected audit file to exceed 2 KB; got ${stat.size}`);
+});
+
+Deno.test("audit file contains a non-empty Mermaid block", () => {
+  const audit = loadAudit();
+  const match = audit.match(/```mermaid\n([\s\S]*?)```/);
+  assert(match, "Expected at least one ```mermaid``` fenced block");
+  const body = match![1].trim();
+  assert(body.length > 50, "Mermaid block should contain a real diagram, not be empty");
+});
+
+Deno.test("audit references every per-example README path in the repo", () => {
+  const audit = loadAudit();
+  for (const path of listExampleReadmes()) {
+    assertStringIncludes(audit, path, `Audit must reference ${path}`);
+  }
+});
+
+Deno.test("audit lists every canonical NEAT-AI feature from upstream COMPARISON.md", () => {
+  const audit = loadAudit();
+  // Drawn directly from
+  // https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md
+  // — the "What We've Implemented" section. Each row in the audit must
+  // reference each capability by name.
+  const features = [
+    "Backpropagation",
+    "Memetic Evolution",
+    "MCMC Mutation Acceptance",
+    "GPU-Accelerated Discovery",
+    "Predictive Coding",
+    "Dropout",
+    "L1/L2",
+    "K-Fold Cross-Validation",
+    "Synthetic Synapse Training",
+    "Advanced Breeding",
+    "Hyperparameter Self-Adaptation",
+    "Adaptive Population Sizing",
+    "ONNX",
+    "Transfer Learning",
+    "CRISPR Gene Injection",
+    "Grafting",
+    "Neuron Pruning",
+    "UUID-Based Indexing",
+    "Distributed Evolution",
+    "Lifelong Learning",
+    "Speciation",
+    "Historical Marking",
+    "Discovery Caching",
+    "Ensemble Diversity",
+    "Adaptive Quantum Steps",
+    "Unique Activation Functions",
+    "Sparse Training",
+    "Early Stopping",
+    "Muon",
+  ];
+  for (const f of features) {
+    assertStringIncludes(audit, f, `Audit must list NEAT-AI capability '${f}'`);
+  }
+});
+
+Deno.test("audit captures the specific points from issue #182", () => {
+  const audit = loadAudit();
+  // Back-propagation framing in MNIST.
+  assertStringIncludes(audit, "mnist_classification/README.md");
+  assert(
+    /back[ -]?propagation/i.test(audit),
+    "Audit must discuss the back-propagation framing from issue #182",
+  );
+  // Binary data-format speed advantage.
+  assert(
+    /binary.*(data|format|training)/i.test(audit),
+    "Audit must mention the binary training-data-format speed advantage",
+  );
+  // NEAT-AI-Discovery's science-driven structural mutation.
+  assertStringIncludes(audit, "NEAT-AI-Discovery");
+  assert(
+    /science/i.test(audit),
+    "Audit must capture the 'science-driven' framing for Discovery",
+  );
+});
+
+Deno.test("audit flags the unqualified-NEAT phrasing concern", () => {
+  const audit = loadAudit();
+  // The audit must explicitly call out where unqualified "NEAT" reads as a
+  // limitation of NEAT-AI rather than of standard/textbook NEAT.
+  assert(
+    /(textbook|standard|classical|vanilla)\s+NEAT/i.test(audit),
+    "Audit should distinguish standard/textbook NEAT from NEAT-AI",
+  );
+});
+
+Deno.test("audit groups features into categories in its Mermaid summary", () => {
+  const audit = loadAudit();
+  // The Mermaid block must group capabilities by category (search, training,
+  // structure, scale, interop) per the issue's acceptance criteria.
+  const categories = ["search", "training", "structure", "scale", "interop"];
+  for (const c of categories) {
+    assertStringIncludes(
+      audit.toLowerCase(),
+      c,
+      `Audit category grouping must mention '${c}'`,
+    );
+  }
+});
+
+Deno.test("README.md links to the audit from the Related Repositories section", () => {
+  const readme = loadReadme();
+  // The audit must be discoverable from the parent README so future
+  // contributors find it. Per acceptance criteria it lives within (or just
+  // after) the Related Repositories section.
+  assertStringIncludes(readme, "docs/neat_ai_feature_audit.md");
+});

--- a/docs/pr-summary-184.md
+++ b/docs/pr-summary-184.md
@@ -1,0 +1,60 @@
+# PR Summary — Issue #184
+
+## Summary
+
+Added `docs/neat_ai_feature_audit.md`, a single source-of-truth document that cross-references every
+README in this repository against the upstream
+[`NEAT-AI/COMPARISON.md`](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md)
+feature list. The audit lists each NEAT-AI capability, records which examples exercise it, names the
+READMEs that mention it, and flags every passage that reads as if NEAT-AI were "just textbook NEAT"
+— the misconception raised in parent issue #182. The audit is referenced from the top-level
+`README.md` "Related Repositories" section so future contributors find it. Closes #184.
+
+## Evidence
+
+- **Documentation-only change.** No runtime code is altered; the new files are
+  `docs/neat_ai_feature_audit.md`, `docs/neat_ai_feature_audit_test.ts`, and a
+  `Cross-repository documentation audit` paragraph appended to `README.md`.
+- **No screenshots required.** This change has no UI surface; it is markdown plus a unit test
+  verifying the markdown's structure.
+- **Unit tests verify the audit shape**: `docs/neat_ai_feature_audit_test.ts` — eight `Deno.test`
+  cases covering file existence and size, the presence of a non-empty Mermaid block, references to
+  every per-example README, mention of every canonical NEAT-AI capability, capture of the three
+  reporter points from issue #182 (back-propagation framing in MNIST, binary-data-format speed
+  advantage, science-driven Discovery), unqualified-NEAT phrasing flagged, category grouping, and
+  the README link. All eight pass; the full repo unit-test suite (905 tests) passes after the
+  change.
+
+```mermaid
+flowchart LR
+    AUDIT[#184 Documentation audit] --> MNIST[MNIST README rewrite]
+    AUDIT --> TOP[Top-level README breadth section]
+    AUDIT --> CALLOUT[Per-example feature callouts]
+    AUDIT --> SYN[Synthetic Synapse clarification]
+    AUDIT --> DISC[Discovery 'applies science' framing]
+    AUDIT --> BIN[Binary `.bin` training callout]
+```
+
+The audit deliberately stops short of rewriting any README — that work will land in the follow-up
+sub-issues drawn in the diagram above. This PR is the foundation they all consume.
+
+### Why `./quality.sh` was not run end-to-end
+
+`quality.sh` runs every example program (18 long-running runs) on top of the unit-test suite. The
+change in this PR is purely additive Markdown plus a new unit test; it cannot affect example-program
+behaviour. The validators that _can_ be affected — `deno lint`, `deno fmt --check`,
+`deno check **/*.ts`, and `deno test` over the full suite — all pass locally.
+
+## Test Plan
+
+- [x] `docs/neat_ai_feature_audit_test.ts` exists, with eight cases that fail against an empty audit
+      and pass after the audit is written (TDD).
+- [x] `deno lint` clean.
+- [x] `deno fmt --check` clean.
+- [x] `deno check **/*.ts` clean.
+- [x] `deno test --no-check --allow-read --allow-write --allow-env --allow-net
+      --allow-ffi` —
+      905 passed, 0 failed.
+- [x] Existing `related_repositories_test.ts`, `readme_structure_test.ts`,
+      `readme_paradigms_test.ts`, `readme_acronym_glossary_test.ts`, and `mermaid_diagrams_test.ts`
+      still pass (the README change adds, but does not alter, content).


### PR DESCRIPTION
# PR Summary — Issue #184

## Summary

Added `docs/neat_ai_feature_audit.md`, a single source-of-truth document that cross-references every
README in this repository against the upstream
[`NEAT-AI/COMPARISON.md`](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md)
feature list. The audit lists each NEAT-AI capability, records which examples exercise it, names the
READMEs that mention it, and flags every passage that reads as if NEAT-AI were "just textbook NEAT"
— the misconception raised in parent issue #182. The audit is referenced from the top-level
`README.md` "Related Repositories" section so future contributors find it. Closes #184.

## Evidence

- **Documentation-only change.** No runtime code is altered; the new files are
  `docs/neat_ai_feature_audit.md`, `docs/neat_ai_feature_audit_test.ts`, and a
  `Cross-repository documentation audit` paragraph appended to `README.md`.
- **No screenshots required.** This change has no UI surface; it is markdown plus a unit test
  verifying the markdown's structure.
- **Unit tests verify the audit shape**: `docs/neat_ai_feature_audit_test.ts` — eight `Deno.test`
  cases covering file existence and size, the presence of a non-empty Mermaid block, references to
  every per-example README, mention of every canonical NEAT-AI capability, capture of the three
  reporter points from issue #182 (back-propagation framing in MNIST, binary-data-format speed
  advantage, science-driven Discovery), unqualified-NEAT phrasing flagged, category grouping, and
  the README link. All eight pass; the full repo unit-test suite (905 tests) passes after the
  change.

```mermaid
flowchart LR
    AUDIT[#184 Documentation audit] --> MNIST[MNIST README rewrite]
    AUDIT --> TOP[Top-level README breadth section]
    AUDIT --> CALLOUT[Per-example feature callouts]
    AUDIT --> SYN[Synthetic Synapse clarification]
    AUDIT --> DISC[Discovery 'applies science' framing]
    AUDIT --> BIN[Binary `.bin` training callout]
```

The audit deliberately stops short of rewriting any README — that work will land in the follow-up
sub-issues drawn in the diagram above. This PR is the foundation they all consume.

### Why `./quality.sh` was not run end-to-end

`quality.sh` runs every example program (18 long-running runs) on top of the unit-test suite. The
change in this PR is purely additive Markdown plus a new unit test; it cannot affect example-program
behaviour. The validators that _can_ be affected — `deno lint`, `deno fmt --check`,
`deno check **/*.ts`, and `deno test` over the full suite — all pass locally.

## Test Plan

- [x] `docs/neat_ai_feature_audit_test.ts` exists, with eight cases that fail against an empty audit
      and pass after the audit is written (TDD).
- [x] `deno lint` clean.
- [x] `deno fmt --check` clean.
- [x] `deno check **/*.ts` clean.
- [x] `deno test --no-check --allow-read --allow-write --allow-env --allow-net
      --allow-ffi` —
      905 passed, 0 failed.
- [x] Existing `related_repositories_test.ts`, `readme_structure_test.ts`,
      `readme_paradigms_test.ts`, `readme_acronym_glossary_test.ts`, and `mermaid_diagrams_test.ts`
      still pass (the README change adds, but does not alter, content).



---

🤖 Processed by: stservice<!-- vibe-worker-issue-184 -->