### PR TITLE
lunar_lander: widen scenario distribution and add disjoint train/validate seed pools

### DIFF
--- a/docs/pr-summary-195.md
+++ b/docs/pr-summary-195.md
@@ -1,0 +1,75 @@
+## Summary
+
+Widens the lunar-lander start distribution and adds a deterministic
+scenario sampler that emits **disjoint training and validation seed
+pools**, so a champion that memorises a single trajectory cannot pass
+validation. Closes #195.
+
+- `lunar_lander/physics.ts`
+  - New `WIDE_RANGES` constant documenting the per-component
+    half-ranges at `magnitude=1`.
+  - New `LanderScenario` type and `perturbedScenario(random, magnitude?)`
+    sampler returning `{ state, terrain }` with `padX` varied.
+  - `perturbedInitialState` is widened to the same per-component ranges
+    (`x±25 m`, `y±20 m`, `vx±3 m/s`, `vy±2 m/s`, `angle±0.25 rad`,
+    `fuel±20`); previously narrow ranges (`±5 m`, `±0.5 m/s`,
+    `±0.05 rad`, fuel fixed) let a controller win by memorising a single
+    trajectory.
+- `lunar_lander/scenarios.ts` (new)
+  - `generateScenarioPools(baseSeed, training=1000, validation=200, magnitude=1)`
+    derives two disjoint 32-bit seed pools and realises each pool into
+    `{ seed, state, terrain }` via `perturbedScenario`.
+  - Deterministic for the same `(baseSeed, counts, magnitude)` tuple.
+- `lunar_lander/scenarios_test.ts` (new) and updated
+  `lunar_lander/physics_test.ts` cover deterministic seeds, disjoint
+  pools, every scenario starting in `flying`, and the distribution
+  actually spanning the wider range.
+- `lunar_lander/README.md` documents the wider distribution and the
+  train/validate pool split with a Mermaid diagram.
+
+## Evidence
+
+This is a backend module — there is no web interface to screenshot.
+Verification is via unit tests:
+
+```
+deno test --allow-read --allow-write --allow-env \
+  lunar_lander/physics_test.ts lunar_lander/scenarios_test.ts
+ok | 36 passed | 0 failed
+```
+
+Plus `deno fmt --check`, `deno lint`, `deno check` and
+`markdownlint-cli2 lunar_lander/README.md` — all clean.
+
+```mermaid
+flowchart LR
+    SEED["base seed"] --> POOLS["seed-pool builder<br/>(32-bit, dedup)"]
+    POOLS --> TRAIN["1000 training seeds"]
+    POOLS --> VAL["200 validation seeds"]
+    TRAIN --> SAMPLER["perturbedScenario<br/>(wider distribution)"]
+    VAL --> SAMPLER
+    SAMPLER --> SCENARIOS["LanderState + Terrain pairs"]
+```
+
+## Test Plan
+
+New / updated tests in `lunar_lander/scenarios_test.ts` and
+`lunar_lander/physics_test.ts`:
+
+- `generateScenarioPools produces the requested counts`
+- `generateScenarioPools default counts are 1000 / 200`
+- `generateScenarioPools is deterministic for the same base seed`
+- `generateScenarioPools differs between distinct base seeds`
+- `generateScenarioPools yields disjoint training and validation seed pools`
+- `every generated scenario starts in a flying state`
+- `scenario distribution actually spans the wider range`
+- `each scenario's seed reproduces its state and terrain`
+- `scenarios stay inside world bounds`
+- `generateScenarioPools rejects invalid arguments`
+- `zero-count pools are allowed and disjoint by definition`
+- `perturbedInitialState centres on initialState within the widened ranges`
+  (existing test updated to assert against `WIDE_RANGES`; the legacy
+  narrow ranges no longer apply — change is documented in the test
+  body).
+- `perturbedScenario varies padX within WIDE_RANGES.padX`
+- `perturbedScenario is deterministic for the same seed`

--- a/docs/pr-summary-195.md
+++ b/docs/pr-summary-195.md
@@ -1,36 +1,30 @@
 ## Summary
 
-Widens the lunar-lander start distribution and adds a deterministic
-scenario sampler that emits **disjoint training and validation seed
-pools**, so a champion that memorises a single trajectory cannot pass
-validation. Closes #195.
+Widens the lunar-lander start distribution and adds a deterministic scenario sampler that emits
+**disjoint training and validation seed pools**, so a champion that memorises a single trajectory
+cannot pass validation. Closes #195.
 
 - `lunar_lander/physics.ts`
-  - New `WIDE_RANGES` constant documenting the per-component
-    half-ranges at `magnitude=1`.
-  - New `LanderScenario` type and `perturbedScenario(random, magnitude?)`
-    sampler returning `{ state, terrain }` with `padX` varied.
-  - `perturbedInitialState` is widened to the same per-component ranges
-    (`x±25 m`, `y±20 m`, `vx±3 m/s`, `vy±2 m/s`, `angle±0.25 rad`,
-    `fuel±20`); previously narrow ranges (`±5 m`, `±0.5 m/s`,
-    `±0.05 rad`, fuel fixed) let a controller win by memorising a single
-    trajectory.
+  - New `WIDE_RANGES` constant documenting the per-component half-ranges at `magnitude=1`.
+  - New `LanderScenario` type and `perturbedScenario(random, magnitude?)` sampler returning
+    `{ state, terrain }` with `padX` varied.
+  - `perturbedInitialState` is widened to the same per-component ranges (`x±25 m`, `y±20 m`,
+    `vx±3 m/s`, `vy±2 m/s`, `angle±0.25 rad`, `fuel±20`); previously narrow ranges (`±5 m`,
+    `±0.5 m/s`, `±0.05 rad`, fuel fixed) let a controller win by memorising a single trajectory.
 - `lunar_lander/scenarios.ts` (new)
