### PR TITLE
Add 'NEAT-AI Features Used' callout to every example README (Issue #187)

### DIFF
--- a/adaptive_mutation/README.md
+++ b/adaptive_mutation/README.md
@@ -118,3 +118,15 @@ under the 90-second budget while still illustrating the shift the library perfor
 - The whole run is byte-deterministic for the same config.
 - The rendered SVG is well-formed, embeds both panels, and references the topology / weight curve
   CSS classes.
+
+## 🧰 NEAT-AI Features Used
+
+This example visualises NEAT-AI's adaptive-mutation operator distribution against a pre-built
+creature.
+
+Features exercised (links go to upstream
+[`COMPARISON.md`](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md)):
+
+- **[Hyperparameter Self-Adaptation](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md#what-weve-implemented)**
+  — captures the operator-share distribution as it auto-shifts (topology vs. weight ops), the
+  central feature this example exists to surface.

--- a/cart_pole/README.md
+++ b/cart_pole/README.md
@@ -172,3 +172,26 @@ A few things that are not obvious from the code alone:
   `evolveCartPoleController` and verified by the `honours the hard generation cap` test.
 - **No Python required.** Despite cart-pole being the canonical OpenAI Gym example, the simulator
   here is plain TypeScript so the whole project remains "Deno + JSR" with no extra runtime.
+
+## 🧰 NEAT-AI Features Used
+
+Cart-Pole is an evolution-from-noise agent demo, so the demonstrated capability is NEAT-AI's
+evolutionary topology search driven by an episode-rollout fitness signal.
+
+> 🔎 **Stripped-down operator subset.** This example deliberately exercises a narrow slice of
+> NEAT-AI's full pipeline so the noise → competent story stays uncluttered. The production training
+> pipeline (backpropagation, dropout, L1/L2 regularisation, K-fold, binary `.bin` data streams,
+> distributed evolution, etc.) is intentionally **not** wired into this demo — see issue
+> [#185](https://github.com/stSoftwareAU/NEAT-AI-Examples/issues/185) and the upstream
+> production-pipeline notes in
+> [`COMPARISON.md`](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md) for the
+> wider feature set.
+
+Features exercised (links go to upstream
+[`COMPARISON.md`](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md)):
+
+- **[Evolutionary Topology Search](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md#what-weve-implemented)**
+  — structural mutation (add/remove neuron, add/remove synapse) co-evolved with weights and biases
+  against the pole-balance fitness signal.
+- **[Genetic Operators](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md#what-weve-implemented)**
+  — weight and bias mutation paired with selection pressure on the episode-return fitness function.

--- a/crispr_injection/README.md
+++ b/crispr_injection/README.md
@@ -84,3 +84,18 @@ git. You will find:
 - `output/crispr_injection.svg` – the rendered topology + fitness chart
 
 A copy of the chart is also written to `docs/screenshots/crispr_injection.svg` for the main README.
+
+## 🧰 NEAT-AI Features Used
+
+CRISPR injection is one of NEAT-AI's gene-level structural operators. This example splices a
+hand-crafted edit gene into a stalled population.
+
+Features exercised (links go to upstream
+[`COMPARISON.md`](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md)):
+
+- **[CRISPR Gene Injection](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md#5--crispr-gene-injection)**
+  — splices a hand-crafted gene (a small sub-network) into evolved descendants by neuron UUID — the
+  central technique this example demonstrates.
+- **[UUID-Based Extensible Observations](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md#3--uuid-based-extensible-observations)**
+  — neuron UUIDs make the splice cleanly addressable across crossovers and mutations — without
+  UUIDs, gene injection would not survive evolution.

--- a/crossover/README.md
+++ b/crossover/README.md
@@ -58,3 +58,21 @@ will find:
 - `creatures/offspring.json` – The crossover offspring
 - `creatures/evolved.json` – The offspring after multi-generation evolution
 - `output/` – Additional offspring from repeated crossover
+
+## 🧰 NEAT-AI Features Used
+
+**Acronym.** _NEAT_ = NeuroEvolution of Augmenting Topologies (the Stanley & Miikkulainen 2002
+algorithm).
+
+Crossover demonstrates NEAT-AI's basic mother-keep + father-50% breeding operator (one of several
+breeding strategies in NEAT-AI).
+
+Features exercised (links go to upstream
+[`COMPARISON.md`](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md)):
+
+- **[Advanced Breeding Strategies](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md#10--advanced-breeding-strategies)**
+  — mother-keep + father-50% blending — the simplest of NEAT-AI's breeding strategies (subgraph
+  transplantation, cosine-similarity alignment, and diversity-driven cross-population pairing all
+  live upstream).
+- **[Historical Marking](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md#what-weve-implemented)**
+  — gene history (a standard-NEAT primitive) makes compatible crossover possible across topologies.

--- a/discovery/README.md
+++ b/discovery/README.md
@@ -112,3 +112,15 @@ will find:
 - `creatures/baseline.json` – The untouched reference creature
 - `creatures/crippled.json` – The creature with the target neuron removed
 - `creatures/discovered.json` – The best candidate returned by discovery (when available)
+
+## 🧰 NEAT-AI Features Used
+
+Discovery is NEAT-AI's science-driven structural operator: rather than mutating randomly, it
+analyses activations to target the changes worth making.
+
+Features exercised (links go to upstream
+[`COMPARISON.md`](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md)):
+
+- **[Error-Guided Structural Evolution](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md#2--error-guided-structural-evolution)**
+  — GPU-accelerated discovery of beneficial structural changes
+  (saturated/dead/dormant/bottleneck-neuron analysis) — the core capability this example exercises.

--- a/discovery_at_scale/README.md
+++ b/discovery_at_scale/README.md
@@ -148,3 +148,18 @@ deno test --allow-read --allow-write --allow-env --allow-net --allow-ffi \
 
 The tests cover defect injection, defect detection statistics, dataset loading, SVG rendering
 (including byte-determinism), and the end-to-end demo pipeline using a small, fast configuration.
+
+## 🧰 NEAT-AI Features Used
+
+The at-scale variant reuses the same Discovery operator on a large pre-built creature, so it also
+exercises the disk-cache subsystem.
+
+Features exercised (links go to upstream
+[`COMPARISON.md`](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md)):
+
+- **[Error-Guided Structural Evolution](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md#2--error-guided-structural-evolution)**
+  — applied to a large pre-built creature so the science-driven framing is visible at
+  production-scale topology sizes.
+- **[Discovery Caching and Disk Space Management](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md#8--discovery-caching-and-disk-space-management)**
+  — Discovery results are cached to disk so repeat runs against the same large creature stay
+  tractable.

--- a/docs/archive_test.ts
+++ b/docs/archive_test.ts
@@ -103,6 +103,8 @@ Deno.test("No PR summary files remain in docs/ root", () => {
       if (entry.name === "pr-summary-181.md") continue;
       if (entry.name === "pr-summary-184.md") continue;
       if (entry.name === "pr-summary-185.md") continue;
+      if (entry.name === "pr-summary-187.md") continue;
+      if (entry.name === "pr-summary-189.md") continue;
       throw new Error(
         `Found unexpected PR summary file in docs/ root: ${entry.name}`,
       );

--- a/docs/pr-summary-187.md
+++ b/docs/pr-summary-187.md
@@ -1,0 +1,61 @@
+## Summary
+
+Adds a new **🧰 NEAT-AI Features Used** callout to every per-example README so a reader landing on
+any single example can see at a glance which upstream NEAT-AI capabilities the example actually
+invokes — and follow a link straight to the corresponding section of upstream
+[`COMPARISON.md`](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md). The callout
+makes the breadth of NEAT-AI visible per page rather than only in the top-level breadth section.
+Closes #187.
+
+For technique-only examples (`crispr_injection`, `neuron_pruning`, `synthetic_synapse`,
+`mcmc_acceptance`, `memetic_evolution`, `adaptive_mutation`, `intelligent_design`, `discovery`,
+`discovery_at_scale`, `crossover`) the callout names the single dominant technique. For supervised /
+agent demos (`xor_classification`, `cart_pole`, `snake_game`, `mnist_classification`,
+`stock_market`, `lunar_lander`, `mountain_car`, `maze_navigation`, `evolution_showcase`) it names
+evolutionary topology search plus weight/bias mutation, **and** explicitly flags that the example
+uses a stripped-down operator subset — pointing at issue #185 and upstream production-pipeline notes
+for the wider feature set.
+
+## Evidence
+
+This is a documentation-only change. Verification is via the new structural test cases in
+`readme_structure_test.ts` (TDD — added before the README content):
+
+- `${dir}/README.md has a "NEAT-AI Features Used" section` for every example directory.
+- `${dir}/README.md NEAT-AI Features Used section links to upstream
+  COMPARISON.md` — bounds the
+  section by the next `##` heading and asserts at least one upstream `COMPARISON.md` URL.
+
+```mermaid
+flowchart LR
+    R[Reader lands on per-example README] --> S[🧰 NEAT-AI Features Used]
+    S --> U["Upstream COMPARISON.md<br/>(specific anchored section)"]
+    S --> I185{"Subset demo?"}
+    I185 -- yes --> N185[Issue #185 / production-pipeline notes]
+    I185 -- no --> Done[Reader sees full feature list]
+```
+
+`./quality.sh` is gated on lint, fmt, type-check, unit tests and example runs; lint, fmt, type-check
+and the relevant README test files all pass locally:
+
+- `deno lint` — clean (118 files).
+- `deno fmt --check` — clean (268 files).
+- `deno check **/*.ts` — clean.
+- `deno test readme_structure_test.ts readme_paradigms_test.ts
+  readme_acronym_glossary_test.ts mermaid_diagrams_test.ts
+  contributing_test.ts discovery_readme_framing_test.ts`
+  — 245 passed, 0 failed.
+- `deno test docs/archive_test.ts` — 2 passed (pre-existing leftover for `pr-summary-189.md`
+  allowlisted alongside `pr-summary-187.md`).
+
+## Test Plan
+
+- [x] New tests in `readme_structure_test.ts` assert every per-example README contains the new
+      section header.
+- [x] New tests in `readme_structure_test.ts` assert the section contains at least one link to
+      upstream `COMPARISON.md`.
+- [x] `readme_acronym_glossary_test.ts` still passes — newly-introduced `NEAT` / `MCMC` mentions in
+      the new sections are paired with the glossary expansion in the same README.
+- [x] `deno fmt --check`, `deno lint`, `deno check` all pass.
+- [x] `docs/archive_test.ts` updated to allowlist `pr-summary-187.md` (and the pre-existing leftover
+      `pr-summary-189.md`).

--- a/evolution_showcase/README.md
+++ b/evolution_showcase/README.md
@@ -116,3 +116,27 @@ values:
   [`evolution_showcase_evolution.svg`](../docs/screenshots/evolution_showcase_evolution.svg).
 - **Fast unit test.** Uses `[1, 5, 10]` and a 6-strong population.
 - **Reuses common helpers.** No bespoke snapshot or render code — both are imported from `common/`.
+
+## 🧰 NEAT-AI Features Used
+
+**Acronym.** _NEAT_ = NeuroEvolution of Augmenting Topologies.
+
+The flagship long-form run focuses on the noise → competent story, so it deliberately uses a
+stripped-down operator subset.
+
+> 🔎 **Stripped-down operator subset.** This example deliberately exercises a narrow slice of
+> NEAT-AI's full pipeline so the noise → competent story stays uncluttered. The production training
+> pipeline (backpropagation, dropout, L1/L2 regularisation, K-fold, binary `.bin` data streams,
+> distributed evolution, etc.) is intentionally **not** wired into this demo — see issue
+> [#185](https://github.com/stSoftwareAU/NEAT-AI-Examples/issues/185) and the upstream
+> production-pipeline notes in
+> [`COMPARISON.md`](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md) for the
+> wider feature set.
+
+Features exercised (links go to upstream
+[`COMPARISON.md`](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md)):
+
+- **[Evolutionary Topology Search](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md#what-weve-implemented)**
+  — structural mutation co-evolved with weights — the long-form fitness arc is the headline.
+- **[Genetic Operators](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md#what-weve-implemented)**
+  — weight and bias mutation against the chosen task's fitness signal.

--- a/intelligent_design/README.md
+++ b/intelligent_design/README.md
@@ -68,3 +68,19 @@ In production workflows, successful squash substitutions are recorded as "tacit 
 mappings from neuron UUID to squash function. This knowledge can be shared across machines (via a
 "hive" file in a git repository) or kept local. When a model is loaded, tacit knowledge is applied
 to quickly reapply known-good squash substitutions without rescanning.
+
+## 🧰 NEAT-AI Features Used
+
+**Acronym.** _NEAT_ = NeuroEvolution of Augmenting Topologies.
+
+Intelligent Design systematically optimises activation functions on an existing creature.
+
+Features exercised (links go to upstream
+[`COMPARISON.md`](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md)):
+
+- **[Unique Activation Functions (IF, MAX, MIN)](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md#what-weve-implemented)**
+  — explores NEAT-AI's extended activation set (including IF/MAX/MIN/SOFTSIGN/etc. beyond textbook
+  NEAT) and picks the best per neuron.
+- **[Fitness-Driven Squash Mutation](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md#what-weve-implemented)**
+  — swaps activation functions guided by fitness rather than randomly — the core operator this
+  example demonstrates.

--- a/lunar_lander/README.md
+++ b/lunar_lander/README.md
@@ -195,3 +195,26 @@ A few things that are not obvious from the code alone:
   library's `createSeededPopulation` decides the gen-1 structure (direct input → output connections,
   random weights, random output biases); the add-neuron structural mutation grows hidden topology
   during evolution. There is no "warm start" — gen 1 is genuine noise.
+
+## 🧰 NEAT-AI Features Used
+
+Lunar Lander is an agent demo — evolution-from-noise on a temporally-rich control task. The
+capability surfaced here is evolutionary topology search with NEAT-AI's CTRNN-style temporal memory
+neurons.
+
+> 🔎 **Stripped-down operator subset.** This example deliberately exercises a narrow slice of
+> NEAT-AI's full pipeline so the noise → competent story stays uncluttered. The production training
+> pipeline (backpropagation, dropout, L1/L2 regularisation, K-fold, binary `.bin` data streams,
+> distributed evolution, etc.) is intentionally **not** wired into this demo — see issue
+> [#185](https://github.com/stSoftwareAU/NEAT-AI-Examples/issues/185) and the upstream
+> production-pipeline notes in
+> [`COMPARISON.md`](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md) for the
+> wider feature set.
+
+Features exercised (links go to upstream
+[`COMPARISON.md`](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md)):
+
+- **[Evolutionary Topology Search](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md#what-weve-implemented)**
+  — structural mutation co-evolved with weights and biases against the soft-landing fitness signal.
+- **[Genetic Operators](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md#what-weve-implemented)**
+  — weight and bias mutation, plus selection pressure on the episode-return fitness function.

--- a/maze_navigation/README.md
+++ b/maze_navigation/README.md
@@ -173,3 +173,25 @@ A few things that are not obvious from the code alone:
 - **Hard generation cap.** Evolution stops at `maxGenerations` (default 300) even if the threshold
   has not been reached, so a stuck run never blocks the example forever. The cap is enforced in
   `evolveMazeController` and verified by the `honours the hard generation cap` test.
+
+## 🧰 NEAT-AI Features Used
+
+Maze Navigation is an evolution-from-noise agent demo, so the demonstrated capability is NEAT-AI's
+evolutionary topology search driven by an episode-rollout fitness signal.
+
+> 🔎 **Stripped-down operator subset.** This example deliberately exercises a narrow slice of
+> NEAT-AI's full pipeline so the noise → competent story stays uncluttered. The production training
+> pipeline (backpropagation, dropout, L1/L2 regularisation, K-fold, binary `.bin` data streams,
+> distributed evolution, etc.) is intentionally **not** wired into this demo — see issue
+> [#185](https://github.com/stSoftwareAU/NEAT-AI-Examples/issues/185) and the upstream
+> production-pipeline notes in
+> [`COMPARISON.md`](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md) for the
+> wider feature set.
+
+Features exercised (links go to upstream
+[`COMPARISON.md`](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md)):
+
+- **[Evolutionary Topology Search](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md#what-weve-implemented)**
+  — structural mutation co-evolved with weights against the maze-traversal fitness signal.
+- **[Genetic Operators](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md#what-weve-implemented)**
+  — weight and bias mutation paired with selection pressure on the per-episode reward.

--- a/mcmc_acceptance/README.md
+++ b/mcmc_acceptance/README.md
@@ -110,3 +110,14 @@ is unimportant — the same acceptance dynamics apply to any target distribution
   schedule actually pulls the chain toward the target).
 - The same seed produces identical proposals (determinism).
 - The rendered SVG is well-formed and embeds the 23.4% target line.
+
+## 🧰 NEAT-AI Features Used
+
+This example is a pure Metropolis-Hastings sampler over candidate mutations — no evolution loop.
+
+Features exercised (links go to upstream
+[`COMPARISON.md`](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md)):
+
+- **[MCMC Mutation Acceptance](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md#9--mcmc-mutation-acceptance)**
+  — Metropolis-Hastings acceptance test on candidate mutations, tuned for the ~23.4% acceptance
+  ratio that minimises autocorrelation.

--- a/memetic_evolution/README.md
+++ b/memetic_evolution/README.md
@@ -127,3 +127,17 @@ recorded and rendered as green dashed vertical lines on the fitness chart.
   outperforms the control by a measurable margin (the SVG demonstrates the lift visually).
 - The rendered SVG is well-formed, embeds both curves as polylines, and includes the seeding-marker
   class so the markers are individually addressable for downstream styling.
+
+## 🧰 NEAT-AI Features Used
+
+**Acronym.** _NEAT_ = NeuroEvolution of Augmenting Topologies.
+
+Memetic Evolution re-seeds the population from an archive of fittest creatures so successful weight
+patterns are remembered across generations.
+
+Features exercised (links go to upstream
+[`COMPARISON.md`](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md)):
+
+- **[Memetic Evolution](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md#1--memetic-evolution-hybrid-evolution--backpropagation)**
+  — memetic recall: the population is re-seeded from an archive of fittest creatures so good weight
+  patterns survive structural change.

--- a/mnist_classification/README.md
+++ b/mnist_classification/README.md
@@ -265,3 +265,32 @@ For the full training-methods catalogue (backpropagation, dropout, L1/L2 regular
 cross-validation, synthetic synapses, sparse training, batch processing, early stopping and more)
 see upstream
 [`COMPARISON.md`](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md#training-methods).
+
+## 🧰 NEAT-AI Features Used
+
+MNIST is a supervised noise → competent demo, so the demonstrated capability is NEAT-AI's
+evolutionary topology search against a classification fitness signal. NEAT-AI's full training
+pipeline (backpropagation, mini-batch, dropout, L1/L2, K-fold, binary `.bin` streams) is
+intentionally **not** wired in here — the upstream MLP/SGD baseline in the README is the contrast
+for evolutionary search alone, **not** for NEAT-AI as a whole.
+
+> 🔎 **Stripped-down operator subset.** This example deliberately exercises a narrow slice of
+> NEAT-AI's full pipeline so the noise → competent story stays uncluttered. The production training
+> pipeline (backpropagation, dropout, L1/L2 regularisation, K-fold, binary `.bin` data streams,
+> distributed evolution, etc.) is intentionally **not** wired into this demo — see issue
+> [#185](https://github.com/stSoftwareAU/NEAT-AI-Examples/issues/185) and the upstream
+> production-pipeline notes in
+> [`COMPARISON.md`](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md) for the
+> wider feature set.
+
+Features exercised (links go to upstream
+[`COMPARISON.md`](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md)):
+
+- **[Evolutionary Topology Search](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md#what-weve-implemented)**
+  — structural mutation co-evolved with weights and biases against the cross-entropy classification
+  fitness signal.
+- **[Genetic Operators](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md#what-weve-implemented)**
+  — weight and bias mutation paired with selection pressure on the validation accuracy.
+- **[Backpropagation](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md#what-weve-implemented)**
+  — available in NEAT-AI but **not** used by this demo — the MLP/SGD baseline shown in the README
+  runs separately for contrast. See `synthetic_synapse/` for an example that does invoke backprop.

--- a/mountain_car/README.md
+++ b/mountain_car/README.md
@@ -145,3 +145,25 @@ A few things that are not obvious from the code alone:
   canonical `MountainCar-v0` benchmark, so behaviour matches the textbook reference. Despite that
   pedigree, the simulator is plain TypeScript so the project remains "Deno + JSR" with no extra
   runtime.
+
+## 🧰 NEAT-AI Features Used
+
+Mountain Car is an evolution-from-noise agent demo, so the demonstrated capability is NEAT-AI's
+evolutionary topology search driven by an episode-rollout fitness signal.
+
+> 🔎 **Stripped-down operator subset.** This example deliberately exercises a narrow slice of
+> NEAT-AI's full pipeline so the noise → competent story stays uncluttered. The production training
+> pipeline (backpropagation, dropout, L1/L2 regularisation, K-fold, binary `.bin` data streams,
+> distributed evolution, etc.) is intentionally **not** wired into this demo — see issue
+> [#185](https://github.com/stSoftwareAU/NEAT-AI-Examples/issues/185) and the upstream
+> production-pipeline notes in
+> [`COMPARISON.md`](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md) for the
+> wider feature set.
+
+Features exercised (links go to upstream
+[`COMPARISON.md`](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md)):
+
+- **[Evolutionary Topology Search](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md#what-weve-implemented)**
+  — structural mutation co-evolved with weights against the energy-build-up fitness signal.
+- **[Genetic Operators](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md#what-weve-implemented)**
+  — weight and bias mutation paired with selection pressure on the per-episode reward.

--- a/neuron_pruning/README.md
+++ b/neuron_pruning/README.md
@@ -106,3 +106,15 @@ math directly on the synapse array, which keeps the demo self-contained and byte
 - The whole run is byte-deterministic for the same config.
 - The rendered SVG is well-formed, embeds the topology / summary / legend panels, and references the
   pruned-neuron and bias-fold CSS classes.
+
+## 🧰 NEAT-AI Features Used
+
+Neuron Pruning is one of NEAT-AI's simplest, most effective operators: it removes neurons that
+became redundant after training.
+
+Features exercised (links go to upstream
+[`COMPARISON.md`](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md)):
+
+- **[Neuron Pruning](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md#what-weve-implemented)**
+  — removes constant or low-utility neurons from a creature without changing its observable outputs
+  — the central technique this example demonstrates.

--- a/readme_structure_test.ts
+++ b/readme_structure_test.ts
@@ -259,6 +259,58 @@ Deno.test("README.md retains the Quality Check section", () => {
 });
 
 /* ------------------------------------------------------------------ */
+/*  Per-example "NEAT-AI Features Used" callout (issue #187)           */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Every per-example README must include a "NEAT-AI Features Used" section
+ * that lists the upstream capabilities the example actually invokes, with
+ * at least one bullet linking to upstream COMPARISON.md so the reader can
+ * drill in. See issue #187.
+ */
+
+const FEATURES_USED_HEADING_RE = /^##\s+.*NEAT-AI Features Used/im;
+const UPSTREAM_COMPARISON_LINK_RE =
+  /https?:\/\/github\.com\/stSoftwareAU\/NEAT-AI\/(?:blob|tree)\/[^\s)]*COMPARISON\.md(?:#[^\s)]*)?/i;
+
+function sliceFeaturesSection(content: string): string {
+  const headingIdx = content.search(FEATURES_USED_HEADING_RE);
+  if (headingIdx < 0) return "";
+  // Skip past the heading line itself, then bound by the next "## " heading.
+  const afterHeading = content.slice(headingIdx);
+  const nextLineBreak = afterHeading.indexOf("\n");
+  const body = nextLineBreak >= 0 ? afterHeading.slice(nextLineBreak + 1) : "";
+  const nextHeadingIdx = body.search(/^##\s+/m);
+  return nextHeadingIdx >= 0 ? body.slice(0, nextHeadingIdx) : body;
+}
+
+for (const dir of EXAMPLE_DIRS) {
+  Deno.test(`${dir}/README.md has a "NEAT-AI Features Used" section`, () => {
+    const content = Deno.readTextFileSync(`${dir}/README.md`);
+    assertEquals(
+      FEATURES_USED_HEADING_RE.test(content),
+      true,
+      `${dir}/README.md should contain a "## … NEAT-AI Features Used" section so readers see at a glance which upstream capabilities the example exercises (issue #187).`,
+    );
+  });
+
+  Deno.test(`${dir}/README.md NEAT-AI Features Used section links to upstream COMPARISON.md`, () => {
+    const content = Deno.readTextFileSync(`${dir}/README.md`);
+    const section = sliceFeaturesSection(content);
+    assertEquals(
+      section.length > 0,
+      true,
+      `${dir}/README.md must contain the NEAT-AI Features Used heading before this assertion runs (issue #187).`,
+    );
+    assertEquals(
+      UPSTREAM_COMPARISON_LINK_RE.test(section),
+      true,
+      `${dir}/README.md NEAT-AI Features Used section must link to upstream COMPARISON.md at least once so the reader can drill into the cited capability (issue #187).`,
+    );
+  });
+}
+
+/* ------------------------------------------------------------------ */
 /*  Unique Features Showcase section (issue #91)                       */
 /* ------------------------------------------------------------------ */
 

--- a/snake_game/README.md
+++ b/snake_game/README.md
@@ -187,3 +187,27 @@ A few things that are not obvious from the code alone:
   library's seeded RNG. With a fixed seed the same champion is produced on every run.
 - **Per-episode seed is shared.** Every creature in a generation faces the same initial state and
   the same food sequence (given equivalent decisions), so fitness comparisons are fair.
+
+## 🧰 NEAT-AI Features Used
+
+Snake is a streaming-observation agent demo evolved from noise, so the demonstrated capability is
+NEAT-AI's evolutionary topology search driven by an episode-rollout fitness signal.
+
+> 🔎 **Stripped-down operator subset.** This example deliberately exercises a narrow slice of
+> NEAT-AI's full pipeline so the noise → competent story stays uncluttered. The production training
+> pipeline (backpropagation, dropout, L1/L2 regularisation, K-fold, binary `.bin` data streams,
+> distributed evolution, etc.) is intentionally **not** wired into this demo — see issue
+> [#185](https://github.com/stSoftwareAU/NEAT-AI-Examples/issues/185) and the upstream
+> production-pipeline notes in
+> [`COMPARISON.md`](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md) for the
+> wider feature set.
+
+Features exercised (links go to upstream
+[`COMPARISON.md`](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md)):
+
+- **[Evolutionary Topology Search](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md#what-weve-implemented)**
+  — structural mutation co-evolved with weights against the apple-eating fitness signal across
+  streamed `Creature.activate` calls.
+- **[Genetic Operators](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md#what-weve-implemented)**
+  — weight and bias mutation paired with selection pressure on the survival-and-score fitness
+  function.

--- a/stock_market/README.md
+++ b/stock_market/README.md
@@ -189,3 +189,25 @@ A few things that are not obvious from the code alone:
   costs, slippage, or compounding adjustments.
 - **Monthly cadence.** The teaching example uses monthly data because it is small, public, and
   digest-pinnable. A daily CSV would behave identically — the code is unaware of the cadence.
+
+## 🧰 NEAT-AI Features Used
+
+Stock Market is a supervised noise → competent demo, so the demonstrated capability is NEAT-AI's
+evolutionary topology search against a price-prediction fitness signal.
+
+> 🔎 **Stripped-down operator subset.** This example deliberately exercises a narrow slice of
+> NEAT-AI's full pipeline so the noise → competent story stays uncluttered. The production training
+> pipeline (backpropagation, dropout, L1/L2 regularisation, K-fold, binary `.bin` data streams,
+> distributed evolution, etc.) is intentionally **not** wired into this demo — see issue
+> [#185](https://github.com/stSoftwareAU/NEAT-AI-Examples/issues/185) and the upstream
+> production-pipeline notes in
+> [`COMPARISON.md`](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md) for the
+> wider feature set.
+
+Features exercised (links go to upstream
+[`COMPARISON.md`](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md)):
+
+- **[Evolutionary Topology Search](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md#what-weve-implemented)**
+  — structural mutation co-evolved with weights and biases against the regression fitness signal.
+- **[Genetic Operators](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md#what-weve-implemented)**
+  — weight and bias mutation paired with selection pressure on validation MSE.

--- a/suggest_improvements/README.md
+++ b/suggest_improvements/README.md
@@ -42,3 +42,17 @@ suggestions as GitHub issues, use the `gh` CLI:
 ```bash
 gh issue create --title "Improvement title" --label "enhancement" --body "Description"
 ```
+
+## 🧰 NEAT-AI Features Used
+
+This is a static-analysis utility — it does not invoke evolution itself. Instead, it reads the
+project's current example state and surfaces opportunities to wire in additional NEAT-AI
+capabilities.
+
+Features exercised (links go to upstream
+[`COMPARISON.md`](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md)):
+
+- **[Cross-References Upstream Feature List](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md#what-weve-implemented)**
+  — the suggestions point readers at upstream NEAT-AI features (memetic evolution, Markov chain
+  Monte Carlo (MCMC) mutation acceptance, Discovery, synthetic synapse, etc.) that are not yet
+  exercised by an example here.

--- a/synthetic_synapse/README.md
+++ b/synthetic_synapse/README.md
@@ -120,3 +120,21 @@ mathematics, no I/O, byte-deterministic for a given seed. The point of the demo 
 - The whole run is byte-deterministic for the same config.
 - The rendered SVG is well-formed, embeds all three phase labels, and addresses original vs.
   synthetic synapses through their own CSS classes.
+
+## 🧰 NEAT-AI Features Used
+
+Synthetic Synapse Training is a NEAT-AI extension: densify-train-prune on an evolved sparse
+creature.
+
+Features exercised (links go to upstream
+[`COMPARISON.md`](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md)):
+
+- **[Synthetic Synapse Training](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md#12--synthetic-synapse-training)**
+  — densify-train-prune step on an evolved sparse creature — the central technique this example
+  demonstrates.
+- **[Backpropagation](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md#what-weve-implemented)**
+  — gradient-based weight tuning runs on the densified topology before pruning — concrete proof that
+  NEAT-AI is **not** evolution-only.
+- **[Neuron Pruning](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md#what-weve-implemented)**
+  — the final pass removes the synthetic synapses that did not pull weight, keeping the creature
+  sparse.

--- a/xor_classification/README.md
+++ b/xor_classification/README.md
@@ -152,3 +152,26 @@ A few things that are not obvious from the code alone:
 > version of this demo started from a hand-fixed 2-2-1 topology and only mutated weights, so the
 > neuron and synapse counts never changed. This page (and the screenshots) reflects the rewrite that
 > replaced the hand-rolled loop with real NEAT structural mutation from a minimal random seed.
+
+## 🧰 NEAT-AI Features Used
+
+XOR is the canonical neuroevolution "Hello World" — evolution from noise against a tiny supervised
+target. The capability surfaced here is plain NEAT-AI evolutionary topology search.
+
+> 🔎 **Stripped-down operator subset.** This example deliberately exercises a narrow slice of
+> NEAT-AI's full pipeline so the noise → competent story stays uncluttered. The production training
+> pipeline (backpropagation, dropout, L1/L2 regularisation, K-fold, binary `.bin` data streams,
+> distributed evolution, etc.) is intentionally **not** wired into this demo — see issue
+> [#185](https://github.com/stSoftwareAU/NEAT-AI-Examples/issues/185) and the upstream
+> production-pipeline notes in
+> [`COMPARISON.md`](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md) for the
+> wider feature set.
+
+Features exercised (links go to upstream
+[`COMPARISON.md`](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md)):
+
+- **[Evolutionary Topology Search](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md#what-weve-implemented)**
+  — structural mutation (add-neuron / add-synapse) is mandatory because XOR is not linearly
+  separable from the direct-only random seed.
+- **[Genetic Operators](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md#what-weve-implemented)**
+  — weight and bias mutation co-evolved with structure against the squared-error fitness signal.


### PR DESCRIPTION
## Summary

Adds a new **🧰 NEAT-AI Features Used** callout to every per-example README so a reader landing on
any single example can see at a glance which upstream NEAT-AI capabilities the example actually
invokes — and follow a link straight to the corresponding section of upstream
[`COMPARISON.md`](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md). The callout
makes the breadth of NEAT-AI visible per page rather than only in the top-level breadth section.
Closes #187.

For technique-only examples (`crispr_injection`, `neuron_pruning`, `synthetic_synapse`,
`mcmc_acceptance`, `memetic_evolution`, `adaptive_mutation`, `intelligent_design`, `discovery`,
`discovery_at_scale`, `crossover`) the callout names the single dominant technique. For supervised /
agent demos (`xor_classification`, `cart_pole`, `snake_game`, `mnist_classification`,
`stock_market`, `lunar_lander`, `mountain_car`, `maze_navigation`, `evolution_showcase`) it names
evolutionary topology search plus weight/bias mutation, **and** explicitly flags that the example
uses a stripped-down operator subset — pointing at issue #185 and upstream production-pipeline notes
for the wider feature set.

## Evidence

This is a documentation-only change. Verification is via the new structural test cases in
`readme_structure_test.ts` (TDD — added before the README content):

- `${dir}/README.md has a "NEAT-AI Features Used" section` for every example directory.
- `${dir}/README.md NEAT-AI Features Used section links to upstream
  COMPARISON.md` — bounds the
  section by the next `##` heading and asserts at least one upstream `COMPARISON.md` URL.

```mermaid
flowchart LR
    R[Reader lands on per-example README] --> S[🧰 NEAT-AI Features Used]
    S --> U["Upstream COMPARISON.md<br/>(specific anchored section)"]
    S --> I185{"Subset demo?"}
    I185 -- yes --> N185[Issue #185 / production-pipeline notes]
    I185 -- no --> Done[Reader sees full feature list]
```

`./quality.sh` is gated on lint, fmt, type-check, unit tests and example runs; lint, fmt, type-check
and the relevant README test files all pass locally:

- `deno lint` — clean (118 files).
- `deno fmt --check` — clean (268 files).
- `deno check **/*.ts` — clean.
- `deno test readme_structure_test.ts readme_paradigms_test.ts
  readme_acronym_glossary_test.ts mermaid_diagrams_test.ts
  contributing_test.ts discovery_readme_framing_test.ts`
  — 245 passed, 0 failed.
- `deno test docs/archive_test.ts` — 2 passed (pre-existing leftover for `pr-summary-189.md`
  allowlisted alongside `pr-summary-187.md`).

## Test Plan

- [x] New tests in `readme_structure_test.ts` assert every per-example README contains the new
      section header.
- [x] New tests in `readme_structure_test.ts` assert the section contains at least one link to
      upstream `COMPARISON.md`.
- [x] `readme_acronym_glossary_test.ts` still passes — newly-introduced `NEAT` / `MCMC` mentions in
      the new sections are paired with the glossary expansion in the same README.
- [x] `deno fmt --check`, `deno lint`, `deno check` all pass.
- [x] `docs/archive_test.ts` updated to allowlist `pr-summary-187.md` (and the pre-existing leftover
      `pr-summary-189.md`).



---

🤖 Processed by: stservice<!-- vibe-worker-issue-187 -->