### PR TITLE
lunar_lander: replace generation cap with NEAT-AI targetError + timeoutMinutes stop conditions (Issue #196)

### DIFF
--- a/docs/pr-summary-196.md
+++ b/docs/pr-summary-196.md
@@ -1,0 +1,54 @@
+# lunar_lander: NEAT-AI standard `targetError` + `timeoutMinutes` stop conditions
+
+## Summary
+
+Replaces the lunar-lander evolver's `maxGenerations` hard cap and `SOLVED_LANDED_RATE = 0.6`
+threshold with the two standard fields from NEAT-AI's `NeatOptions`: `targetError` (default `0.01`,
+i.e. landed-rate ≥ 99%) and `timeoutMinutes` (default `2`). Whichever condition fires first wins.
+`EvolveResult` now reports `wallclockMs` and `stopReason: "target" | "timeout"` so callers can
+distinguish the two outcomes, and the CLI accepts `--target-error=N` / `--timeout-minutes=N`
+overrides. Closes #196.
+
+## Evidence
+
+This is a backend / CLI-only change — there is no UI to screenshot. Verified via:
+
+- `deno test lunar_lander/lunar_lander_test.ts` — all 32 tests pass, including two new tests that
+  exercise both stop reasons (`stops on timeout when targetError is unreachable`,
+  `stops on target
+  when targetError is generous`).
+- `deno lint lunar_lander/`, `deno fmt --check lunar_lander/`, `deno check **/*.ts` — clean.
+- Local CLI smoke test:
+  `deno run … lunar_lander/lunar_lander.ts --timeout-minutes=0.05
+  --target-error=-1` reported
+  `stop=timeout, wallclock=3.3s` with the new banner line announcing the configured stop conditions.
+
+```mermaid
+flowchart LR
+    EVAL["Score champion<br/>landed-rate"] --> TARGET{"landed-rate ≥<br/>1 − targetError?"}
+    TARGET -- "yes" --> STOPT["stopReason = target"]
+    TARGET -- "no" --> CLOCK{"elapsed ≥<br/>timeoutMinutes?"}
+    CLOCK -- "yes" --> STOPC["stopReason = timeout"]
+    CLOCK -- "no" --> NEXT["breed next generation"]
+    NEXT --> EVAL
+```
+
+## Test Plan
+
+- Added `evolveLanderController stops on timeout when targetError is unreachable` — sets
+  `targetError = -1` (landed-rate ≥ 2 is impossible) and `timeoutMinutes = 0.005` (~300 ms); asserts
+  `stopReason === "timeout"`, `solved === false`, `wallclockMs` finite, `generations` finite and >
+  0, and that `wallclockMs` is consistent with the observed elapsed time.
+- Added `evolveLanderController stops on target when targetError is generous` — sets
+  `targetError = 1` (landed-rate ≥ 0 trips at gen 0) with a generous `timeoutMinutes = 1`; asserts
+  `stopReason === "target"`, `solved === true`, finite `wallclockMs` and `generations > 0`.
+- Updated existing tests to drop `maxGenerations` and `SOLVED_LANDED_RATE` in favour of the new
+  option shape. The `noise on average` test now uses `1 - DEFAULT_EVOLVE_OPTIONS.targetError` (i.e.
+  the new 99% threshold) as the upper bound for gen-1 landed rate. The
+  `champion improves
+  over generations` and snapshot/neurons tests use a `snapshotConfig` to
+  deterministically pin the loop to a fixed number of generations after target trips immediately,
+  instead of relying on the removed generation cap.
+- README updated: the `Soft-Landing Threshold and Hard Generation Cap` section becomes
+  `NEAT-AI
+  Standard Stop Conditions` and documents the two new fields + CLI overrides.

--- a/lunar_lander/README.md
+++ b/lunar_lander/README.md
@@ -25,7 +25,7 @@ flowchart LR
     SCORE["📏 Multi-Trial Score<br/>landed / crashed / oob / flying"]
     SELECT["🏆 Truncation Selection<br/>top 50% are parents"]
     MUTATE["🧬 Weight + Bias + Add-Neuron"]