-  - `generateScenarioPools(baseSeed, training=1000, validation=200, magnitude=1)`
-    derives two disjoint 32-bit seed pools and realises each pool into
-    `{ seed, state, terrain }` via `perturbedScenario`.
+  - `generateScenarioPools(baseSeed, training=1000, validation=200, magnitude=1)` derives two
+    disjoint 32-bit seed pools and realises each pool into `{ seed, state, terrain }` via
+    `perturbedScenario`.
   - Deterministic for the same `(baseSeed, counts, magnitude)` tuple.
-- `lunar_lander/scenarios_test.ts` (new) and updated
-  `lunar_lander/physics_test.ts` cover deterministic seeds, disjoint
-  pools, every scenario starting in `flying`, and the distribution
+- `lunar_lander/scenarios_test.ts` (new) and updated `lunar_lander/physics_test.ts` cover
+  deterministic seeds, disjoint pools, every scenario starting in `flying`, and the distribution
   actually spanning the wider range.
-- `lunar_lander/README.md` documents the wider distribution and the
-  train/validate pool split with a Mermaid diagram.
+- `lunar_lander/README.md` documents the wider distribution and the train/validate pool split with a
+  Mermaid diagram.
 
 ## Evidence
 
-This is a backend module — there is no web interface to screenshot.
-Verification is via unit tests:
+This is a backend module — there is no web interface to screenshot. Verification is via unit tests:
 
 ```
 deno test --allow-read --allow-write --allow-env \
@@ -38,8 +32,8 @@ deno test --allow-read --allow-write --allow-env \
 ok | 36 passed | 0 failed
 ```
 
