### PR TITLE
docs(readme): add Beyond Standard NEAT feature breadth section (#186)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,125 @@ The remaining examples (`intelligent_design`, `discovery`, `discovery_at_scale`,
 `adaptive_mutation`, `suggest_improvements`) are tagged **🛠 technique** — they demonstrate a single
 operator or algorithm rather than a complete training paradigm.
 
+## 🚀 Beyond Standard NEAT — what NEAT-AI ships
+
+NEAT-AI is a substantial **superset** of the textbook Stanley & Miikkulainen (2002) algorithm. The
+original paper described topology-and-weight neuroevolution; NEAT-AI keeps that core and layers on a
+broad set of techniques drawn from modern deep learning, Bayesian inference, and engineering
+practice. The list below summarises each capability in one line and points at the demo in this repo
+that exercises it (where one exists).
+
+- 🎓 **Backpropagation** — full mini-batch SGD (stochastic gradient descent) with momentum, L1/L2
+  weight decay, dropout, and K-fold cross-validation, run on the same creature representation that
+  evolution uses. Demonstrated by [🔢 MNIST](mnist_classification/README.md) and
+  [📈 Stock Market](stock_market/README.md).
+- 🧠 **Memetic evolution** — maintain an archive of the fittest weight vectors and re-seed the
+  population from it to shrug off mini-batch noise. Demonstrated by
+  [🧠 Memetic Evolution](memetic_evolution/README.md).
+- 🌡️ **MCMC mutation acceptance** — adaptive Metropolis-Hastings cooling so the empirical mutation
+  acceptance rate converges on the 23.4% optimum from Roberts/Gelman/Gilks (1997). Demonstrated by
+  [🌡️ MCMC Acceptance](mcmc_acceptance/README.md).
+- 🔬 **GPU-accelerated Discovery** — defect-driven structural mutation that brings _a bit of science
+  to the structural changes_: detect saturated, dead, dormant, and bottleneck neurons and target
+  mutations at them, with the heavy search loop running through a Rust FFI backed by GPU compute.
+  Demonstrated by [🔍 Discovery](discovery/README.md) and
+  [🔬 Discovery at Scale](discovery_at_scale/README.md).
+- 🧬 **Synthetic synapse training** — densify an evolved sparse creature with zero-weight synapses,
+  train them, then prune the unused edges so behaviour is preserved at lower complexity.
+  Demonstrated by [🧬 Synthetic Synapse](synthetic_synapse/README.md).
+- 🔀 **Advanced breeding** — crossover that aligns parents with different architectures via
+  innovation numbers and recombines disjoint/excess genes, plus
+  [🧬 CRISPR Injection](crispr_injection/README.md) for hand-crafted gene splicing into a stalled
+  population. Demonstrated by [🔀 Crossover](crossover/README.md) and the CRISPR demo above.
+- 🔮 **Predictive coding (opt-in)** — score creatures partly on how well their internal activations
+  predict the next observation, biasing evolution toward forward models that compress the
+  environment. Upstream feature; not yet isolated as a stand-alone demo here — see upstream
+  COMPARISON.md.
+- 🎛️ **Hyperparameter self-adaptation** — mutation rates, MCMC temperature, and crossover share
+  adapt online during a run, freeing the user from hand-tuning per task. The size-driven topology
+  policy is demonstrated by [🧬 Adaptive Mutation](adaptive_mutation/README.md).
+- 📈 **Adaptive population sizing** — population size is not fixed; the runtime grows or shrinks it
+  based on diversity and stagnation signals. Upstream feature; effects are visible across every
+  evolution-driven example in this repo.
+- 📦 **ONNX export** — trained creatures can be exported to the ONNX (Open Neural Network Exchange)
+  format and loaded by any ONNX-compatible runtime, decoupling deployment from Deno. Upstream
+  feature; not yet isolated as a stand-alone demo here — see upstream COMPARISON.md.
+- 🔁 **Transfer learning** — re-use a creature trained on one task as the seed for a related task,
+  preserving learnt weight structure rather than re-evolving from scratch. Closely related to
+  [🧠 Memetic Evolution](memetic_evolution/README.md), which seeds from a fittest archive.
+- ✂️ **Constant-activation neuron pruning** — remove neurons whose activations don't vary, folding
+  their bias contribution into downstream neighbours so the output is unchanged. Demonstrated by
+  [✂️ Neuron Pruning](neuron_pruning/README.md).
+- 💾 **Binary `.bin` training stream** — chunked binary on-disk format for fast, large-data
+  evolution; samples stream straight off the cache without per-row JSON parsing overhead. Upstream
+  feature in `neat-core`; surfaces in this repo through the data-heavy supervised examples
+  ([🔢 MNIST](mnist_classification/README.md), [📈 Stock Market](stock_market/README.md)).
+
+```mermaid
+flowchart TB
+    subgraph search ["🔎 search"]
+        MCMC2["🌡️ MCMC acceptance"]
+        ADAPT["🎛️ Hyperparameter<br/>self-adaptation"]
+        POP["📈 Adaptive<br/>population sizing"]
+    end
+
+    subgraph training ["🎓 training"]
+        BP["🎓 Backpropagation<br/>SGD + momentum,<br/>L1/L2, dropout, K-fold"]
+        MEME2["🧠 Memetic evolution"]
+        XFER["🔁 Transfer learning"]
+        PRED["🔮 Predictive coding"]
+    end
+
+    subgraph structure ["🧬 structure"]
+        DISC2["🔬 GPU-accelerated<br/>Discovery"]
+        SYN["🧬 Synthetic synapse"]
+        BREED["🔀 Advanced breeding<br/>+ CRISPR injection"]
+        PRUNE["✂️ Neuron pruning"]
+    end
+
+    subgraph scale ["⚡ scale"]
+        BIN["💾 Binary .bin<br/>training stream"]
+    end
+
+    subgraph interop ["🔌 interop"]
+        ONNX["📦 ONNX export"]
+    end
+
+    EX_MNIST["🔢 MNIST"]
+    EX_STOCK["📈 Stock Market"]
+    EX_MEME["🧠 Memetic Evolution"]
+    EX_MCMC["🌡️ MCMC Acceptance"]
+    EX_DISC["🔍 Discovery /<br/>🔬 Discovery at Scale"]
+    EX_SYN["🧬 Synthetic Synapse"]
+    EX_CROSS["🔀 Crossover /<br/>🧬 CRISPR Injection"]
+    EX_ADAPT["🧬 Adaptive Mutation"]
+    EX_PRUNE["✂️ Neuron Pruning"]
+
+    BP --> EX_MNIST
+    BP --> EX_STOCK
+    BIN --> EX_MNIST
+    BIN --> EX_STOCK
+    MEME2 --> EX_MEME
+    XFER --> EX_MEME
+    MCMC2 --> EX_MCMC
+    DISC2 --> EX_DISC
+    SYN --> EX_SYN
+    BREED --> EX_CROSS
+    ADAPT --> EX_ADAPT
+    PRUNE --> EX_PRUNE
+
+    style search fill:#fff3cd,stroke:#f5a623,color:#333
+    style training fill:#d4edda,stroke:#28a745,color:#333
+    style structure fill:#d6eaff,stroke:#3498db,color:#333
+    style scale fill:#fde2e2,stroke:#e74c3c,color:#333
+    style interop fill:#e8d6ff,stroke:#9b59b6,color:#333
+```
+
+> 📚 **See
+> [upstream `COMPARISON.md`](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md) for
+> the full taxonomy** of capabilities — including the textbook NEAT baseline, deep-learning
+> additions, Bayesian additions, and engineering features — with citations and per-feature notes.
+
 ## 🧬 Examples at a Glance
 
 | Example                                                               | Paradigm      | What it shows                                                                                                                                                                                           | How to run                      |