-    SOLVED{"landed-rate ≥ 60%?"}
+    SOLVED{"landed-rate ≥ 1−targetError?"}
     CHAMP["💾 Save champion.json"]
     RUN["▶️ Replay Champion<br/>record trajectory"]
     SVG["🖼️ docs/screenshots/<br/>lunar_lander.svg"]
@@ -36,8 +36,8 @@ flowchart LR
     SELECT --> MUTATE
     MUTATE --> SCORE
     SCORE --> SOLVED
-    SOLVED -- "no, gens < cap" --> SELECT
-    SOLVED -- "yes, or cap reached" --> CHAMP
+    SOLVED -- "no, time remaining" --> SELECT
+    SOLVED -- "yes, or timeout reached" --> CHAMP
     CHAMP --> RUN
     RUN --> SVG
 
@@ -52,16 +52,25 @@ flowchart LR
     style SVG fill:#50e3c2,stroke:#333,color:#fff
 ```
 
-## 🎯 Soft-Landing Threshold and Hard Generation Cap
+## 🎯 NEAT-AI Standard Stop Conditions
 
-Two stop conditions bound the search:
+Two stop conditions bound the search — the same two fields used across NEAT-AI's `NeatOptions`:
 
-- **Soft-landing threshold** — the champion must achieve a **landed-on-pad rate ≥ 60%**
-  (`SOLVED_LANDED_RATE = 0.6`) across a fixed deterministic batch of perturbed-start trials. Each
-  landed trial obeys the safe-landing limits (≤ 11.5° tilt, ≤ 2 m/s vertical and ≤ 2 m/s horizontal
-  speed at touchdown), so the threshold checks both pad accuracy _and_ gentleness, not just one.
-- **Hard generation cap** — `DEFAULT_EVOLVE_OPTIONS.maxGenerations = 1000`. The evolver always stops
-  at the cap even when the threshold is not reached, so the example terminates predictably.
+- **`targetError`** (default `0.01`) — the champion must achieve a **landed-on-pad rate ≥
+  `1 − targetError`** across a fixed deterministic batch of perturbed-start trials. The default
+  threshold is `landed-rate ≥ 99%`. Each landed trial obeys the safe-landing limits (≤ 11.5° tilt, ≤
+  2 m/s vertical and ≤ 2 m/s horizontal speed at touchdown), so the threshold checks both pad
+  accuracy _and_ gentleness, not just one.
+- **`timeoutMinutes`** (default `2`) — the evolver stops once `timeoutMinutes` minutes have elapsed
+  since the loop began, even when the target is not reached, so the example terminates predictably.
+
+Whichever condition fires first wins. The runner reports `result.stopReason` (`"target"` or
+`"timeout"`) and `result.wallclockMs` so callers can distinguish the two outcomes. The CLI runner
+accepts overrides:
+
+```bash
+./lunar_lander/run.sh --target-error=0.05 --timeout-minutes=5
+```
 
 Multi-trial scoring (`trials = 10`, `initialPerturbation = 1.0`) means a controller cannot win by
 getting lucky on a single canonical launch — it has to land robustly across a varied batch of
@@ -131,7 +140,7 @@ Artefacts:
 ![Lunar-Lander evolution chart — best score on the left axis with champion neuron and synapse counts on the right axis, plotted against generation](../docs/screenshots/lunar_lander/evolution.svg)
 
 The runner captures a snapshot of the **running champion** at the canonical checkpoint generations
-`[1, 10, 100, 500, 1000]` (those that fall inside the configured `maxGenerations`). The cadence is
+`[1, 10, 100, 500, 1000]` (those reached before the `timeoutMinutes` budget elapses). The cadence is
 wider than the previous fixed-topology demo because variable-topology evolution from uniform-random
 noise typically needs more generations to find structure.
 

--- a/lunar_lander/lunar_lander.ts
+++ b/lunar_lander/lunar_lander.ts
@@ -65,24 +65,6 @@ export const OUTPUT_COUNT = 3;
 /** Maximum number of timesteps a single episode is allowed to run. */
 export const MAX_STEPS = 400;
 
-/**
- * Landed-on-pad rate at or above which the controller is declared
- * "solved": at least 60% of the perturbed-start trial batch must end
- * with a `landed` outcome (touching down inside the pad, near-upright,
- * with vertical and horizontal speeds inside the safe-landing bounds).
- * The threshold is checked across a fixed deterministic batch of
- * perturbed initial states so a lucky single launch cannot pass it.
- *
- * Lunar-lander is a substantially harder control problem than
- * cart-pole — the controller has to coordinate three discrete
- * thrusters against gravity, drift, fuel limits, and a pad-relative
- * landing test — so a 60% bar within 1000 generations of evolution
- * from uniform-random noise is a practical demonstration of the
- * "noise → competent" story this example tells. (The `e.g. ≥ 80%`
- * suggestion in issue #153 was an example, not a hard requirement.)
- */
-export const SOLVED_LANDED_RATE = 0.6;
-
 /** Scoring constants — tuned so a fuel-rich, pad-centred landing scores >> 0
  *  while free fall crashes far below it. The "flying" timeout penalises
  *  altitude so an indefinite hover does not dominate the reward. */
@@ -108,8 +90,19 @@ export interface EvolveOptions {
   seed: number;
   /** Population size for each generation. */
   populationSize: number;
-  /** Hard cap on the number of generations before giving up. */
-  maxGenerations: number;
+  /**
+   * NEAT-AI standard target-error stop condition. Evolution halts as
+   * soon as the champion's landed rate on the training trial batch
+   * reaches `1 - targetError` (default `0.01`, i.e. landed-rate ≥ 99%).
+   */
+  targetError: number;
+  /**
+   * NEAT-AI standard wall-clock stop condition. Evolution halts when
+   * the elapsed time since the loop began exceeds `timeoutMinutes`
+   * minutes (default `2`). Whichever of `targetError` and
+   * `timeoutMinutes` fires first wins.
+   */
+  timeoutMinutes: number;
   /** Standard deviation of the weight/bias perturbation noise. */
   mutationStrength: number;
   /** Probability that any given gene is perturbed each generation. */
@@ -211,7 +204,10 @@ export interface EvolveResult {
   bestScore: number;
   /** Number of generations actually run before stopping. */
   generations: number;
-  /** True when the champion reached {@link SOLVED_LANDED_RATE}. */
+  /**
+   * True when the champion reached the configured target landed rate
+   * (`>= 1 - targetError`) at any point during the run.
+   */
   solved: boolean;
   /** Champion's measured landed rate across the perturbed-start batch. */
   landedRate: number;
@@ -219,16 +215,26 @@ export interface EvolveResult {
   championOutcome: LanderOutcome;
   /** Final-generation mean score (for sanity checks against baselines). */
   finalMeanScore: number;
+  /** Wall-clock duration of the evolution loop in milliseconds. */
+  wallclockMs: number;
+  /**
+   * Why the evolution loop terminated:
+   * - `"target"` — the champion reached `1 - targetError` landed rate.
+   * - `"timeout"` — `timeoutMinutes` elapsed before the target fired.
+   */
+  stopReason: "target" | "timeout";
 }
 
 /** Sensible defaults for the demonstration runner. */
 export const DEFAULT_EVOLVE_OPTIONS: EvolveOptions = {
   seed: 12345,
   populationSize: 80,
-  // Hard generation cap. Variable-topology evolution from uniform-
-  // random noise needs more generations to converge than the previous
-  // fixed-topology search did, so the budget is bigger than the old 60.
-  maxGenerations: 1000,
+  // NEAT-AI standard stop conditions: evolution halts as soon as the
+  // champion's landed-rate on the training trial batch reaches
+  // `1 - targetError` (default 99%) OR `timeoutMinutes` minutes have
+  // elapsed since the loop began — whichever fires first.
+  targetError: 0.01,
+  timeoutMinutes: 2,
   mutationStrength: 0.7,
   mutationRate: 0.5,
   addNeuronRate: 0.05,
@@ -551,10 +557,11 @@ function topologyCounts(json: CreatureExport): { neurons: number; synapses: numb
 /**
  * Run a generational evolutionary algorithm. Truncation selection keeps
  * the top half as parents; the elite carries over so the best score is
- * monotonically non-decreasing. Stops as soon as the champion's
- * landed rate reaches {@link SOLVED_LANDED_RATE} **or**
- * `maxGenerations` is exhausted (whichever comes first) — the **hard
- * generation cap** is the second guarantee.
+ * monotonically non-decreasing. Stops as soon as the champion's landed
+ * rate on the training trial batch reaches `1 - targetError` **or**
+ * `timeoutMinutes` minutes of wall-clock have elapsed — whichever
+ * fires first. The two stop conditions match the standard NEAT-AI
+ * `NeatOptions.targetError` / `NeatOptions.timeoutMinutes` fields.
  */
 export function evolveLanderController(
   options: EvolveOptions = DEFAULT_EVOLVE_OPTIONS,
@@ -597,7 +604,13 @@ export function evolveLanderController(
   let lastMeanScore = 0;
   let solvedAt = -1;
 
-  for (let generation = 0; generation < options.maxGenerations; generation++) {
+  const targetLandedRate = 1 - options.targetError;
+  const timeoutMs = options.timeoutMinutes * 60_000;
+  const loopStart = Date.now();
+  let stopReason: "target" | "timeout" = "timeout";
+  let generation = 0;
+
+  while (true) {
     population.sort((a, b) => b.score - a.score);
     const generationBest = population[0];
     if (generationBest.score > bestScore) {
@@ -628,22 +641,29 @@ export function evolveLanderController(
       }
     }
 
-    if (bestLandedRate >= SOLVED_LANDED_RATE) {
-      if (solvedAt < 0) solvedAt = generation;
+    const targetMet = bestLandedRate >= targetLandedRate;
+    if (targetMet && solvedAt < 0) solvedAt = generation;
+
+    const elapsedMs = Date.now() - loopStart;
+    const timedOut = elapsedMs >= timeoutMs;
+
+    if (targetMet) {
       // When capturing snapshots, keep running until the next
-      // not-yet-fired checkpoint within maxGenerations is captured —
-      // otherwise the progression strip would be a single panel.
-      if (options.snapshotConfig) {
-        const nextCheckpoint = options.snapshotConfig.checkpoints
-          .filter((c) => c > generation + 1 && c <= options.maxGenerations)
-          .sort((a, b) => a - b)[0];
-        if (nextCheckpoint === undefined) break;
-      } else {
+      // not-yet-fired checkpoint is captured — otherwise the
+      // progression strip would be a single panel.
+      const nextCheckpoint = options.snapshotConfig?.checkpoints
+        .filter((c) => c > generation + 1)
+        .sort((a, b) => a - b)[0];
+      if (nextCheckpoint === undefined) {
+        stopReason = "target";
         break;
       }
     }
 
-    if (generation === options.maxGenerations - 1) break;
+    if (timedOut) {
+      stopReason = solvedAt >= 0 ? "target" : "timeout";
+      break;
+    }
 
     const parentCount = Math.max(1, Math.floor(options.populationSize / 2));
     const parents = population.slice(0, parentCount);
@@ -672,17 +692,20 @@ export function evolveLanderController(
       });
     }
     population = next;
+    generation++;
   }
 
   const champion = Creature.fromJSON(bestJSON);
   return {
     champion,
     bestScore,
-    generations: solvedAt >= 0 ? solvedAt + 1 : options.maxGenerations,
-    solved: bestLandedRate >= SOLVED_LANDED_RATE,
+    generations: generation + 1,
+    solved: solvedAt >= 0,
     landedRate: bestLandedRate,
     championOutcome: bestOutcome,
     finalMeanScore: lastMeanScore,
+    wallclockMs: Date.now() - loopStart,
+    stopReason,
   };
 }
 
@@ -707,6 +730,21 @@ export const EVOLUTION_PROGRESS_SVG_PATH = "docs/screenshots/lunar_lander_evolut
 /** Path to the per-generation evolution-chart SVG the runner emits. */
 export const EVOLUTION_CHART_PATH = "docs/screenshots/lunar_lander/evolution.svg";
 
+/**
+ * Trivial `--name=value` CLI flag parser. Returns `undefined` when the
+ * flag is absent or its value is not a finite number.
+ */
+function parseNumericFlag(args: string[], name: string): number | undefined {
+  const prefix = `${name}=`;
+  for (const arg of args) {
+    if (arg.startsWith(prefix)) {
+      const v = parseFloat(arg.slice(prefix.length));
+      if (Number.isFinite(v)) return v;
+    }
+  }
+  return undefined;
+}
+
 if (import.meta.main) {
   const start = Date.now();
 
@@ -718,7 +756,18 @@ if (import.meta.main) {
   const baseline = freeFallBaselineScore();
   console.log(`🪂 Free-fall baseline score: ${baseline.toFixed(1)}`);
 
+  // CLI overrides for the NEAT-AI standard stop conditions.
+  const targetError = parseNumericFlag(Deno.args, "--target-error") ??
+    DEFAULT_EVOLVE_OPTIONS.targetError;
+  const timeoutMinutes = parseNumericFlag(Deno.args, "--timeout-minutes") ??
+    DEFAULT_EVOLVE_OPTIONS.timeoutMinutes;
+
   console.log("\n🧬 Evolving controller from uniform-random NEAT noise...");
+  console.log(
+    `   Stop conditions: targetError=${targetError} ` +
+      `(landed-rate ≥ ${((1 - targetError) * 100).toFixed(0)}%), ` +
+      `timeoutMinutes=${timeoutMinutes}`,
+  );
   ensureDirSync(SNAPSHOTS_DIR);
   for (const entry of Deno.readDirSync(SNAPSHOTS_DIR)) {
     if (entry.isFile) Deno.removeSync(join(SNAPSHOTS_DIR, entry.name));
@@ -727,6 +776,8 @@ if (import.meta.main) {
   const evolutionStart = Date.now();
   const result = evolveLanderController({
     ...DEFAULT_EVOLVE_OPTIONS,
+    targetError,
+    timeoutMinutes,
     snapshotConfig: {
       checkpoints: [...EVOLUTION_CHECKPOINTS],
       outputDir: SNAPSHOTS_DIR,
@@ -751,7 +802,8 @@ if (import.meta.main) {
       `generations (best=${result.bestScore.toFixed(1)}, landed=${
         (result.landedRate * 100).toFixed(0)
       }%, ` +
-      `threshold=${(SOLVED_LANDED_RATE * 100).toFixed(0)}%, baseline=${baseline.toFixed(1)}).`,
+      `threshold=${((1 - targetError) * 100).toFixed(0)}%, baseline=${baseline.toFixed(1)}, ` +
+      `stop=${result.stopReason}, wallclock=${(result.wallclockMs / 1000).toFixed(1)}s).`,
   );
 
   const championPath = join(creaturesDir, "champion.json");

--- a/lunar_lander/lunar_lander_test.ts
+++ b/lunar_lander/lunar_lander_test.ts
@@ -29,7 +29,6 @@ import {
   replayController,
   scoreController,
   scoreFinalState,
-  SOLVED_LANDED_RATE,
 } from "./lunar_lander.ts";
 import { renderRunSVG } from "./svg.ts";
 import { DEFAULT_TERRAIN, initialState, type LanderState } from "./physics.ts";
@@ -39,14 +38,20 @@ import { renderEvolutionProgressSvg } from "../common/evolution_progress_svg.ts"
 
 /**
  * A fast, deterministic configuration suitable for unit tests. The
- * mutation pressure is low and the budget tight so the loop never
- * accidentally solves the task; test cases that expect "solved"
- * results override these values.
+ * `targetError` is set generously so the loop trips the `target` stop
+ * condition immediately at gen 0 — both runs of the same options end
+ * after a single generation so reproducibility checks compare the
+ * same number of generations regardless of host speed. Tests that
+ * exercise multi-generation behaviour override these values.
  */
 const TEST_EVOLVE_OPTIONS = {
   seed: 42,
   populationSize: 12,
-  maxGenerations: 8,
+  // targetError = 1 means the threshold is `landed-rate ≥ 0`, which
+  // is satisfied at gen 0 — the loop terminates deterministically.
+  targetError: 1,
+  // Generous timeout so target always wins the race.
+  timeoutMinutes: 1,
   mutationStrength: 0.5,
   mutationRate: 0.4,
   addNeuronRate: 0,
@@ -222,7 +227,9 @@ Deno.test(
     let firstGenLanded = 1;
     evolveLanderController({
       ...DEFAULT_EVOLVE_OPTIONS,
-      maxGenerations: 1,
+      // Stop after the first generation: targetError=1 trips at gen 0.
+      targetError: 1,
+      timeoutMinutes: 1,
       populationSize: 30,
       onGeneration: (info) => {
         if (info.generation === 0 && firstGenMean === Infinity) {
@@ -235,24 +242,29 @@ Deno.test(
       firstGenMean < 0,
       `expected gen-1 population mean to be negative (mostly crashes), got ${firstGenMean}`,
     );
+    // The default targetError of 0.01 implies a "solved" threshold of
+    // landed-rate ≥ 0.99, so gen-1 noise should be far below it.
     assert(
-      firstGenLanded < SOLVED_LANDED_RATE,
-      `expected gen-1 best landed rate below the solved threshold (${SOLVED_LANDED_RATE}), got ${firstGenLanded}`,
+      firstGenLanded < 1 - DEFAULT_EVOLVE_OPTIONS.targetError,
+      `expected gen-1 best landed rate below the solved threshold ` +
+        `(${1 - DEFAULT_EVOLVE_OPTIONS.targetError}), got ${firstGenLanded}`,
     );
   },
 );
 
 Deno.test(
-  "evolveLanderController honours the hard generation cap",
+  "evolveLanderController stops on timeout when targetError is unreachable",
   () => {
-    // With vanishing mutation, the evolver cannot solve the task within
-    // the cap. The result must therefore stop at the cap and report
-    // `solved=false`.
-    const cap = 3;
+    // targetError=-1 means the threshold is `landed-rate ≥ 2`, which
+    // can never be met — the only way out is the wall-clock timeout.
+    const start = Date.now();
     const result = evolveLanderController({
       seed: 999,
       populationSize: 4,
-      maxGenerations: cap,
+      // Never satisfied: landed-rate is bounded by 1.
+      targetError: -1,
+      // ~300 ms of wall clock — short enough for a fast unit test.
+      timeoutMinutes: 0.005,
       mutationStrength: 0.001,
       mutationRate: 0.001,
       addNeuronRate: 0,
@@ -260,15 +272,48 @@ Deno.test(
       trialSeed: 1,
       initialPerturbation: 1.0,
     });
-    assertEquals(
-      result.generations,
-      cap,
-      `expected evolution to run to the hard cap of ${cap} generations, got ${result.generations}`,
+    const elapsed = Date.now() - start;
+    assertEquals(result.stopReason, "timeout");
+    assertEquals(result.solved, false);
+    assert(
+      Number.isFinite(result.wallclockMs),
+      `expected finite wallclockMs, got ${result.wallclockMs}`,
     );
-    assertEquals(
-      result.solved,
-      false,
-      "with vanishing mutation the search must not solve lunar-lander within the cap",
+    assert(
+      Number.isFinite(result.generations),
+      `expected finite generations, got ${result.generations}`,
+    );
+    assertGreater(result.generations, 0);
+    // The reported wall-clock duration must be consistent with the
+    // observed elapsed time (allowing slop for setup outside the loop).
+    assertGreaterOrEqual(elapsed + 50, result.wallclockMs);
+  },
+);
+
+Deno.test(
+  "evolveLanderController stops on target when targetError is generous",
+  () => {
+    // targetError=1 means the threshold is `landed-rate ≥ 0` — every
+    // population member meets that on gen 0, so target wins the race.
+    const result = evolveLanderController({
+      seed: 7,
+      populationSize: 6,
+      targetError: 1,
+      // Generous timeout so target trips first.
+      timeoutMinutes: 1,
+      mutationStrength: 0.001,
+      mutationRate: 0.001,
+      addNeuronRate: 0,
+      trials: 2,
+      trialSeed: 1,
+      initialPerturbation: 1.0,
+    });
+    assertEquals(result.stopReason, "target");
+    assertEquals(result.solved, true);
+    assertGreater(result.generations, 0);
+    assert(
+      Number.isFinite(result.wallclockMs),
+      `expected finite wallclockMs, got ${result.wallclockMs}`,
     );
   },
 );
@@ -285,23 +330,30 @@ Deno.test("evolveLanderController champion improves over generations", () => {
   // The champion's score must monotonically increase across the run
   // (truncation selection + elitism guarantees this) and the final
   // best must strictly exceed the gen-1 best, proving the search is
-  // making progress on the noisy start.
+  // making progress on the noisy start. The snapshotConfig is used as
+  // a `keep-running-after-target` mechanism so the loop runs across
+  // multiple generations after target trips at gen 0.
+  const tmp = Deno.makeTempDirSync({ prefix: "lunar_lander_improves_test_" });
   const events: GenerationInfo[] = [];
-  const result = evolveLanderController({
-    ...TEST_EVOLVE_OPTIONS,
-    populationSize: 30,
-    maxGenerations: 12,
-    onGeneration: (info) => events.push(info),
-  });
-  assert(events.length > 0, "expected at least one generation event");
-  // Champion score must be finite across the whole run.
-  for (const info of events) {
-    assert(Number.isFinite(info.bestScore), `expected finite best, got ${info.bestScore}`);
-    assert(Number.isFinite(info.meanScore), `expected finite mean, got ${info.meanScore}`);
+  try {
+    const result = evolveLanderController({
+      ...TEST_EVOLVE_OPTIONS,
+      populationSize: 30,
+      snapshotConfig: { checkpoints: [1, 5, 12], outputDir: tmp },
+      onGeneration: (info) => events.push(info),
+    });
+    assert(events.length > 0, "expected at least one generation event");
+    // Champion score must be finite across the whole run.
+    for (const info of events) {
+      assert(Number.isFinite(info.bestScore), `expected finite best, got ${info.bestScore}`);
+      assert(Number.isFinite(info.meanScore), `expected finite mean, got ${info.meanScore}`);
+    }
+    // Final best ≥ first best (elitism). The strict inequality is checked
+    // through `result.bestScore` aggregating the best across the run.
+    assertGreaterOrEqual(result.bestScore, events[0].bestScore);
+  } finally {
+    Deno.removeSync(tmp, { recursive: true });
   }
-  // Final best ≥ first best (elitism). The strict inequality is checked
-  // through `result.bestScore` aggregating the best across the run.
-  assertGreaterOrEqual(result.bestScore, events[0].bestScore);
 });
 
 Deno.test("champion JSON exports cleanly to disk", async () => {
@@ -521,12 +573,13 @@ Deno.test(
       const checkpoints = [1, 2, 3];
       evolveLanderController({
         ...TEST_EVOLVE_OPTIONS,
-        // Keep mutation pressure low so the loop does not solve early
-        // and break out before all configured snapshot checkpoints fire.
         mutationStrength: 0.01,
         mutationRate: 0.01,
-        maxGenerations: 4,
         populationSize: 6,
+        // The snapshot-capture branch keeps the loop running past the
+        // first not-yet-fired checkpoint even after target trips at
+        // gen 0, so all three checkpoints are captured before the
+        // loop stops.
         snapshotConfig: { checkpoints, outputDir: tmp },
       });
 
@@ -561,27 +614,35 @@ Deno.test(
     // synapse counts so the runner can plot them on the evolution
     // chart. With addNeuronRate=0 the topology stays at the library's
     // minimal seed throughout the run.
+    //
+    // The snapshot-checkpoint trick deterministically pins the run to
+    // exactly three generations: target trips at gen 0 (targetError=1),
+    // but the snapshot branch keeps the loop running until the last
+    // checkpoint at gen 3 has been captured.
+    const tmp = Deno.makeTempDirSync({ prefix: "lunar_lander_neurons_test_" });
     const events: GenerationInfo[] = [];
-    evolveLanderController({
-      ...TEST_EVOLVE_OPTIONS,
-      // Vanishing mutation keeps the search well away from the solved
-      // threshold so the early-stop branch cannot fire and skip events.
-      mutationStrength: 0.001,
-      mutationRate: 0.001,
-      maxGenerations: 3,
-      populationSize: 6,
-      onGeneration: (info) => events.push(info),
-    });
-    assertEquals(events.length, 3);
-    for (const info of events) {
-      assertEquals(typeof info.neurons, "number");
-      assertEquals(typeof info.synapses, "number");
-      assertGreater(info.neurons, 0);
-      assertGreater(info.synapses, 0);
-      // No structural mutation in this test, so the topology stays
-      // constant across generations.
-      assertEquals(info.neurons, events[0].neurons);
-      assertEquals(info.synapses, events[0].synapses);
+    try {
+      evolveLanderController({
+        ...TEST_EVOLVE_OPTIONS,
+        mutationStrength: 0.001,
+        mutationRate: 0.001,
+        populationSize: 6,
+        snapshotConfig: { checkpoints: [1, 2, 3], outputDir: tmp },
+        onGeneration: (info) => events.push(info),
+      });
+      assertEquals(events.length, 3);
+      for (const info of events) {
+        assertEquals(typeof info.neurons, "number");
+        assertEquals(typeof info.synapses, "number");
+        assertGreater(info.neurons, 0);
+        assertGreater(info.synapses, 0);
+        // No structural mutation in this test, so the topology stays
+        // constant across generations.
+        assertEquals(info.neurons, events[0].neurons);
+        assertEquals(info.synapses, events[0].synapses);
+      }
+    } finally {
+      Deno.removeSync(tmp, { recursive: true });
     }
   },
 );


### PR DESCRIPTION
# lunar_lander: NEAT-AI standard `targetError` + `timeoutMinutes` stop conditions

## Summary

Replaces the lunar-lander evolver's `maxGenerations` hard cap and `SOLVED_LANDED_RATE = 0.6`
threshold with the two standard fields from NEAT-AI's `NeatOptions`: `targetError` (default `0.01`,
i.e. landed-rate ≥ 99%) and `timeoutMinutes` (default `2`). Whichever condition fires first wins.
`EvolveResult` now reports `wallclockMs` and `stopReason: "target" | "timeout"` so callers can
distinguish the two outcomes, and the CLI accepts `--target-error=N` / `--timeout-minutes=N`
overrides. Closes #196.

## Evidence

This is a backend / CLI-only change — there is no UI to screenshot. Verified via:

- `deno test lunar_lander/lunar_lander_test.ts` — all 32 tests pass, including two new tests that
  exercise both stop reasons (`stops on timeout when targetError is unreachable`,
  `stops on target
  when targetError is generous`).
- `deno lint lunar_lander/`, `deno fmt --check lunar_lander/`, `deno check **/*.ts` — clean.
- Local CLI smoke test:
  `deno run … lunar_lander/lunar_lander.ts --timeout-minutes=0.05
  --target-error=-1` reported
  `stop=timeout, wallclock=3.3s` with the new banner line announcing the configured stop conditions.

```mermaid
flowchart LR
    EVAL["Score champion<br/>landed-rate"] --> TARGET{"landed-rate ≥<br/>1 − targetError?"}
    TARGET -- "yes" --> STOPT["stopReason = target"]
    TARGET -- "no" --> CLOCK{"elapsed ≥<br/>timeoutMinutes?"}
    CLOCK -- "yes" --> STOPC["stopReason = timeout"]
    CLOCK -- "no" --> NEXT["breed next generation"]
    NEXT --> EVAL
```

## Test Plan

- Added `evolveLanderController stops on timeout when targetError is unreachable` — sets
  `targetError = -1` (landed-rate ≥ 2 is impossible) and `timeoutMinutes = 0.005` (~300 ms); asserts
  `stopReason === "timeout"`, `solved === false`, `wallclockMs` finite, `generations` finite and >
  0, and that `wallclockMs` is consistent with the observed elapsed time.
- Added `evolveLanderController stops on target when targetError is generous` — sets
  `targetError = 1` (landed-rate ≥ 0 trips at gen 0) with a generous `timeoutMinutes = 1`; asserts
  `stopReason === "target"`, `solved === true`, finite `wallclockMs` and `generations > 0`.
- Updated existing tests to drop `maxGenerations` and `SOLVED_LANDED_RATE` in favour of the new
  option shape. The `noise on average` test now uses `1 - DEFAULT_EVOLVE_OPTIONS.targetError` (i.e.
  the new 99% threshold) as the upper bound for gen-1 landed rate. The
  `champion improves
  over generations` and snapshot/neurons tests use a `snapshotConfig` to
  deterministically pin the loop to a fixed number of generations after target trips immediately,
  instead of relying on the removed generation cap.
- README updated: the `Soft-Landing Threshold and Hard Generation Cap` section becomes
  `NEAT-AI
  Standard Stop Conditions` and documents the two new fields + CLI overrides.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-196 -->