### PR TITLE
docs(mnist): clarify embedded chart is the MLP baseline, not NEAT (#191)

### DIFF
--- a/docs/archive_test.ts
+++ b/docs/archive_test.ts
@@ -107,6 +107,7 @@ Deno.test("No PR summary files remain in docs/ root", () => {
       if (entry.name === "pr-summary-188.md") continue;
       if (entry.name === "pr-summary-189.md") continue;
       if (entry.name === "pr-summary-190.md") continue;
+      if (entry.name === "pr-summary-191.md") continue;
       throw new Error(
         `Found unexpected PR summary file in docs/ root: ${entry.name}`,
       );

--- a/docs/pr-summary-191.md
+++ b/docs/pr-summary-191.md
@@ -1,0 +1,42 @@
+# PR Summary — Issue #191
+
+## Summary
+
+The MNIST README's headline narrative talks about a long-form NEAT-from-noise evolution (hours of
+wall-clock, up to 50 000 generations, growing topology) but the chart embedded immediately below it
+came from the **MLP/SGD baseline** — fixed `196 → 64 → 10` topology, crosses 95 % in ~10 epochs,
+flat neuron and synapse counts. To a fresh reader that looks like a NEAT run that "cheated" by
+guessing the right topology, exactly as the reporter pointed out. Updates the README so the chart
+caption identifies the MLP baseline, agrees with the SVG's own `<title>`, and an inline disclaimer
+spells out that the chart is **not** from the NEAT-from-noise run and the constant neuron/synapse
+counts are by design (the MLP topology is hand-prescribed). Closes #191.
+
+## Evidence
+
+This is a documentation-only change. Verified by four new "what" tests in
+`mnist_classification/readme_screenshot_honesty_test.ts` that read the README and the embedded SVG
+and assert:
+
+1. The chart caption identifies the screenshot as the MLP baseline run.
+2. The chart caption includes the SVG's own `<title>` verbatim.
+3. The README contains an explicit paragraph naming `evolution.svg`, identifying it as the MLP
+   baseline, and stating it is not the NEAT evolution.
+4. The README explains that the MLP baseline's neuron/synapse counts are constant by design (fixed
+   topology), not a NEAT cheat.
+
+```mermaid
+flowchart LR
+    A["Issue #191<br/>chart looks like NEAT cheated"] --> B["Failing tests<br/>readme_screenshot_honesty_test.ts"]
+    B --> C["Disclaimer + caption fix<br/>mnist_classification/README.md"]
+    C --> D["Tests pass<br/>4 / 4 ✅"]
+```
+
+## Test Plan
+
+- [x] Added `mnist_classification/readme_screenshot_honesty_test.ts` (four tests, all initially red,
+      all green after the README change).
+- [x] `deno fmt --check` passes (277 files).
+- [x] `deno lint` passes (122 files).
+- [x] `deno check **/*.ts` passes.
+- [x] Pre-existing test failures (`pr-summary-186.md` allowlist gap, network-permission-gated
+      example tests) are out of scope — they exist on `Develop` before this change.

--- a/mnist_classification/README.md
+++ b/mnist_classification/README.md
@@ -27,8 +27,9 @@ binary cross-entropy, the standard per-output loss for sigmoid (LOGISTIC) classi
    `quality.sh` runs by default so CI stays fast. This baseline is **not** the NEAT demo — it does
    not start from random noise and does not grow topology.
 
-To run the long-form NEAT screenshot evolution (the one that produces the chart, progression strip,
-and prediction grid in `docs/screenshots/`), set `MNIST_NEAT_EVOLUTION=1`:
+To run the long-form NEAT screenshot evolution (the run that emits the multi-panel
+evolution-progression strip at `docs/screenshots/mnist_classification_evolution.svg`), set
+`MNIST_NEAT_EVOLUTION=1`:
 
 ```bash
 MNIST_NEAT_EVOLUTION=1 ./mnist_classification/run.sh
@@ -37,11 +38,24 @@ MNIST_NEAT_EVOLUTION=1 ./mnist_classification/run.sh
 This is **one-off developer work** — convergence from uniform-random noise is unbounded and may take
 hours of wall-clock. The evolution stops as soon as the champion crosses 95 % validation accuracy or
 the 50 000-generation hard cap is reached, whichever comes first. The default `quality.sh`
-invocation runs the SGD baseline instead so CI completes promptly.
+invocation runs the MLP/SGD baseline instead so CI completes promptly, and that baseline is what
+produces the per-epoch chart and the prediction grid embedded immediately below.
 
-![MNIST classification evolution chart — best validation accuracy on the left axis with champion neuron and synapse counts on the right axis, plotted against generation](../docs/screenshots/mnist_classification/evolution.svg)
+> ⚠️ **The chart below is the MLP baseline, not the NEAT evolution.** Issue
+> [#191](https://github.com/stSoftwareAU/NEAT-AI-Examples/issues/191) called out that the previously
+> embedded `evolution.svg` reached 95 % in ~10 generations with **constant** neuron and synapse
+> counts — which looked like a NEAT-from-noise run that had cheated by guessing the right topology.
+> It is not a cheat: this chart comes from the MLP/SGD baseline (`evolveMLPClassifier`) that
+> `quality.sh` runs by default. The MLP has a hand-prescribed `196 → 64 → 10` topology, so its
+> neuron and synapse counts are **constant by design** — there is no structural search to plot. The
+> chart is **not** from the NEAT-from-noise evolution; the NEAT run is gated behind
+> `MNIST_NEAT_EVOLUTION=1` and is genuinely a multi-hour, up-to-50 000-generation search whose
+> neuron and synapse counts grow over time. See the heading directly above the chart for the SVG's
+> own `<title>`, which agrees with this caption.
 
-![Animated grid of MNIST champion predictions, with green ticks for correct classifications and red crosses for misclassifications](../docs/screenshots/mnist_classification.svg)
+![MNIST classification — MLP baseline (validation accuracy per epoch) — dual-axis chart with validation accuracy on the left axis and the MLP's constant 74-neuron / 12 544-synapse fixed `196 → 64 → 10` topology on the right axis (this is the MLP baseline, NOT the NEAT evolution from random noise)](../docs/screenshots/mnist_classification/evolution.svg)
+
+![Animated grid of MLP-baseline champion predictions, with green ticks for correct classifications and red crosses for misclassifications](../docs/screenshots/mnist_classification.svg)
 
 ## 🔧 How It Works
 

--- a/mnist_classification/readme_screenshot_honesty_test.ts
+++ b/mnist_classification/readme_screenshot_honesty_test.ts
@@ -1,0 +1,114 @@
+/**
+ * Tests for the MNIST README's honesty about which run produced the
+ * embedded `evolution.svg` screenshot (issue #191).
+ *
+ * The reporter pointed out that the README narrates a long-form NEAT
+ * evolution from uniform-random noise (hours of wall-clock, up to
+ * `MAX_GENERATIONS` = 50 000 generations) but the embedded chart shows
+ * the MLP/SGD baseline crossing 95 % in ~10 epochs with constant
+ * neuron and synapse counts. That is misleading — the chart is from
+ * the **MLP baseline** run that `quality.sh` executes by default, not
+ * from the NEAT evolution.
+ *
+ * These are "what" tests — they read the README markdown and the
+ * actual SVG title and assert the README's caption and surrounding
+ * prose match the chart that is actually embedded.
+ */
+
+import { assert, assertStringIncludes } from "@std/assert";
+
+const README_PATH = "mnist_classification/README.md";
+const EVOLUTION_SVG_PATH = "docs/screenshots/mnist_classification/evolution.svg";
+
+function loadReadme(): string {
+  return Deno.readTextFileSync(README_PATH);
+}
+
+/** Pull the markdown image line that references the evolution chart. */
+function findEvolutionChartImageLine(readme: string): string {
+  const lines = readme.split("\n");
+  const match = lines.find((line) =>
+    line.includes("![") && line.includes("mnist_classification/evolution.svg")
+  );
+  assert(
+    match !== undefined,
+    `README must embed the evolution chart at ${EVOLUTION_SVG_PATH}`,
+  );
+  return match!;
+}
+
+/** Pull the `<title>…</title>` from the SVG. */
+function loadSvgTitle(): string {
+  const svg = Deno.readTextFileSync(EVOLUTION_SVG_PATH);
+  const m = svg.match(/<title>([^<]+)<\/title>/);
+  assert(m !== null, `${EVOLUTION_SVG_PATH} must have a <title> element`);
+  return m![1];
+}
+
+Deno.test("MNIST README chart caption identifies the MLP baseline run", () => {
+  // The chart embedded in the README is produced by the MLP baseline
+  // (the default `quality.sh` mode); its <title> says so. The README
+  // caption must agree — saying "MLP baseline" — so a reader does not
+  // mistake a 10-epoch fixed-topology MLP curve for a 50 000-generation
+  // NEAT-from-noise evolution.
+  const line = findEvolutionChartImageLine(loadReadme()).toLowerCase();
+  assertStringIncludes(
+    line,
+    "mlp baseline",
+    "evolution chart caption must identify the screenshot as the MLP baseline run",
+  );
+});
+
+Deno.test("MNIST README chart caption matches the actual SVG <title>", () => {
+  // The reporter's worry is that the chart's narrative (10 generations,
+  // constant neuron/synapse count) does not match the README's narrative
+  // (hours, 50 000 generations, growing topology). The simplest defence
+  // is to require the caption to repeat the SVG's own title verbatim.
+  const svgTitle = loadSvgTitle().toLowerCase();
+  const line = findEvolutionChartImageLine(loadReadme()).toLowerCase();
+  assertStringIncludes(
+    line,
+    svgTitle,
+    `evolution chart caption must include the SVG's own <title> ("${svgTitle}")`,
+  );
+});
+
+Deno.test("MNIST README explains the embedded chart is NOT from the NEAT run", () => {
+  // Somewhere in the README the reader needs an explicit statement that
+  // the embedded screenshot comes from the MLP baseline, not from the
+  // NEAT-from-noise evolution. Phrase it any way you like, but the two
+  // ideas must appear together in a single paragraph so the disclaimer
+  // is unmissable.
+  const readme = loadReadme().toLowerCase();
+  const paragraphs = readme.split(/\n\s*\n/);
+  const disclaimer = paragraphs.find((p) =>
+    p.includes("evolution.svg") &&
+    p.includes("mlp baseline") &&
+    (p.includes("not") && (p.includes("neat run") || p.includes("neat evolution") ||
+      p.includes("neat-from-noise")))
+  );
+  assert(
+    disclaimer !== undefined,
+    "README must contain a paragraph that names evolution.svg, identifies it as the MLP baseline, and states it is NOT the NEAT evolution",
+  );
+});
+
+Deno.test("MNIST README explains why MLP neuron/synapse counts are constant", () => {
+  // The reporter saw a flat neuron/synapse line on the chart and read
+  // it as "you cheated — you guessed the right number". That is true
+  // for the MLP baseline (it is a hand-prescribed 196 → 64 → 10 MLP),
+  // but the README must say so explicitly so no reader is misled. The
+  // word "constant" or "fixed" must appear near the words "neuron" and
+  // "synapse" in the same paragraph that mentions the MLP baseline.
+  const readme = loadReadme().toLowerCase();
+  const paragraphs = readme.split(/\n\s*\n/);
+  const para = paragraphs.find((p) =>
+    p.includes("mlp baseline") &&
+    (p.includes("constant") || p.includes("fixed") || p.includes("hand-prescribed")) &&
+    p.includes("neuron") && p.includes("synapse")
+  );
+  assert(
+    para !== undefined,
+    "README must explain that the MLP baseline's neuron/synapse counts are constant by design (fixed topology), not a NEAT cheat",
+  );
+});