--- a/docs/pr-summary-186.md
+++ b/docs/pr-summary-186.md
@@ -1,0 +1,54 @@
+## Summary
+
+Added a new **🚀 Beyond Standard NEAT — what NEAT-AI ships** section to the top-level `README.md`,
+inserted immediately after the existing _Two Training Paradigms_ section. The section makes the
+breadth of NEAT-AI's capabilities discoverable from page one, mapping each capability to the demo in
+this repo that exercises it (where one exists), grouping them visually with a Mermaid diagram by
+category (search · training · structure · scale · interop), and ending with a prominent call-out to
+upstream [`COMPARISON.md`](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md).
+Closes #186.
+
+## Evidence
+
+This is a documentation-only change. The structure is enforced by a new "what" test file,
+`readme_beyond_standard_neat_test.ts`, which asserts:
+
+- the section heading is present;
+- it sits between the paradigms section and Examples at a Glance;
+- it frames NEAT-AI as a **superset** of textbook Stanley & Miikkulainen NEAT;
+- every required capability is mentioned (backprop, memetic, MCMC, GPU-accelerated Discovery,
+  synthetic synapse, advanced breeding, predictive coding, hyperparameter self-adaptation, adaptive
+  population sizing, ONNX, transfer learning, binary `.bin` training stream);
+- the section contains a Mermaid block;
+- the diagram labels all five required category subgraphs (search · training · structure · scale ·
+  interop);
+- the section links to upstream `COMPARISON.md` and uses the word "taxonomy" in the closing
+  call-out.
+
+```mermaid
+flowchart LR
+    Issue[Issue #186] --> Tests[readme_beyond_standard_neat_test.ts]
+    Tests --> README[README.md<br/>new section]
+    README --> Mermaid[Mermaid category diagram]
+    README --> Comparison[Upstream COMPARISON.md call-out]
+```
+
+Quality gates:
+
+- `deno lint` — clean.
+- `deno fmt --check` — clean.
+- `deno check **/*.ts` — clean.
+- `deno test` — **1000 passed | 0 failed** (the suite includes the new file plus the existing README
+  structure, paradigms, acronym-glossary, and Mermaid validators).
+
+The full `./quality.sh` script also runs every example end-to-end. Those example runs are unrelated
+to a README-only change, so they were not re-executed in this run; the lint, fmt, type-check, and
+unit-test gates that gate quality cover the change.
+
+## Test Plan
+
+- Added `readme_beyond_standard_neat_test.ts` (20 tests) covering the section header, placement,
+  superset framing, required capability mentions, Mermaid block, category labels, and upstream
+  `COMPARISON.md` call-out.
+- All existing README tests still pass — `readme_paradigms_test.ts`, `readme_structure_test.ts`,
+  `readme_acronym_glossary_test.ts`, and `mermaid_diagrams_test.ts` are unchanged and green.

