### PR TITLE
docs(discovery): frame Discovery READMEs as science-driven structural mutation (#189)

### DIFF
--- a/discovery/README.md
+++ b/discovery/README.md
@@ -1,5 +1,52 @@
 # 🔍 Discovery — Recover a Missing Neuron
 
+**Science-driven structural mutation, not random search.** Textbook NEAT searches network structure
+with **random** add-node and add-connection mutations and evaluates the result blindly through
+fitness. NEAT-AI-Discovery is **error-driven**: it analyses each neuron's activation distribution
+across the dataset — flagging **saturated**, **dead**, **dormant**, **bimodal**, and **bottleneck**
+neurons — correlates those signals with the loss, and proposes targeted structural changes (rewire,
+replace, prune, split) backed by a GPU-accelerated Rust pipeline. See
+[`COMPARISON.md` Feature 2](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md)
+(error-driven structural mutation) and
+[`COMPARISON.md` Feature 8](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md)
+(discovery caching) for the upstream definitions. This example is the simplest possible window onto
+that pipeline: remove one neuron, ask Discovery to find a replacement, and watch it recover the lost
+behaviour — a contrast you cannot make with random mutation alone.
+
+```mermaid
+flowchart LR
+    subgraph TXT["📚 Textbook NEAT — random mutation"]
+        T1["🎲 Pick mutation<br/>(add-node / add-conn)"]
+        T2["🧬 Apply blindly"]
+        T3["🏋️ Evaluate fitness"]
+        T4{"Better?"}
+        T1 --> T2 --> T3 --> T4
+        T4 -- "no" --> T1
+        T4 -- "yes" --> TKEEP["✅ Keep"]
+    end
+    subgraph SCI["🔬 Discovery-driven mutation"]
+        S1["📊 Activations per neuron"]
+        S2["🔍 Classify<br/>saturated · dead · dormant · bimodal · bottleneck"]
+        S3["📉 Correlate with loss"]
+        S4["🛠 Propose targeted change<br/>rewire · replace · prune · split"]
+        S5["🏋️ Evaluate"]
+        S1 --> S2 --> S3 --> S4 --> S5 --> SKEEP["✅ Keep best"]
+    end
+    style TXT fill:#fff7e6,stroke:#e67e22,color:#333
+    style SCI fill:#eaf6ff,stroke:#2e86de,color:#333
+    style T1 fill:#f5a623,stroke:#333,color:#fff
+    style T2 fill:#f5a623,stroke:#333,color:#fff
+    style T3 fill:#f5a623,stroke:#333,color:#fff
+    style T4 fill:#e74c3c,stroke:#333,color:#fff
+    style TKEEP fill:#7ed321,stroke:#333,color:#fff
+    style S1 fill:#4a90d9,stroke:#333,color:#fff
+    style S2 fill:#9b59b6,stroke:#333,color:#fff
+    style S3 fill:#bd10e0,stroke:#333,color:#fff
+    style S4 fill:#16a085,stroke:#333,color:#fff
+    style S5 fill:#f5a623,stroke:#333,color:#fff
+    style SKEEP fill:#50e3c2,stroke:#333,color:#fff
+```
+
 **Acronyms.** _NEAT_ = NeuroEvolution of Augmenting Topologies. _FFI_ = Foreign Function Interface
 (Deno's mechanism for calling native libraries from TypeScript).
 

--- a/discovery_at_scale/README.md
+++ b/discovery_at_scale/README.md
@@ -1,5 +1,53 @@
 # 🔬 Discovery at Scale — Multi-Defect Detection on Large Creatures
 
+**Science-driven structural mutation, not random search.** Textbook NEAT searches network structure
+with **random** add-node and add-connection mutations and evaluates the result blindly through
+fitness — at this scale (~200 hidden neurons, ~1 k synapses) the random walk is hopeless.
+NEAT-AI-Discovery is **error-driven**: it analyses each neuron's activation distribution across the
+dataset — flagging **saturated**, **dead**, **dormant**, **bimodal**, and **bottleneck** neurons —
+correlates those signals with the loss, and proposes targeted structural changes (rewire, replace,
+prune, split) backed by a GPU-accelerated Rust pipeline. See
+[`COMPARISON.md` Feature 2](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md)
+(error-driven structural mutation) and
+[`COMPARISON.md` Feature 8](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md)
+(discovery caching) for the upstream definitions. This demo deliberately injects defects into a
+creature too large for random mutation to repair, then lets Discovery's structural surgery walk it
+back — exactly the contrast textbook NEAT cannot make.
+
+```mermaid
+flowchart LR
+    subgraph TXT["📚 Textbook NEAT — random mutation"]
+        T1["🎲 Pick mutation<br/>(add-node / add-conn)"]
+        T2["🧬 Apply blindly"]
+        T3["🏋️ Evaluate fitness"]
+        T4{"Better?"}
+        T1 --> T2 --> T3 --> T4
+        T4 -- "no" --> T1
+        T4 -- "yes" --> TKEEP["✅ Keep"]
+    end
+    subgraph SCI["🔬 Discovery-driven mutation"]
+        S1["📊 Activations per neuron"]
+        S2["🔍 Classify<br/>saturated · dead · dormant · bimodal · bottleneck"]
+        S3["📉 Correlate with loss"]
+        S4["🛠 Propose targeted change<br/>rewire · replace · prune · split"]
+        S5["🏋️ Evaluate"]
+        S1 --> S2 --> S3 --> S4 --> S5 --> SKEEP["✅ Keep best"]
+    end
+    style TXT fill:#fff7e6,stroke:#e67e22,color:#333
+    style SCI fill:#eaf6ff,stroke:#2e86de,color:#333
+    style T1 fill:#f5a623,stroke:#333,color:#fff
+    style T2 fill:#f5a623,stroke:#333,color:#fff
+    style T3 fill:#f5a623,stroke:#333,color:#fff
+    style T4 fill:#e74c3c,stroke:#333,color:#fff
+    style TKEEP fill:#7ed321,stroke:#333,color:#fff
+    style S1 fill:#4a90d9,stroke:#333,color:#fff
+    style S2 fill:#9b59b6,stroke:#333,color:#fff
+    style S3 fill:#bd10e0,stroke:#333,color:#fff
+    style S4 fill:#16a085,stroke:#333,color:#fff
+    style S5 fill:#f5a623,stroke:#333,color:#fff
+    style SKEEP fill:#50e3c2,stroke:#333,color:#fff
+```
+
 **Acronyms.** _NEAT_ = NeuroEvolution of Augmenting Topologies. _FFI_ = Foreign Function Interface
 (Deno's mechanism for calling native libraries from TypeScript).
 
@@ -47,15 +95,18 @@ flowchart TD
 
 ## 🎨 Defect Categories
 
-| Colour      | Category        | Detection rule                                                 |
-| ----------- | --------------- | -------------------------------------------------------------- |
-| 🟩 Green    | `healthy`       | All neurons that fall through the rules below.                 |
-| 🟥 Red      | `saturated`     | Variance below `1e-3` AND \|mean\| ≥ 0.9 across the dataset.   |
-| ⚫ Charcoal | `dead`          | Variance below `1e-3` AND \|mean\| ≤ 0.05 across the dataset.  |
-| ⚪ Grey     | `dormant`       | Variance below `1e-3` but neither saturated nor dead.          |
-| 🟪 Purple   | `bimodal`       | ≤ 3 distinct rounded activations across the dataset.           |
-| 🟧 Orange   | `bottleneck`    | Outgoing degree ≥ 6 (structural — many edges from one neuron). |
-| ⚪ Dashed   | dormant synapse | \|weight\| < 1e-4 — drawn as a dashed light-grey line.         |
+Each row lists the detection rule **and** the structural intervention Discovery would propose for
+that defect class — the targeted, error-driven response that random NEAT mutation cannot make.
+
+| Colour      | Category        | Detection rule                                                 | Discovery intervention                                                                      |
+| ----------- | --------------- | -------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| 🟩 Green    | `healthy`       | All neurons that fall through the rules below.                 | Leave alone — no structural change proposed.                                                |
+| 🟥 Red      | `saturated`     | Variance below `1e-3` AND \|mean\| ≥ 0.9 across the dataset.   | **Rewire** — adjust incoming weights / bias or swap squash to break saturation.             |
+| ⚫ Charcoal | `dead`          | Variance below `1e-3` AND \|mean\| ≤ 0.05 across the dataset.  | **Replace** — substitute neuron with a fresh activation/squash that responds to the inputs. |
+| ⚪ Grey     | `dormant`       | Variance below `1e-3` but neither saturated nor dead.          | **Prune** — remove the neuron and rewire its successors.                                    |
+| 🟪 Purple   | `bimodal`       | ≤ 3 distinct rounded activations across the dataset.           | **Split** — duplicate the neuron and specialise each copy to one mode.                      |
+| 🟧 Orange   | `bottleneck`    | Outgoing degree ≥ 6 (structural — many edges from one neuron). | **Rewire** — insert a relay neuron to break the fan-out and decompose the load.             |
+| ⚪ Dashed   | dormant synapse | \|weight\| < 1e-4 — drawn as a dashed light-grey line.         | **Prune** — remove the synapse so the discovery cache focuses on live edges.                |
 
 The detection rules are intentionally simple so the demo is self-contained and the SVG output is
 trivially explainable. The full taxonomy of 40+ scenarios lives in the

--- a/discovery_readme_framing_test.ts
+++ b/discovery_readme_framing_test.ts
@@ -1,0 +1,158 @@
+/**
+ * Tests for the science-driven structural mutation framing on the
+ * Discovery and Discovery-at-Scale READMEs (issue #189).
+ *
+ * Both pages must:
+ *  - Open with a paragraph stating Discovery is error-driven structural
+ *    mutation, not random search.
+ *  - Link to upstream COMPARISON.md features 2 and 8.
+ *  - Contain a Mermaid block contrasting random NEAT mutation with
+ *    Discovery-driven mutation.
+ *
+ * These are "what" tests — they read the README files and check the
+ * required structural elements without inspecting implementation.
+ */
+
+import { assert, assertStringIncludes } from "@std/assert";
+
+const README_PATHS: Record<string, string> = {
+  discovery: "discovery/README.md",
+  discoveryAtScale: "discovery_at_scale/README.md",
+};
+
+const COMPARISON_URL = "https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md";
+
+function loadReadme(path: string): string {
+  return Deno.readTextFileSync(path);
+}
+
+/** Extract mermaid code blocks from markdown content. */
+function extractMermaidBlocks(content: string): string[] {
+  const blocks: string[] = [];
+  const regex = /```mermaid\n([\s\S]*?)```/g;
+  let m: RegExpExecArray | null;
+  while ((m = regex.exec(content)) !== null) blocks.push(m[1]);
+  return blocks;
+}
+
+/**
+ * Return the prose between the first H1 and the first H2 — the
+ * "top-level paragraph" the issue requires.
+ */
+function topLevelIntro(content: string): string {
+  const h1 = content.search(/^#\s+/m);
+  if (h1 < 0) return "";
+  const after = content.slice(h1);
+  const nextH2 = after.search(/^##\s+/m);
+  return nextH2 < 0 ? after : after.slice(0, nextH2);
+}
+
+for (const [name, path] of Object.entries(README_PATHS)) {
+  Deno.test(`${name} README opens with science-driven structural mutation framing`, () => {
+    const intro = topLevelIntro(loadReadme(path)).toLowerCase();
+    // The intro must say Discovery is error-driven, not random.
+    for (
+      const phrase of [
+        "error-driven",
+        "structural mutation",
+        "not random",
+      ]
+    ) {
+      assertStringIncludes(
+        intro,
+        phrase,
+        `${path} intro should mention "${phrase}"`,
+      );
+    }
+    // The reporter's exact framing must appear verbatim somewhere in the intro.
+    assertStringIncludes(
+      intro,
+      "science-driven structural mutation",
+      `${path} intro should use the phrase "science-driven structural mutation"`,
+    );
+  });
+
+  Deno.test(`${name} README intro contrasts textbook NEAT random mutation`, () => {
+    const intro = topLevelIntro(loadReadme(path)).toLowerCase();
+    for (const term of ["textbook neat", "random"]) {
+      assertStringIncludes(
+        intro,
+        term,
+        `${path} intro should reference textbook NEAT random mutation (missing "${term}")`,
+      );
+    }
+  });
+
+  Deno.test(`${name} README intro mentions activation analysis vocabulary`, () => {
+    const intro = topLevelIntro(loadReadme(path)).toLowerCase();
+    // The activation distribution categories that drive Discovery's
+    // structural decisions must be named.
+    for (const term of ["saturated", "dead", "dormant", "bottleneck"]) {
+      assertStringIncludes(
+        intro,
+        term,
+        `${path} intro should mention activation category "${term}"`,
+      );
+    }
+  });
+
+  Deno.test(`${name} README links to upstream COMPARISON.md`, () => {
+    const content = loadReadme(path);
+    assertStringIncludes(
+      content,
+      COMPARISON_URL,
+      `${path} should link to upstream COMPARISON.md`,
+    );
+    // Both feature 2 (error-driven mutation) and feature 8 (discovery
+    // caching) must be cited explicitly.
+    const lower = content.toLowerCase();
+    assertStringIncludes(lower, "feature 2", `${path} should cite COMPARISON.md feature 2`);
+    assertStringIncludes(lower, "feature 8", `${path} should cite COMPARISON.md feature 8`);
+  });
+
+  Deno.test(`${name} README has a Mermaid block contrasting random vs Discovery-driven mutation`, () => {
+    const content = loadReadme(path);
+    const blocks = extractMermaidBlocks(content);
+    assert(blocks.length >= 1, `${path} should contain at least one mermaid block`);
+    // At least one block must mention both "random" and "discovery-driven"
+    // so the contrast is unambiguous.
+    const hasContrast = blocks.some((b) => {
+      const lower = b.toLowerCase();
+      return lower.includes("random") && lower.includes("discovery-driven");
+    });
+    assert(
+      hasContrast,
+      `${path} should contain a Mermaid block contrasting random NEAT mutation with Discovery-driven mutation`,
+    );
+  });
+}
+
+/* ------------------------------------------------------------------ */
+/*  discovery_at_scale: defect table annotates structural intervention */
+/* ------------------------------------------------------------------ */
+
+Deno.test("discovery_at_scale README defect table annotates structural interventions", () => {
+  const content = loadReadme(README_PATHS.discoveryAtScale);
+  // Locate the Defect Categories section (before the next H2).
+  const start = content.search(/^##\s+.*Defect Categories.*$/im);
+  assert(start >= 0, "Defect Categories section must exist");
+  const after = content.slice(start + 1);
+  const nextH2 = after.search(/^##\s+/m);
+  const section = nextH2 < 0 ? content.slice(start) : content.slice(start, start + 1 + nextH2);
+  // Each defect category row must mention its structural intervention.
+  // We assert the interventions Discovery proposes are named in the section.
+  const lower = section.toLowerCase();
+  for (
+    const intervention of [
+      "rewire", // for saturated / bottleneck
+      "replace", // for dead neurons
+      "prune", // for dormant
+    ]
+  ) {
+    assertStringIncludes(
+      lower,
+      intervention,
+      `Defect Categories section should describe the "${intervention}" structural intervention`,
+    );
+  }
+});

--- a/docs/pr-summary-189.md
+++ b/docs/pr-summary-189.md
@@ -1,0 +1,57 @@
+# PR Summary — Issue #189
+
+## Summary
+
+Reframes both Discovery READMEs (`discovery/README.md` and `discovery_at_scale/README.md`) around
+the reporter's wording: **science-driven structural mutation, not random search**. Each page now
+opens with a top-level paragraph contrasting textbook NEAT's blind random add-node / add-conn
+mutations with NEAT-AI-Discovery's error-driven analysis (saturated · dead · dormant · bimodal ·
+bottleneck → targeted rewire / replace / prune / split), cites upstream
+[`COMPARISON.md`](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md) features 2
+(error-driven mutation) and 8 (discovery caching), and includes a Mermaid block making the contrast
+visual. The defect-category table on `discovery_at_scale/README.md` gains a new "Discovery
+intervention" column annotating each defect class with the structural change Discovery would
+propose. A new `discovery_readme_framing_test.ts` enforces the framing on both pages.
+
+Closes #189.
+
+## Evidence
+
+This is a documentation-only change — no UI, CLI, or runtime behaviour is modified — so the evidence
+is the new test suite plus a Mermaid diagram showing the framing both pages now adopt.
+
+```mermaid
+flowchart LR
+    subgraph TXT["📚 Textbook NEAT — random mutation"]
+        T1["🎲 Pick mutation"] --> T2["🧬 Apply blindly"] --> T3["🏋️ Evaluate fitness"] --> T4{"Better?"}
+        T4 -- "no" --> T1
+        T4 -- "yes" --> TKEEP["✅ Keep"]
+    end
+    subgraph SCI["🔬 Discovery-driven mutation"]
+        S1["📊 Activations"] --> S2["🔍 Classify defects"] --> S3["📉 Correlate with loss"] --> S4["🛠 Targeted change"] --> S5["🏋️ Evaluate"] --> SKEEP["✅ Keep best"]
+    end
+```
+
+Verification:
+
+- `deno fmt --check` — clean (267 files).
+- `deno lint` — clean (118 files).
+- `deno check discovery_readme_framing_test.ts` — clean.
+- `deno test --no-check --allow-read --allow-write --allow-env --allow-net --allow-ffi` — **922
+  passed**, 0 failed (full unit-test run).
+
+## Test Plan
+
+Added `discovery_readme_framing_test.ts` at the repo root. It loads both README files and asserts:
+
+- The intro paragraph (between H1 and the first H2) contains "error-driven", "structural mutation",
+  "not random", and the verbatim phrase "science-driven structural mutation".
+- The intro names textbook NEAT's random mutation and the activation categories (saturated, dead,
+  dormant, bottleneck).
+- Both pages link to the upstream `COMPARISON.md` URL and cite "Feature 2" and "Feature 8".
+- Each page contains at least one Mermaid block whose body mentions both `random` and
+  `discovery-driven`.
+- The Defect Categories section on `discovery_at_scale/README.md` describes the rewire / replace /
+  prune interventions.
+
+All 11 new tests pass; the existing 911 tests remain green.


### PR DESCRIPTION
# PR Summary — Issue #189

## Summary

Reframes both Discovery READMEs (`discovery/README.md` and `discovery_at_scale/README.md`) around
the reporter's wording: **science-driven structural mutation, not random search**. Each page now
opens with a top-level paragraph contrasting textbook NEAT's blind random add-node / add-conn
mutations with NEAT-AI-Discovery's error-driven analysis (saturated · dead · dormant · bimodal ·
bottleneck → targeted rewire / replace / prune / split), cites upstream
[`COMPARISON.md`](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md) features 2
(error-driven mutation) and 8 (discovery caching), and includes a Mermaid block making the contrast
visual. The defect-category table on `discovery_at_scale/README.md` gains a new "Discovery
intervention" column annotating each defect class with the structural change Discovery would
propose. A new `discovery_readme_framing_test.ts` enforces the framing on both pages.

Closes #189.

## Evidence

This is a documentation-only change — no UI, CLI, or runtime behaviour is modified — so the evidence
is the new test suite plus a Mermaid diagram showing the framing both pages now adopt.

```mermaid
flowchart LR
    subgraph TXT["📚 Textbook NEAT — random mutation"]
        T1["🎲 Pick mutation"] --> T2["🧬 Apply blindly"] --> T3["🏋️ Evaluate fitness"] --> T4{"Better?"}
        T4 -- "no" --> T1
        T4 -- "yes" --> TKEEP["✅ Keep"]
    end
    subgraph SCI["🔬 Discovery-driven mutation"]
        S1["📊 Activations"] --> S2["🔍 Classify defects"] --> S3["📉 Correlate with loss"] --> S4["🛠 Targeted change"] --> S5["🏋️ Evaluate"] --> SKEEP["✅ Keep best"]
    end
```

Verification:

- `deno fmt --check` — clean (267 files).
- `deno lint` — clean (118 files).
- `deno check discovery_readme_framing_test.ts` — clean.
- `deno test --no-check --allow-read --allow-write --allow-env --allow-net --allow-ffi` — **922
  passed**, 0 failed (full unit-test run).

## Test Plan

Added `discovery_readme_framing_test.ts` at the repo root. It loads both README files and asserts:

- The intro paragraph (between H1 and the first H2) contains "error-driven", "structural mutation",
  "not random", and the verbatim phrase "science-driven structural mutation".
- The intro names textbook NEAT's random mutation and the activation categories (saturated, dead,
  dormant, bottleneck).
- Both pages link to the upstream `COMPARISON.md` URL and cite "Feature 2" and "Feature 8".
- Each page contains at least one Mermaid block whose body mentions both `random` and
  `discovery-driven`.
- The Defect Categories section on `discovery_at_scale/README.md` describes the rewire / replace /
  prune interventions.

All 11 new tests pass; the existing 911 tests remain green.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-189 -->