-Plus `deno fmt --check`, `deno lint`, `deno check` and
-`markdownlint-cli2 lunar_lander/README.md` — all clean.
+Plus `deno fmt --check`, `deno lint`, `deno check` and `markdownlint-cli2 lunar_lander/README.md` —
+all clean.
 
 ```mermaid
 flowchart LR
@@ -53,8 +47,7 @@ flowchart LR
 
 ## Test Plan
 
-New / updated tests in `lunar_lander/scenarios_test.ts` and
-`lunar_lander/physics_test.ts`:
+New / updated tests in `lunar_lander/scenarios_test.ts` and `lunar_lander/physics_test.ts`:
 
 - `generateScenarioPools produces the requested counts`
 - `generateScenarioPools default counts are 1000 / 200`
@@ -67,9 +60,8 @@ New / updated tests in `lunar_lander/scenarios_test.ts` and
 - `scenarios stay inside world bounds`
 - `generateScenarioPools rejects invalid arguments`
 - `zero-count pools are allowed and disjoint by definition`
-- `perturbedInitialState centres on initialState within the widened ranges`
-  (existing test updated to assert against `WIDE_RANGES`; the legacy
-  narrow ranges no longer apply — change is documented in the test
-  body).
+- `perturbedInitialState centres on initialState within the widened ranges` (existing test updated
+  to assert against `WIDE_RANGES`; the legacy narrow ranges no longer apply — change is documented
+  in the test body).
 - `perturbedScenario varies padX within WIDE_RANGES.padX`
 - `perturbedScenario is deterministic for the same seed`

--- a/lunar_lander/README.md
+++ b/lunar_lander/README.md
@@ -157,6 +157,47 @@ must actively manoeuvre — exactly like the classic Atari Lunar Lander.
 The controller has to translate sideways towards the pad while braking against gravity AND its own
 horizontal drift, all on a finite fuel budget.
 
+## 🧪 Wider Scenario Distribution and Disjoint Train/Validate Pools
+
+Issue [#195](https://github.com/stSoftwareAU/NEAT-AI-Examples/issues/195): a champion that simply
+memorises one trajectory must not pass evaluation. Two safeguards live in `physics.ts` and the new
+`scenarios.ts` module:
+
+- **Wider distribution** — `perturbedScenario` (and the legacy `perturbedInitialState`) draws every
+  component around the canonical entry across a substantially wider range. The half-ranges at
+  `magnitude=1` are exported as `WIDE_RANGES`:
+
+  | Component | Centre                   | ± Half-range | Notes                             |
+  | --------- | ------------------------ | ------------ | --------------------------------- |
+  | `x`       | `DEFAULT_START_X`        | 25 m         | Stays inside `worldHalfWidth`     |
+  | `y`       | `DEFAULT_START_ALTITUDE` | 20 m         | Always above the ground           |
+  | `vx`      | `DEFAULT_START_VX`       | 3 m/s        | —                                 |
+  | `vy`      | 0                        | 2 m/s        | —                                 |
+  | `angle`   | 0                        | 0.25 rad     | ≈ ±14°                            |
+  | `fuel`    | `DEFAULT_START_FUEL`     | 20 units     | Always > 0                        |
+  | `padX`    | 0                        | 20 m         | Pad still inside the world bounds |
+
+  Only `perturbedScenario` varies `padX` (it returns both the lander state and the terrain).
+
+- **Disjoint training and validation seed pools** — `generateScenarioPools(baseSeed, 1000, 200)` in
+  `scenarios.ts` derives two non-overlapping pools of 32-bit per-scenario seeds from a single base
+  seed, then realises each pool into `{ state, terrain }` pairs. Same base seed → identical pools;
+  different seeds → different pools. A controller that overfits training seeds cannot see validation
+  seeds during evolution, so the validation score reflects generalisation rather than memorisation.
+
+  ```mermaid
+  flowchart LR
+      SEED["base seed"] --> POOLS["seed-pool builder<br/>(32-bit, dedup)"]
+      POOLS --> TRAIN["1000 training seeds"]
+      POOLS --> VAL["200 validation seeds"]
+      TRAIN --> SAMPLER["perturbedScenario<br/>(wider distribution)"]
+      VAL --> SAMPLER
+      SAMPLER --> SCENARIOS["LanderState + Terrain pairs"]
+  ```
+
+  Every drawn scenario classifies as `flying` at `t=0`: above ground, inside the world bounds, with
+  fuel remaining — no impossible launches.
+
 ## 🧠 Why This Task Benefits from Temporal Memory
 
 Cart-Pole is solvable by a stateless linear policy — every timestep's correct action is determined

--- a/lunar_lander/physics.ts
+++ b/lunar_lander/physics.ts
@@ -152,19 +152,65 @@ export function initialState(
 }
 
 /**
- * Sample a perturbed starting state. Used to evaluate a controller
- * across a fixed batch of varied initial conditions so robustness — not
- * a single lucky launch — drives selection. Each component is sampled
- * around the canonical {@link initialState} centre using independent
- * uniform draws scaled by `magnitude`:
+ * Per-component sampling ranges used by {@link perturbedInitialState}
+ * and {@link perturbedScenario} at `magnitude=1`. Ranges are chosen so
+ * every drawn scenario is recoverable by an ideal controller — the
+ * lander always starts above the ground, inside world bounds, with
+ * enough altitude and fuel to react.
  *
- *   - `x` ± 5·m metres of horizontal offset
- *   - `y` ± 5·m metres of altitude
- *   - `vx`, `vy` ± 0.5·m m/s
- *   - `angle` ± 0.05·m radians (≈ ±2.9° at `m=1`)
+ * Issue #195: ranges were widened so a champion cannot win by
+ * memorising a single trajectory. Each value is the symmetric half-
+ * range (i.e. the sampled offset is uniform on `[-r, +r]`).
+ */
+export const WIDE_RANGES = {
+  /** Horizontal offset around {@link DEFAULT_START_X} (metres). */
+  x: 25,
+  /** Altitude offset around {@link DEFAULT_START_ALTITUDE} (metres). */
+  y: 20,
+  /** Horizontal-velocity offset around {@link DEFAULT_START_VX} (m/s). */
+  vx: 3,
+  /** Vertical-velocity offset around 0 (m/s). */
+  vy: 2,
+  /** Tilt offset around 0 (radians; ≈ ±14° at `m=1`). */
+  angle: 0.25,
+  /** Fuel offset around {@link DEFAULT_START_FUEL}. */
+  fuel: 20,
+  /** Pad-centre horizontal offset around 0 (metres). */
+  padX: 20,
+} as const;
+
+/** A complete starting condition: lander state plus its terrain. */
+export interface LanderScenario {
+  /** Starting state of the lander. */
+  state: LanderState;
+  /** Terrain the lander operates within (notably `padX`). */
+  terrain: LanderTerrain;
+}
+
+/**
+ * Sample a perturbed starting state from the wider scenario
+ * distribution. Used to evaluate a controller across a batch of varied
+ * initial conditions so robustness — not a single lucky launch — drives
+ * selection. Each component is sampled around the canonical
+ * {@link initialState} centre using independent uniform draws scaled by
+ * `magnitude`. The per-component half-ranges at `magnitude=1` come from
+ * {@link WIDE_RANGES}:
  *
- * Fuel and angular velocity are held fixed so every trial in a batch
- * starts with the same propellant budget.
+ *   - `x` ± `WIDE_RANGES.x * m` metres around `DEFAULT_START_X`
+ *   - `y` ± `WIDE_RANGES.y * m` metres around `DEFAULT_START_ALTITUDE`
+ *   - `vx` ± `WIDE_RANGES.vx * m` m/s around `DEFAULT_START_VX`
+ *   - `vy` ± `WIDE_RANGES.vy * m` m/s around 0
+ *   - `angle` ± `WIDE_RANGES.angle * m` radians around 0
+ *   - `fuel` ± `WIDE_RANGES.fuel * m` units around `DEFAULT_START_FUEL`
+ *
+ * Issue #195: the legacy distribution was much narrower (≈ ±5 m, ±0.5
+ * m/s, ±0.05 rad, fuel fixed). Widening forces the controller to learn
+ * a real recovery policy rather than memorise one trajectory. Note
+ * that `padX` does **not** vary here — use {@link perturbedScenario}
+ * if pad-centre variation is also required.
+ *
+ * The angular velocity is held fixed at 0 so every trial starts
+ * spinning-free.
  *
  * @param random Deterministic PRNG returning values in `[0, 1)`.
  * @param magnitude Scaling factor for the per-component perturbation.
@@ -175,14 +221,50 @@ export function perturbedInitialState(
 ): LanderState {
   const sample = (range: number) => (random() * 2 - 1) * range;
   return {
-    x: DEFAULT_START_X + sample(5 * magnitude),
-    y: DEFAULT_START_ALTITUDE + sample(5 * magnitude),
-    vx: DEFAULT_START_VX + sample(0.5 * magnitude),
-    vy: sample(0.5 * magnitude),
-    angle: sample(0.05 * magnitude),
+    x: DEFAULT_START_X + sample(WIDE_RANGES.x * magnitude),
+    y: DEFAULT_START_ALTITUDE + sample(WIDE_RANGES.y * magnitude),
+    vx: DEFAULT_START_VX + sample(WIDE_RANGES.vx * magnitude),
+    vy: sample(WIDE_RANGES.vy * magnitude),
+    angle: sample(WIDE_RANGES.angle * magnitude),
     angularV: 0,
-    fuel: DEFAULT_START_FUEL,
+    fuel: DEFAULT_START_FUEL + sample(WIDE_RANGES.fuel * magnitude),
   };
+}
+
+/**
+ * Sample a perturbed scenario — both starting state and terrain. The
+ * state components are drawn exactly as in {@link perturbedInitialState};
+ * additionally, the pad's horizontal centre `padX` is sampled uniformly
+ * on `[-WIDE_RANGES.padX * m, +WIDE_RANGES.padX * m]` while the rest of
+ * the terrain (ground level, pad half-width, world half-width) stays at
+ * {@link DEFAULT_TERRAIN}.
+ *
+ * Every drawn scenario classifies as `flying` at `t=0`: the altitude
+ * offset is bounded so `y > groundY`, and the horizontal offset plus
+ * `DEFAULT_START_X` keep `|x| < worldHalfWidth`.
+ *
+ * @param random Deterministic PRNG returning values in `[0, 1)`.
+ * @param magnitude Scaling factor for the per-component perturbation.
+ */
+export function perturbedScenario(
+  random: () => number,
+  magnitude: number = 1.0,
+): LanderScenario {
+  const sample = (range: number) => (random() * 2 - 1) * range;
+  const state: LanderState = {
+    x: DEFAULT_START_X + sample(WIDE_RANGES.x * magnitude),
+    y: DEFAULT_START_ALTITUDE + sample(WIDE_RANGES.y * magnitude),
+    vx: DEFAULT_START_VX + sample(WIDE_RANGES.vx * magnitude),
+    vy: sample(WIDE_RANGES.vy * magnitude),
+    angle: sample(WIDE_RANGES.angle * magnitude),
+    angularV: 0,
+    fuel: DEFAULT_START_FUEL + sample(WIDE_RANGES.fuel * magnitude),
+  };
+  const terrain: LanderTerrain = {
+    ...DEFAULT_TERRAIN,
+    padX: sample(WIDE_RANGES.padX * magnitude),
+  };
+  return { state, terrain };
 }
 
 /**

--- a/lunar_lander/physics_test.ts
+++ b/lunar_lander/physics_test.ts
@@ -22,10 +22,12 @@ import {
   type LanderState,
   NO_ACTION,
   perturbedInitialState,
+  perturbedScenario,
   SAFE_LANDING_ANGLE,
   SAFE_LANDING_VX_MAGNITUDE,
   SAFE_LANDING_VY_MAGNITUDE,
   step,
+  WIDE_RANGES,
 } from "./physics.ts";
 
 import { createDeterministicRandom } from "../common/deterministic_random.ts";
@@ -285,26 +287,59 @@ Deno.test("encodeState produces a 7-element Float32Array of [x, y, vx, vy, angle
   assertAlmostEquals(arr[6], 99, 1e-6);
 });
 
-Deno.test("perturbedInitialState centres on initialState", () => {
-  // Perturbations should be small relative to the canonical entry — at
-  // magnitude=1 the altitude varies by at most 5 m, vx by 0.5 m/s, and
-  // the angle by ~0.05 rad. Fuel and angularV are held fixed.
+Deno.test("perturbedInitialState centres on initialState within the widened ranges", () => {
+  // Issue #195: the perturbed-start distribution was widened so a
+  // champion cannot win by memorising a single trajectory. At
+  // magnitude=1 the per-component half-ranges are taken from
+  // WIDE_RANGES (x±25 m, y±20 m, vx±3 m/s, vy±2 m/s, angle±0.25 rad,
+  // fuel±20). Angular velocity is still held fixed at 0.
   const random = createDeterministicRandom(11);
   for (let i = 0; i < 100; i++) {
     const s = perturbedInitialState(random, 1.0);
-    assert(Math.abs(s.x - DEFAULT_START_X) <= 5);
-    assert(Math.abs(s.y - DEFAULT_START_ALTITUDE) <= 5);
-    assert(Math.abs(s.vx - DEFAULT_START_VX) <= 0.5);
-    assert(Math.abs(s.vy) <= 0.5);
-    assert(Math.abs(s.angle) <= 0.05);
+    assert(Math.abs(s.x - DEFAULT_START_X) <= WIDE_RANGES.x);
+    assert(Math.abs(s.y - DEFAULT_START_ALTITUDE) <= WIDE_RANGES.y);
+    assert(Math.abs(s.vx - DEFAULT_START_VX) <= WIDE_RANGES.vx);
+    assert(Math.abs(s.vy) <= WIDE_RANGES.vy);
+    assert(Math.abs(s.angle) <= WIDE_RANGES.angle);
     assertEquals(s.angularV, 0);
-    assertEquals(s.fuel, DEFAULT_START_FUEL);
+    assert(Math.abs(s.fuel - DEFAULT_START_FUEL) <= WIDE_RANGES.fuel);
   }
 });
 
 Deno.test("perturbedInitialState is deterministic for the same seed", () => {
   const a = perturbedInitialState(createDeterministicRandom(7), 1.0);
   const b = perturbedInitialState(createDeterministicRandom(7), 1.0);
+  assertEquals(a, b);
+});
+
+Deno.test("perturbedScenario varies padX within WIDE_RANGES.padX", () => {
+  const random = createDeterministicRandom(23);
+  let minPadX = Infinity;
+  let maxPadX = -Infinity;
+  for (let i = 0; i < 200; i++) {
+    const { state, terrain } = perturbedScenario(random, 1.0);
+    assert(Math.abs(terrain.padX) <= WIDE_RANGES.padX);
+    minPadX = Math.min(minPadX, terrain.padX);
+    maxPadX = Math.max(maxPadX, terrain.padX);
+    // The state still respects the same per-component bounds as
+    // perturbedInitialState.
+    assert(Math.abs(state.x - DEFAULT_START_X) <= WIDE_RANGES.x);
+    assert(state.y > DEFAULT_TERRAIN.groundY, `should start above ground (y=${state.y})`);
+    assert(
+      Math.abs(state.x) < DEFAULT_TERRAIN.worldHalfWidth,
+      `should start inside world (x=${state.x})`,
+    );
+  }
+  // Smoke-check that padX is actually swept rather than near-constant.
+  assert(
+    maxPadX - minPadX > WIDE_RANGES.padX,
+    `padX did not span its range: [${minPadX}, ${maxPadX}]`,
+  );
+});
+
+Deno.test("perturbedScenario is deterministic for the same seed", () => {
+  const a = perturbedScenario(createDeterministicRandom(3), 1.0);
+  const b = perturbedScenario(createDeterministicRandom(3), 1.0);
   assertEquals(a, b);
 });
 

--- a/lunar_lander/scenarios.ts
+++ b/lunar_lander/scenarios.ts
@@ -1,0 +1,135 @@
+/**
+ * Deterministic scenario sampler for the lunar-lander example.
+ *
+ * Issue #195: a champion that simply memorises a single trajectory must
+ * not pass evaluation. Two safeguards live here:
+ *
+ *   1. **Wider distribution** — every component (position, velocity,
+ *      tilt, fuel, and the pad's horizontal centre) is sampled around
+ *      the canonical entry across a substantially wider range than the
+ *      legacy {@link perturbedInitialState} sampler. See
+ *      {@link WIDE_RANGES} in `physics.ts`.
+ *   2. **Disjoint training and validation pools** — given a single base
+ *      seed, this module derives two non-overlapping pools of per-
+ *      scenario seeds. A controller that overfits training seeds cannot
+ *      see validation seeds during evolution, so its validation score
+ *      reflects generalisation rather than memorisation.
+ *
+ * The output is byte-deterministic for any fixed `(baseSeed, training,
+ * validation)` tuple.
+ */
+import { createDeterministicRandom } from "../common/deterministic_random.ts";
+import {
+  type LanderScenario,
+  type LanderState,
+  type LanderTerrain,
+  perturbedScenario,
+} from "./physics.ts";
+
+/** Default training-pool size. */
+export const DEFAULT_TRAINING_COUNT = 1000;
+
+/** Default validation-pool size. */
+export const DEFAULT_VALIDATION_COUNT = 200;
+
+/** A seeded scenario: starting state + terrain + the seed that produced them. */
+export interface SeededScenario {
+  /** The 32-bit seed used to draw this scenario. */
+  seed: number;
+  /** Initial lander state. */
+  state: LanderState;
+  /** Terrain (notably `padX`, which varies between scenarios). */
+  terrain: LanderTerrain;
+}
+
+/** Disjoint training/validation seed pools and their realised scenarios. */
+export interface ScenarioPools {
+  /** 32-bit seeds used for training scenarios. */
+  trainingSeeds: number[];
+  /** 32-bit seeds used for validation scenarios; disjoint from training. */
+  validationSeeds: number[];
+  /** Realised training scenarios, in seed order. */
+  training: SeededScenario[];
+  /** Realised validation scenarios, in seed order. */
+  validation: SeededScenario[];
+}
+
+/**
+ * Build disjoint training and validation seed pools and the matching
+ * lander scenarios. The procedure is deterministic: for any given
+ * `baseSeed`, the same `trainingCount` and `validationCount` produce
+ * byte-identical pools.
+ *
+ * Seeds are drawn from a splitmix32-style PRNG seeded by `baseSeed`,
+ * with a `Set` rejecting duplicates so the training and validation
+ * pools never share a seed.
+ *
+ * Each scenario is built by feeding its own seed into a fresh PRNG and
+ * passing that to {@link perturbedScenario}. Per-scenario isolation
+ * means a scenario's state does not depend on its position in the
+ * pool.
+ *
+ * @param baseSeed Master seed driving the seed-pool draw.
+ * @param trainingCount Number of training scenarios (default 1000).
+ * @param validationCount Number of validation scenarios (default 200).
+ * @param magnitude Scale factor passed to {@link perturbedScenario}.
+ */
+export function generateScenarioPools(
+  baseSeed: number,
+  trainingCount: number = DEFAULT_TRAINING_COUNT,
+  validationCount: number = DEFAULT_VALIDATION_COUNT,
+  magnitude: number = 1.0,
+): ScenarioPools {
+  if (!Number.isFinite(baseSeed)) {
+    throw new Error(`baseSeed must be finite, got ${baseSeed}`);
+  }
+  if (
+    !Number.isInteger(trainingCount) || trainingCount < 0 ||
+    !Number.isInteger(validationCount) || validationCount < 0
+  ) {
+    throw new Error(
+      `pool counts must be non-negative integers, got training=${trainingCount} validation=${validationCount}`,
+    );
+  }
+  if (!(magnitude > 0)) {
+    throw new Error(`magnitude must be positive, got ${magnitude}`);
+  }
+
+  const seedDraw = createDeterministicRandom(baseSeed);
+  const used = new Set<number>();
+  const drawSeed = (): number => {
+    // Reject duplicates so training and validation pools cannot share
+    // a seed. With a 32-bit PRNG and pool sizes of O(10^3) collisions
+    // are vanishingly rare, but the explicit check is a guarantee, not
+    // an optimisation.
+    let attempts = 0;
+    while (true) {
+      const r = Math.floor(seedDraw() * 0x1_0000_0000) >>> 0;
+      if (!used.has(r)) {
+        used.add(r);
+        return r;
+      }
+      if (++attempts > 1024) {
+        throw new Error("seed draw failed to find a unique 32-bit value");
+      }
+    }
+  };
+
+  const trainingSeeds: number[] = [];
+  for (let i = 0; i < trainingCount; i++) trainingSeeds.push(drawSeed());
+  const validationSeeds: number[] = [];
+  for (let i = 0; i < validationCount; i++) validationSeeds.push(drawSeed());
+
+  const buildScenario = (seed: number): SeededScenario => {
+    const random = createDeterministicRandom(seed);
+    const scenario: LanderScenario = perturbedScenario(random, magnitude);
+    return { seed, state: scenario.state, terrain: scenario.terrain };
+  };
+
+  return {
+    trainingSeeds,
+    validationSeeds,
+    training: trainingSeeds.map(buildScenario),
+    validation: validationSeeds.map(buildScenario),
+  };
+}

--- a/lunar_lander/scenarios_test.ts
+++ b/lunar_lander/scenarios_test.ts
@@ -1,0 +1,198 @@
+/**
+ * Tests for the lunar-lander scenario sampler. "What" tests only —
+ * each case calls the public API and asserts on observable outputs
+ * (seed-pool contents, scenario classifications, distribution span).
+ */
+
+import { assert, assertEquals, assertThrows } from "@std/assert";
+
+import {
+  classifyOutcome,
+  DEFAULT_START_ALTITUDE,
+  DEFAULT_START_FUEL,
+  DEFAULT_START_VX,
+  DEFAULT_START_X,
+  DEFAULT_TERRAIN,
+  WIDE_RANGES,
+} from "./physics.ts";
+
+import {
+  DEFAULT_TRAINING_COUNT,
+  DEFAULT_VALIDATION_COUNT,
+  generateScenarioPools,
+  type SeededScenario,
+} from "./scenarios.ts";
+
+Deno.test("generateScenarioPools produces the requested counts", () => {
+  const pools = generateScenarioPools(42, 50, 10);
+  assertEquals(pools.trainingSeeds.length, 50);
+  assertEquals(pools.validationSeeds.length, 10);
+  assertEquals(pools.training.length, 50);
+  assertEquals(pools.validation.length, 10);
+});
+
+Deno.test("generateScenarioPools default counts are 1000 / 200", () => {
+  // Avoid the heavy lift in unit tests but verify the constants the
+  // issue calls for so they cannot drift accidentally.
+  assertEquals(DEFAULT_TRAINING_COUNT, 1000);
+  assertEquals(DEFAULT_VALIDATION_COUNT, 200);
+});
+
+Deno.test("generateScenarioPools is deterministic for the same base seed", () => {
+  const a = generateScenarioPools(7, 100, 25);
+  const b = generateScenarioPools(7, 100, 25);
+  assertEquals(a.trainingSeeds, b.trainingSeeds);
+  assertEquals(a.validationSeeds, b.validationSeeds);
+  assertEquals(a.training, b.training);
+  assertEquals(a.validation, b.validation);
+});
+
+Deno.test("generateScenarioPools differs between distinct base seeds", () => {
+  const a = generateScenarioPools(1, 50, 20);
+  const b = generateScenarioPools(2, 50, 20);
+  // Sanity: the two seed pools should not be identical.
+  let differ = false;
+  for (let i = 0; i < a.trainingSeeds.length; i++) {
+    if (a.trainingSeeds[i] !== b.trainingSeeds[i]) {
+      differ = true;
+      break;
+    }
+  }
+  assert(differ, "different base seeds should produce different training seeds");
+});
+
+Deno.test("generateScenarioPools yields disjoint training and validation seed pools", () => {
+  const pools = generateScenarioPools(99, 500, 100);
+  const trainingSet = new Set(pools.trainingSeeds);
+  // Training seeds are themselves unique.
+  assertEquals(trainingSet.size, pools.trainingSeeds.length);
+  // Validation seeds are unique.
+  const validationSet = new Set(pools.validationSeeds);
+  assertEquals(validationSet.size, pools.validationSeeds.length);
+  // No seed appears in both pools.
+  for (const seed of pools.validationSeeds) {
+    assert(!trainingSet.has(seed), `validation seed ${seed} also appears in training pool`);
+  }
+});
+
+Deno.test("every generated scenario starts in a flying state", () => {
+  const pools = generateScenarioPools(123, 200, 50);
+  for (const scenario of [...pools.training, ...pools.validation]) {
+    const outcome = classifyOutcome(scenario.state, scenario.terrain);
+    assertEquals(
+      outcome,
+      "flying",
+      `seed=${scenario.seed} produced non-flying outcome ${outcome} (state=${
+        JSON.stringify(scenario.state)
+      })`,
+    );
+    // The classification is the headline assertion, but additionally
+    // confirm fuel is non-negative — an "impossible launch" with no
+    // propellant defeats the purpose of a varied scenario.
+    assert(scenario.state.fuel > 0, `seed=${scenario.seed} started with no fuel`);
+  }
+});
+
+Deno.test("scenario distribution actually spans the wider range", () => {
+  // Smoke-check: with a few hundred draws every component should reach
+  // close to its half-range on both sides. We require at least 60% of
+  // the configured half-range to ensure we are not collapsed near the
+  // centre.
+  const pools = generateScenarioPools(2026, 500, 100);
+  const all: SeededScenario[] = [...pools.training, ...pools.validation];
+
+  type Spread = { min: number; max: number };
+  const init = (): Spread => ({ min: Infinity, max: -Infinity });
+  const update = (s: Spread, value: number) => {
+    s.min = Math.min(s.min, value);
+    s.max = Math.max(s.max, value);
+  };
+
+  const xSpread = init();
+  const ySpread = init();
+  const vxSpread = init();
+  const vySpread = init();
+  const angleSpread = init();
+  const fuelSpread = init();
+  const padXSpread = init();
+
+  for (const sc of all) {
+    update(xSpread, sc.state.x);
+    update(ySpread, sc.state.y);
+    update(vxSpread, sc.state.vx);
+    update(vySpread, sc.state.vy);
+    update(angleSpread, sc.state.angle);
+    update(fuelSpread, sc.state.fuel);
+    update(padXSpread, sc.terrain.padX);
+  }
+
+  const requireSpan = (label: string, s: Spread, halfRange: number, centre: number) => {
+    const low = centre - halfRange;
+    const high = centre + halfRange;
+    // All draws stay inside the configured range.
+    assert(s.min >= low - 1e-9, `${label} min=${s.min} below configured low=${low}`);
+    assert(s.max <= high + 1e-9, `${label} max=${s.max} above configured high=${high}`);
+    // And the observed span covers a healthy fraction of the range —
+    // this is the "actually spans the wider range" smoke check.
+    const observedSpan = s.max - s.min;
+    const minSpan = 2 * halfRange * 0.6;
+    assert(
+      observedSpan >= minSpan,
+      `${label} span ${observedSpan.toFixed(3)} < ${minSpan.toFixed(3)} (range ±${halfRange})`,
+    );
+  };
+
+  requireSpan("x", xSpread, WIDE_RANGES.x, DEFAULT_START_X);
+  requireSpan("y", ySpread, WIDE_RANGES.y, DEFAULT_START_ALTITUDE);
+  requireSpan("vx", vxSpread, WIDE_RANGES.vx, DEFAULT_START_VX);
+  requireSpan("vy", vySpread, WIDE_RANGES.vy, 0);
+  requireSpan("angle", angleSpread, WIDE_RANGES.angle, 0);
+  requireSpan("fuel", fuelSpread, WIDE_RANGES.fuel, DEFAULT_START_FUEL);
+  requireSpan("padX", padXSpread, WIDE_RANGES.padX, 0);
+});
+
+Deno.test("each scenario's seed reproduces its state and terrain", () => {
+  // The pool's published seed is the contract — re-seeding from it
+  // must reconstruct the exact same scenario.
+  const pools = generateScenarioPools(555, 30, 5);
+  for (const scenario of pools.training) {
+    const reproduced = generateScenarioPools(555, 30, 5).training.find((s) =>
+      s.seed === scenario.seed
+    );
+    assertEquals(reproduced, scenario);
+  }
+});
+
+Deno.test("scenarios stay inside world bounds", () => {
+  const pools = generateScenarioPools(7777, 300, 60);
+  for (const sc of [...pools.training, ...pools.validation]) {
+    assert(
+      Math.abs(sc.state.x) < DEFAULT_TERRAIN.worldHalfWidth,
+      `seed=${sc.seed} state.x=${sc.state.x} outside world bounds`,
+    );
+    // Pad must remain inside the world too — otherwise scenarios are
+    // unreachable.
+    assert(
+      Math.abs(sc.terrain.padX) + sc.terrain.padHalfWidth <
+        DEFAULT_TERRAIN.worldHalfWidth,
+      `seed=${sc.seed} pad at padX=${sc.terrain.padX} extends past world bounds`,
+    );
+  }
+});
+
+Deno.test("generateScenarioPools rejects invalid arguments", () => {
+  assertThrows(() => generateScenarioPools(Number.NaN, 10, 5));
+  assertThrows(() => generateScenarioPools(0, -1, 5));
+  assertThrows(() => generateScenarioPools(0, 10, -5));
+  assertThrows(() => generateScenarioPools(0, 1.5, 5));
+  assertThrows(() => generateScenarioPools(0, 10, 5, 0));
+  assertThrows(() => generateScenarioPools(0, 10, 5, -1));
+});
+
+Deno.test("zero-count pools are allowed and disjoint by definition", () => {
+  const pools = generateScenarioPools(0, 0, 0);
+  assertEquals(pools.trainingSeeds.length, 0);
+  assertEquals(pools.validationSeeds.length, 0);
+  assertEquals(pools.training.length, 0);
+  assertEquals(pools.validation.length, 0);
+});


### PR DESCRIPTION
## Summary

Widens the lunar-lander start distribution and adds a deterministic
scenario sampler that emits **disjoint training and validation seed
pools**, so a champion that memorises a single trajectory cannot pass
validation. Closes #195.

- `lunar_lander/physics.ts`
  - New `WIDE_RANGES` constant documenting the per-component
    half-ranges at `magnitude=1`.
  - New `LanderScenario` type and `perturbedScenario(random, magnitude?)`
    sampler returning `{ state, terrain }` with `padX` varied.
  - `perturbedInitialState` is widened to the same per-component ranges
    (`x±25 m`, `y±20 m`, `vx±3 m/s`, `vy±2 m/s`, `angle±0.25 rad`,
    `fuel±20`); previously narrow ranges (`±5 m`, `±0.5 m/s`,
    `±0.05 rad`, fuel fixed) let a controller win by memorising a single
    trajectory.
- `lunar_lander/scenarios.ts` (new)
  - `generateScenarioPools(baseSeed, training=1000, validation=200, magnitude=1)`
    derives two disjoint 32-bit seed pools and realises each pool into
    `{ seed, state, terrain }` via `perturbedScenario`.
  - Deterministic for the same `(baseSeed, counts, magnitude)` tuple.
- `lunar_lander/scenarios_test.ts` (new) and updated
  `lunar_lander/physics_test.ts` cover deterministic seeds, disjoint
  pools, every scenario starting in `flying`, and the distribution
  actually spanning the wider range.
- `lunar_lander/README.md` documents the wider distribution and the
  train/validate pool split with a Mermaid diagram.

## Evidence

This is a backend module — there is no web interface to screenshot.
Verification is via unit tests:

```
deno test --allow-read --allow-write --allow-env \
  lunar_lander/physics_test.ts lunar_lander/scenarios_test.ts