--- a/readme_beyond_standard_neat_test.ts
+++ b/readme_beyond_standard_neat_test.ts
@@ -1,0 +1,198 @@
+/**
+ * Tests for the "Beyond Standard NEAT" feature breadth section in
+ * README.md (issue #186).
+ *
+ * The top-level README must surface — from page one — that NEAT-AI is a
+ * substantial superset of the textbook Stanley & Miikkulainen (2002)
+ * algorithm. The section lists the major capability categories with
+ * one-line summaries, maps each capability to the demo in this repo
+ * that exercises it, includes a Mermaid diagram grouping the
+ * capabilities by category, and ends with a prominent call-out to
+ * upstream COMPARISON.md.
+ *
+ * These are "what" tests — they read README.md and verify the structural
+ * elements the issue requires, not the implementation.
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+
+const README_PATH = "README.md";
+
+function loadReadme(): string {
+  return Deno.readTextFileSync(README_PATH);
+}
+
+const SECTION_HEADING_RE = /^##\s+.*Beyond Standard NEAT.*$/im;
+const PARADIGMS_HEADING_RE = /^##\s+.*(Two Training Paradigms|Supervised vs Agent).*$/im;
+const EXAMPLES_HEADING_RE = /^##\s+.*Examples at a Glance.*$/im;
+const UPSTREAM_COMPARISON_LINK_RE =
+  /https?:\/\/github\.com\/stSoftwareAU\/NEAT-AI\/(?:blob|tree)\/[^\s)]*COMPARISON\.md(?:#[^\s)]*)?/i;
+
+function beyondSection(content: string): string {
+  const start = content.search(SECTION_HEADING_RE);
+  if (start < 0) return "";
+  const after = content.slice(start + 1);
+  const nextHeadingOffset = after.search(/^##\s+/m);
+  return nextHeadingOffset < 0
+    ? content.slice(start)
+    : content.slice(start, start + 1 + nextHeadingOffset);
+}
+
+function extractMermaidBlocks(content: string): string[] {
+  const blocks: string[] = [];
+  const regex = /```mermaid\n([\s\S]*?)```/g;
+  let m: RegExpExecArray | null;
+  while ((m = regex.exec(content)) !== null) blocks.push(m[1]);
+  return blocks;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Section exists and sits between paradigms and Examples at a Glance */
+/* ------------------------------------------------------------------ */
+
+Deno.test("README.md has a Beyond Standard NEAT section", () => {
+  const content = loadReadme();
+  assertEquals(
+    SECTION_HEADING_RE.test(content),
+    true,
+    "README.md should have a 'Beyond Standard NEAT' heading",
+  );
+});
+
+Deno.test("Beyond Standard NEAT section appears after the paradigms section", () => {
+  const content = loadReadme();
+  const paradigmMatch = content.match(PARADIGMS_HEADING_RE);
+  const beyondMatch = content.match(SECTION_HEADING_RE);
+  assertEquals(paradigmMatch !== null, true, "paradigms section must exist");
+  assertEquals(beyondMatch !== null, true, "Beyond Standard NEAT section must exist");
+  if (paradigmMatch && beyondMatch) {
+    const paradigmIndex = content.indexOf(paradigmMatch[0]);
+    const beyondIndex = content.indexOf(beyondMatch[0]);
+    assertEquals(
+      paradigmIndex < beyondIndex,
+      true,
+      "Beyond Standard NEAT should sit after the paradigms section",
+    );
+  }
+});
+
+Deno.test("Beyond Standard NEAT section appears before Examples at a Glance", () => {
+  const content = loadReadme();
+  const beyondMatch = content.match(SECTION_HEADING_RE);
+  const examplesMatch = content.match(EXAMPLES_HEADING_RE);
+  assertEquals(beyondMatch !== null, true, "Beyond Standard NEAT section must exist");
+  assertEquals(examplesMatch !== null, true, "Examples at a Glance section must exist");
+  if (beyondMatch && examplesMatch) {
+    const beyondIndex = content.indexOf(beyondMatch[0]);
+    const examplesIndex = content.indexOf(examplesMatch[0]);
+    assertEquals(
+      beyondIndex < examplesIndex,
+      true,
+      "Beyond Standard NEAT should sit before Examples at a Glance",
+    );
+  }
+});
+
+/* ------------------------------------------------------------------ */
+/*  Section frames NEAT-AI as a superset of textbook NEAT             */
+/* ------------------------------------------------------------------ */
+
+Deno.test("Beyond Standard NEAT section frames NEAT-AI as a superset of textbook NEAT", () => {
+  const section = beyondSection(loadReadme()).toLowerCase();
+  assertStringIncludes(
+    section,
+    "superset",
+    "section should explicitly state NEAT-AI is a superset of textbook NEAT",
+  );
+  assertStringIncludes(
+    section,
+    "stanley",
+    "section should reference Stanley (& Miikkulainen) so readers know which baseline is being extended",
+  );
+});
+
+/* ------------------------------------------------------------------ */
+/*  Capability one-line summaries                                     */
+/* ------------------------------------------------------------------ */
+
+const REQUIRED_CAPABILITIES: ReadonlyArray<{ name: string; tokens: ReadonlyArray<string> }> = [
+  { name: "Backpropagation", tokens: ["backprop"] },
+  { name: "Memetic evolution", tokens: ["memetic"] },
+  { name: "MCMC mutation acceptance", tokens: ["mcmc"] },
+  { name: "GPU-accelerated Discovery", tokens: ["discovery"] },
+  { name: "Synthetic synapse training", tokens: ["synthetic synapse"] },
+  { name: "Advanced breeding", tokens: ["breeding", "crossover"] },
+  { name: "Predictive coding", tokens: ["predictive coding"] },
+  { name: "Hyperparameter self-adaptation", tokens: ["hyperparameter"] },
+  { name: "Adaptive population sizing", tokens: ["population sizing", "adaptive population"] },
+  { name: "ONNX export", tokens: ["onnx"] },
+  { name: "Transfer learning", tokens: ["transfer learning"] },
+  { name: "Binary .bin training stream", tokens: [".bin"] },
+];
+
+for (const cap of REQUIRED_CAPABILITIES) {
+  Deno.test(`Beyond Standard NEAT section mentions ${cap.name}`, () => {
+    const section = beyondSection(loadReadme()).toLowerCase();
+    const present = cap.tokens.some((t) => section.includes(t.toLowerCase()));
+    assertEquals(
+      present,
+      true,
+      `Beyond Standard NEAT section should mention ${cap.name} (any of: ${cap.tokens.join(", ")})`,
+    );
+  });
+}
+
+/* ------------------------------------------------------------------ */
+/*  Mermaid diagram with category groupings                           */
+/* ------------------------------------------------------------------ */
+
+Deno.test("Beyond Standard NEAT section contains a Mermaid diagram", () => {
+  const section = beyondSection(loadReadme());
+  const blocks = extractMermaidBlocks(section);
+  assertEquals(
+    blocks.length >= 1,
+    true,
+    "Beyond Standard NEAT section should contain at least one mermaid diagram",
+  );
+});
+
+Deno.test("Beyond Standard NEAT diagram groups capabilities by category", () => {
+  const section = beyondSection(loadReadme());
+  const diagrams = extractMermaidBlocks(section).join("\n").toLowerCase();
+  for (const category of ["search", "training", "structure", "scale", "interop"]) {
+    assertStringIncludes(
+      diagrams,
+      category,
+      `Beyond Standard NEAT diagram should label the ${category} category`,
+    );
+  }
+});
+
+/* ------------------------------------------------------------------ */
+/*  Prominent call-out to upstream COMPARISON.md                      */
+/* ------------------------------------------------------------------ */
+
+Deno.test("Beyond Standard NEAT section links to upstream COMPARISON.md", () => {
+  const section = beyondSection(loadReadme());
+  assertEquals(
+    UPSTREAM_COMPARISON_LINK_RE.test(section),
+    true,
+    "Beyond Standard NEAT section should link to upstream NEAT-AI/COMPARISON.md",
+  );
+});
+
+Deno.test("Beyond Standard NEAT section ends with a COMPARISON.md call-out", () => {
+  const section = beyondSection(loadReadme());
+  // The call-out must mention COMPARISON.md and use the word "taxonomy"
+  // so the closing pointer is unambiguous.
+  assertStringIncludes(
+    section,
+    "COMPARISON.md",
+    "section should call out COMPARISON.md by name",
+  );
+  assertStringIncludes(
+    section.toLowerCase(),
+    "taxonomy",
+    "section should use the word 'taxonomy' in the closing call-out",
+  );
+});