### PR DESCRIPTION
# PR Summary — Issue #191

## Summary

The MNIST README's headline narrative talks about a long-form NEAT-from-noise evolution (hours of
wall-clock, up to 50 000 generations, growing topology) but the chart embedded immediately below it
came from the **MLP/SGD baseline** — fixed `196 → 64 → 10` topology, crosses 95 % in ~10 epochs,
flat neuron and synapse counts. To a fresh reader that looks like a NEAT run that "cheated" by
guessing the right topology, exactly as the reporter pointed out. Updates the README so the chart
caption identifies the MLP baseline, agrees with the SVG's own `<title>`, and an inline disclaimer
spells out that the chart is **not** from the NEAT-from-noise run and the constant neuron/synapse
counts are by design (the MLP topology is hand-prescribed). Closes #191.

## Evidence

This is a documentation-only change. Verified by four new "what" tests in
`mnist_classification/readme_screenshot_honesty_test.ts` that read the README and the embedded SVG
and assert:

1. The chart caption identifies the screenshot as the MLP baseline run.
2. The chart caption includes the SVG's own `<title>` verbatim.
3. The README contains an explicit paragraph naming `evolution.svg`, identifying it as the MLP
   baseline, and stating it is not the NEAT evolution.
4. The README explains that the MLP baseline's neuron/synapse counts are constant by design (fixed
   topology), not a NEAT cheat.

```mermaid
flowchart LR
    A["Issue #191<br/>chart looks like NEAT cheated"] --> B["Failing tests<br/>readme_screenshot_honesty_test.ts"]
    B --> C["Disclaimer + caption fix<br/>mnist_classification/README.md"]
    C --> D["Tests pass<br/>4 / 4 ✅"]
```

## Test Plan

- [x] Added `mnist_classification/readme_screenshot_honesty_test.ts` (four tests, all initially red,
      all green after the README change).
- [x] `deno fmt --check` passes (277 files).
- [x] `deno lint` passes (122 files).
- [x] `deno check **/*.ts` passes.
- [x] Pre-existing test failures (`pr-summary-186.md` allowlist gap, network-permission-gated
      example tests) are out of scope — they exist on `Develop` before this change.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-191 -->