ok | 36 passed | 0 failed
```

Plus `deno fmt --check`, `deno lint`, `deno check` and
`markdownlint-cli2 lunar_lander/README.md` — all clean.

```mermaid
flowchart LR
    SEED["base seed"] --> POOLS["seed-pool builder<br/>(32-bit, dedup)"]
    POOLS --> TRAIN["1000 training seeds"]
    POOLS --> VAL["200 validation seeds"]
    TRAIN --> SAMPLER["perturbedScenario<br/>(wider distribution)"]
    VAL --> SAMPLER
    SAMPLER --> SCENARIOS["LanderState + Terrain pairs"]
```

## Test Plan

New / updated tests in `lunar_lander/scenarios_test.ts` and
`lunar_lander/physics_test.ts`:

- `generateScenarioPools produces the requested counts`
- `generateScenarioPools default counts are 1000 / 200`
- `generateScenarioPools is deterministic for the same base seed`
- `generateScenarioPools differs between distinct base seeds`
- `generateScenarioPools yields disjoint training and validation seed pools`
- `every generated scenario starts in a flying state`
- `scenario distribution actually spans the wider range`
- `each scenario's seed reproduces its state and terrain`
- `scenarios stay inside world bounds`
- `generateScenarioPools rejects invalid arguments`
- `zero-count pools are allowed and disjoint by definition`
- `perturbedInitialState centres on initialState within the widened ranges`
  (existing test updated to assert against `WIDE_RANGES`; the legacy
  narrow ranges no longer apply — change is documented in the test
  body).
- `perturbedScenario varies padX within WIDE_RANGES.padX`
- `perturbedScenario is deterministic for the same seed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)