### PR DESCRIPTION
## Summary

Added a new **🚀 Beyond Standard NEAT — what NEAT-AI ships** section to the top-level `README.md`,
inserted immediately after the existing _Two Training Paradigms_ section. The section makes the
breadth of NEAT-AI's capabilities discoverable from page one, mapping each capability to the demo in
this repo that exercises it (where one exists), grouping them visually with a Mermaid diagram by
category (search · training · structure · scale · interop), and ending with a prominent call-out to
upstream [`COMPARISON.md`](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md).
Closes #186.

## Evidence

This is a documentation-only change. The structure is enforced by a new "what" test file,
`readme_beyond_standard_neat_test.ts`, which asserts:

- the section heading is present;
- it sits between the paradigms section and Examples at a Glance;
- it frames NEAT-AI as a **superset** of textbook Stanley & Miikkulainen NEAT;
- every required capability is mentioned (backprop, memetic, MCMC, GPU-accelerated Discovery,
  synthetic synapse, advanced breeding, predictive coding, hyperparameter self-adaptation, adaptive
  population sizing, ONNX, transfer learning, binary `.bin` training stream);
- the section contains a Mermaid block;
- the diagram labels all five required category subgraphs (search · training · structure · scale ·
  interop);
- the section links to upstream `COMPARISON.md` and uses the word "taxonomy" in the closing
  call-out.

```mermaid
flowchart LR
    Issue[Issue #186] --> Tests[readme_beyond_standard_neat_test.ts]
    Tests --> README[README.md<br/>new section]
    README --> Mermaid[Mermaid category diagram]
    README --> Comparison[Upstream COMPARISON.md call-out]
```

Quality gates:

- `deno lint` — clean.
- `deno fmt --check` — clean.
- `deno check **/*.ts` — clean.
- `deno test` — **1000 passed | 0 failed** (the suite includes the new file plus the existing README
  structure, paradigms, acronym-glossary, and Mermaid validators).

The full `./quality.sh` script also runs every example end-to-end. Those example runs are unrelated
to a README-only change, so they were not re-executed in this run; the lint, fmt, type-check, and
unit-test gates that gate quality cover the change.

## Test Plan

- Added `readme_beyond_standard_neat_test.ts` (20 tests) covering the section header, placement,
  superset framing, required capability mentions, Mermaid block, category labels, and upstream
  `COMPARISON.md` call-out.
- All existing README tests still pass — `readme_paradigms_test.ts`, `readme_structure_test.ts`,
  `readme_acronym_glossary_test.ts`, and `mermaid_diagrams_test.ts` are unchanged and green.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-186 -->