### PR TITLE
lunar_lander: render per-validation-scenario landed-rate bar chart (Issue #200)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,6 +146,7 @@ reinventing equivalent logic in a new example.
 | `common/evolution_progress_svg.ts` | Multi-panel animated SVG strip rendered from snapshots.       |
 | `common/large_creature.ts`         | Deterministic large creatures (~10k synapses) for size demos. |
 | `common/episode_runner.ts`         | Shared per-episode rollout loop for agent examples.           |
+| `common/outcome_bar_chart.ts`      | Per-scenario outcome bar chart (count panel + cell strip).    |
 
 ### `common/data_cache.ts`
 
@@ -245,6 +246,8 @@ common/
   large_creature_test.ts           — Unit tests for the large creature builder
   episode_runner.ts                — Shared per-episode rollout loop for agent examples
   episode_runner_test.ts           — Unit tests for the episode runner helper
+  outcome_bar_chart.ts             — Per-scenario outcome bar chart (count panel + cell strip)
+  outcome_bar_chart_test.ts        — Unit tests for the outcome bar chart renderer
 
 crossover/
   crossover_example.ts             — Example: breed two creatures (crossover)

--- a/common/outcome_bar_chart.ts
+++ b/common/outcome_bar_chart.ts
@@ -1,0 +1,318 @@
+/**
+ * Per-validation-scenario outcome bar chart renderer.
+ *
+ * Visualises a champion's outcome across every validation scenario as a
+ * single SVG. The layout is the 2x2 split recommended in #200:
+ *
+ *   - **Left panel** — a four-bar count chart (`landed`, `crashed`,
+ *     `out_of_bounds`, `flying`). Reads the headline robustness number
+ *     at a glance.
+ *   - **Right panel** — a per-scenario strip with one coloured cell per
+ *     scenario, in pool order. Reading left-to-right surfaces individual
+ *     failures (a single red cell in a sea of green is obvious).
+ *
+ * Why both? The four-bar count is hopeless at 200 scenarios for spotting
+ * which specific seeds failed, and the 200-cell strip is hopeless for
+ * reading the "92% landed" headline. Stacking them in one SVG gives the
+ * reader both views without having to flip between charts.
+ *
+ * Output is byte-deterministic for identical input — no timestamps, no
+ * Math.random, no DOM. Pure string emission, matching the convention of
+ * {@link ./fitness_chart.ts} and {@link ./evolution_chart.ts}.
+ */
+
+/** Outcome categories supported by the renderer. */
+export type OutcomeCategory = "landed" | "crashed" | "out_of_bounds" | "flying";
+
+/** A single per-scenario outcome record. */
+export interface ScenarioOutcome {
+  /** Scenario index in pool order. Used purely for tooltip / aria text. */
+  scenarioIndex: number;
+  /** Final classification of the trial. */
+  outcome: OutcomeCategory;
+  /** Trial score under the example's scoring function. */
+  score: number;
+}
+
+/** Options controlling {@link renderOutcomeBarChartSVG}. */
+export interface RenderOutcomeBarChartOptions {
+  /** Total SVG width in user units. Default 800. */
+  width?: number;
+  /** Total SVG height in user units. Default 320. */
+  height?: number;
+  /** Chart title rendered at the top. Default "Validation Outcomes". */
+  title?: string;
+}
+
+/** Display order for the count panel — the canonical ordering used in JSDoc. */
+export const OUTCOME_ORDER: readonly OutcomeCategory[] = [
+  "landed",
+  "crashed",
+  "out_of_bounds",
+  "flying",
+] as const;
+
+/** Colour swatch per outcome — kept here so the count bars and strip cells agree. */
+export const OUTCOME_COLOUR: Readonly<Record<OutcomeCategory, string>> = {
+  landed: "#2ca02c",
+  crashed: "#d62728",
+  out_of_bounds: "#7f7f7f",
+  flying: "#1f77b4",
+};
+
+const DEFAULT_WIDTH = 800;
+const DEFAULT_HEIGHT = 320;
+
+/** Plot-area inset from the SVG edges, leaving room for axes and legend. */
+const MARGIN = { top: 50, right: 20, bottom: 60, left: 60 } as const;
+
+/**
+ * Render the per-scenario outcomes as an SVG string with a 2x2 layout
+ * (count bars on the left, per-scenario strip on the right).
+ *
+ * Throws if `outcomes` is empty — callers are expected to skip rendering
+ * when no scenarios have been validated.
+ */
+export function renderOutcomeBarChartSVG(
+  outcomes: readonly ScenarioOutcome[],
+  options: RenderOutcomeBarChartOptions = {},
+): string {
+  if (outcomes.length === 0) {
+    throw new Error("renderOutcomeBarChartSVG requires at least one outcome");
+  }
+
+  const width = options.width ?? DEFAULT_WIDTH;
+  const height = options.height ?? DEFAULT_HEIGHT;
+  const title = options.title ?? "Validation Outcomes";
+
+  const plotX = MARGIN.left;
+  const plotY = MARGIN.top;
+  const plotW = Math.max(1, width - MARGIN.left - MARGIN.right);
+  const plotH = Math.max(1, height - MARGIN.top - MARGIN.bottom);
+
+  // Split the plot area: the left panel is a small four-bar count chart;
+  // the right panel hosts the per-scenario strip. The 35/65 split keeps
+  // the headline counts readable while giving the strip plenty of room
+  // for 200 cells.
+  const leftW = Math.max(120, Math.floor(plotW * 0.35));
+  const stripX = plotX + leftW + 24;
+  const stripW = Math.max(60, plotX + plotW - stripX);
+
+  const counts = countOutcomes(outcomes);
+  const totalScenarios = outcomes.length;
+
+  const lines: string[] = [];
+  lines.push(
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ${height}" ` +
+      `width="${width}" height="${height}" role="img" ` +
+      `aria-label="${escapeAttr(title)} bar chart">`,
+    `  <title>${escapeText(title)}</title>`,
+    `  <rect width="${width}" height="${height}" fill="#fafafa"/>`,
+    `  <text x="${width / 2}" y="24" text-anchor="middle" ` +
+      `font-family="sans-serif" font-size="16" font-weight="bold" fill="#222">` +
+      escapeText(title) +
+      `</text>`,
+  );
+
+  lines.push(renderCountPanel(counts, totalScenarios, plotX, plotY, leftW, plotH));
+  lines.push(renderScenarioStrip(outcomes, stripX, plotY, stripW, plotH));
+  lines.push(renderLegend(plotX, plotY + plotH + 24, width - MARGIN.left - MARGIN.right));
+
+  lines.push(`</svg>`, "");
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Counts panel (left-hand four-bar chart)
+// ---------------------------------------------------------------------------
+
+interface OutcomeCounts {
+  landed: number;
+  crashed: number;
+  out_of_bounds: number;
+  flying: number;
+}
+
+function countOutcomes(outcomes: readonly ScenarioOutcome[]): OutcomeCounts {
+  const counts: OutcomeCounts = { landed: 0, crashed: 0, out_of_bounds: 0, flying: 0 };
+  for (const o of outcomes) counts[o.outcome] += 1;
+  return counts;
+}
+
+function renderCountPanel(
+  counts: OutcomeCounts,
+  total: number,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+): string {
+  // Domain max is the largest count; pad by 10% so the tallest bar does
+  // not touch the panel ceiling. Floor at 1 so a single non-zero count
+  // still produces a visible bar.
+  const domainMax = Math.max(1, ...OUTCOME_ORDER.map((c) => counts[c]));
+  const ceiling = domainMax * 1.1;
+
+  const out: string[] = [];
+  out.push(`  <g class="count-panel" font-family="sans-serif" font-size="11" fill="#333">`);
+  out.push(
+    `    <rect x="${fmt(x)}" y="${fmt(y)}" width="${fmt(w)}" height="${fmt(h)}" ` +
+      `fill="#ffffff" stroke="#333" stroke-width="1"/>`,
+  );
+
+  // Bars: equal-width slots across the panel with 20% padding either side.
+  const slotCount = OUTCOME_ORDER.length;
+  const slotW = w / slotCount;
+  const barW = slotW * 0.6;
+  for (let i = 0; i < slotCount; i++) {
+    const cat = OUTCOME_ORDER[i];
+    const count = counts[cat];
+    const barH = (count / ceiling) * h;
+    const barX = x + i * slotW + (slotW - barW) / 2;
+    const barY = y + h - barH;
+    out.push(
+      `    <rect class="count-bar count-bar-${cat}" x="${fmt(barX)}" y="${fmt(barY)}" ` +
+        `width="${fmt(barW)}" height="${fmt(barH)}" fill="${OUTCOME_COLOUR[cat]}"/>`,
+    );
+    // Count label above the bar.
+    out.push(
+      `    <text x="${fmt(barX + barW / 2)}" y="${fmt(barY - 4)}" text-anchor="middle" ` +
+        `font-weight="bold">${count}</text>`,
+    );
+    // Category label below the bar.
+    out.push(
+      `    <text x="${fmt(barX + barW / 2)}" y="${fmt(y + h + 16)}" text-anchor="middle">` +
+        escapeText(cat) +
+        `</text>`,
+    );
+  }
+
+  // Y axis: label on the left edge.
+  out.push(
+    `    <text x="${fmt(x - 10)}" y="${fmt(y + h / 2)}" text-anchor="middle" ` +
+      `dominant-baseline="middle" font-weight="bold" ` +
+      `transform="rotate(-90 ${fmt(x - 10)} ${fmt(y + h / 2)})">scenarios (${total})</text>`,
+  );
+
+  out.push(`  </g>`);
+  return out.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Per-scenario strip (right-hand cell grid)
+// ---------------------------------------------------------------------------
+
+function renderScenarioStrip(
+  outcomes: readonly ScenarioOutcome[],
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+): string {
+  const n = outcomes.length;
+  // Choose a roughly-square grid sized to fill the panel. With 200
+  // scenarios this gives ~14×15 cells — easy to scan visually.
+  const cols = Math.max(1, Math.ceil(Math.sqrt((n * w) / h)));
+  const rows = Math.max(1, Math.ceil(n / cols));
+  const cellW = w / cols;
+  const cellH = h / rows;
+  // Inset the cell rectangle slightly so adjacent cells do not bleed
+  // into each other once the SVG is rasterised.
+  const pad = Math.min(cellW, cellH) * 0.06;
+
+  const out: string[] = [];
+  out.push(`  <g class="scenario-strip" font-family="sans-serif" font-size="10" fill="#333">`);
+  out.push(
+    `    <rect x="${fmt(x)}" y="${fmt(y)}" width="${fmt(w)}" height="${fmt(h)}" ` +
+      `fill="#ffffff" stroke="#333" stroke-width="1"/>`,
+  );
+
+  for (let i = 0; i < n; i++) {
+    const o = outcomes[i];
+    const col = i % cols;
+    const row = Math.floor(i / cols);
+    const cx = x + col * cellW + pad;
+    const cy = y + row * cellH + pad;
+    out.push(
+      `    <rect class="scenario-cell scenario-cell-${o.outcome}" ` +
+        `x="${fmt(cx)}" y="${fmt(cy)}" width="${fmt(cellW - 2 * pad)}" ` +
+        `height="${fmt(cellH - 2 * pad)}" fill="${OUTCOME_COLOUR[o.outcome]}">` +
+        `<title>scenario ${o.scenarioIndex}: ${o.outcome} (score=${formatScore(o.score)})</title>` +
+        `</rect>`,
+    );
+  }
+
+  // Title above the strip noting the per-scenario layout.
+  out.push(
+    `    <text x="${fmt(x)}" y="${fmt(y - 8)}" text-anchor="start" ` +
+      `font-weight="bold">per-scenario outcome (n=${n})</text>`,
+  );
+
+  // Score range axis: min and max scores at the bottom corners so the
+  // reader can sanity-check the spread without a full numeric axis.
+  let minScore = Infinity;
+  let maxScore = -Infinity;
+  for (const o of outcomes) {
+    if (o.score < minScore) minScore = o.score;
+    if (o.score > maxScore) maxScore = o.score;
+  }
+  out.push(
+    `    <text class="score-axis-min" x="${fmt(x)}" y="${fmt(y + h + 16)}" ` +
+      `text-anchor="start">min score ${formatScore(minScore)}</text>`,
+  );
+  out.push(
+    `    <text class="score-axis-max" x="${fmt(x + w)}" y="${fmt(y + h + 16)}" ` +
+      `text-anchor="end">max score ${formatScore(maxScore)}</text>`,
+  );
+
+  out.push(`  </g>`);
+  return out.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Legend (shared between count bars and strip cells)
+// ---------------------------------------------------------------------------
+
+function renderLegend(x: number, y: number, w: number): string {
+  const itemW = w / OUTCOME_ORDER.length;
+  const out: string[] = [];
+  out.push(`  <g class="legend" font-family="sans-serif" font-size="11" fill="#222">`);
+  for (let i = 0; i < OUTCOME_ORDER.length; i++) {
+    const cat = OUTCOME_ORDER[i];
+    const itemX = x + i * itemW;
+    out.push(
+      `    <rect class="legend-swatch" x="${fmt(itemX)}" y="${fmt(y)}" width="14" height="12" ` +
+        `fill="${OUTCOME_COLOUR[cat]}"/>`,
+    );
+    out.push(
+      `    <text x="${fmt(itemX + 20)}" y="${fmt(y + 10)}">${escapeText(cat)}</text>`,
+    );
+  }
+  out.push(`  </g>`);
+  return out.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Number / text formatting
+// ---------------------------------------------------------------------------
+
+function fmt(v: number): string {
+  if (!Number.isFinite(v)) return "0";
+  return (Math.round(v * 100) / 100).toString();
+}
+
+function formatScore(v: number): string {
+  if (!Number.isFinite(v)) return "0";
+  return (Math.round(v * 1000) / 1000).toString();
+}
+
+function escapeText(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function escapeAttr(s: string): string {
+  return escapeText(s).replace(/"/g, "&quot;");
+}

--- a/common/outcome_bar_chart_test.ts
+++ b/common/outcome_bar_chart_test.ts
@@ -1,0 +1,125 @@
+/**
+ * Unit tests for the per-validation-scenario outcome bar chart renderer.
+ * "What" tests only — each test calls `renderOutcomeBarChartSVG` with
+ * known input and asserts on structural elements of the returned SVG
+ * string.
+ */
+
+import { assert, assertEquals, assertStringIncludes, assertThrows } from "@std/assert";
+
+import {
+  OUTCOME_ORDER,
+  renderOutcomeBarChartSVG,
+  type ScenarioOutcome,
+} from "./outcome_bar_chart.ts";
+
+function makeOutcomes(): ScenarioOutcome[] {
+  // A spread that exercises every outcome category at least once.
+  return [
+    { scenarioIndex: 0, outcome: "landed", score: 1000 },
+    { scenarioIndex: 1, outcome: "landed", score: 950 },
+    { scenarioIndex: 2, outcome: "crashed", score: -250 },
+    { scenarioIndex: 3, outcome: "out_of_bounds", score: -1500 },
+    { scenarioIndex: 4, outcome: "flying", score: -75 },
+    { scenarioIndex: 5, outcome: "landed", score: 880 },
+  ];
+}
+
+Deno.test("renderOutcomeBarChartSVG: empty input throws a clear error", () => {
+  assertThrows(
+    () => renderOutcomeBarChartSVG([]),
+    Error,
+    "at least one outcome",
+  );
+});
+
+Deno.test("renderOutcomeBarChartSVG: emits a well-formed <svg> root", () => {
+  const svg = renderOutcomeBarChartSVG(makeOutcomes());
+  assert(svg.startsWith("<svg"), "must start with <svg>");
+  assertStringIncludes(svg, "</svg>");
+  assertStringIncludes(svg, 'xmlns="http://www.w3.org/2000/svg"');
+  assertStringIncludes(svg, "viewBox=");
+});
+
+Deno.test("renderOutcomeBarChartSVG: every outcome category renders a bar", () => {
+  const svg = renderOutcomeBarChartSVG(makeOutcomes());
+  for (const cat of OUTCOME_ORDER) {
+    assertStringIncludes(svg, `count-bar-${cat}`);
+  }
+});
+
+Deno.test("renderOutcomeBarChartSVG: per-scenario strip renders one cell per scenario", () => {
+  const outcomes = makeOutcomes();
+  const svg = renderOutcomeBarChartSVG(outcomes);
+  const cellCount = (svg.match(/class="scenario-cell scenario-cell-/g) ?? []).length;
+  assertEquals(
+    cellCount,
+    outcomes.length,
+    `expected ${outcomes.length} cells, got ${cellCount}`,
+  );
+});
+
+Deno.test("renderOutcomeBarChartSVG: score range axis renders min and max", () => {
+  const svg = renderOutcomeBarChartSVG(makeOutcomes());
+  assertStringIncludes(svg, "score-axis-min");
+  assertStringIncludes(svg, "score-axis-max");
+  // The makeOutcomes() spread has min=-1500 and max=1000; both must appear.
+  assertStringIncludes(svg, "-1500");
+  assertStringIncludes(svg, "1000");
+});
+
+Deno.test("renderOutcomeBarChartSVG: count labels reflect input distribution", () => {
+  const svg = renderOutcomeBarChartSVG(makeOutcomes());
+  // 3 landed, 1 crashed, 1 out_of_bounds, 1 flying.
+  assertStringIncludes(svg, ">3<");
+  // Total should appear in the y-axis label.
+  assertStringIncludes(svg, "scenarios (6)");
+});
+
+Deno.test("renderOutcomeBarChartSVG: deterministic for identical input", () => {
+  const outcomes = makeOutcomes();
+  const a = renderOutcomeBarChartSVG(outcomes, { title: "Run", width: 800, height: 320 });
+  const b = renderOutcomeBarChartSVG(outcomes, { title: "Run", width: 800, height: 320 });
+  assertEquals(a, b);
+});
+
+Deno.test("renderOutcomeBarChartSVG: scales to 200 scenarios", () => {
+  const outcomes: ScenarioOutcome[] = [];
+  for (let i = 0; i < 200; i++) {
+    outcomes.push({
+      scenarioIndex: i,
+      outcome: i % 17 === 0 ? "crashed" : "landed",
+      score: i,
+    });
+  }
+  const svg = renderOutcomeBarChartSVG(outcomes);
+  const cellCount = (svg.match(/class="scenario-cell scenario-cell-/g) ?? []).length;
+  assertEquals(cellCount, 200);
+  assert(!svg.includes("NaN"), "SVG must not contain NaN");
+  assert(!svg.includes("Infinity"), "SVG must not contain Infinity");
+});
+
+Deno.test("renderOutcomeBarChartSVG: legend renders all four outcome labels", () => {
+  const svg = renderOutcomeBarChartSVG(makeOutcomes());
+  assertStringIncludes(svg, "legend");
+  for (const cat of OUTCOME_ORDER) {
+    assertStringIncludes(svg, cat);
+  }
+});
+
+Deno.test("renderOutcomeBarChartSVG: tooltips include scenario index and outcome", () => {
+  const outcomes: ScenarioOutcome[] = [
+    { scenarioIndex: 42, outcome: "landed", score: 1000 },
+  ];
+  const svg = renderOutcomeBarChartSVG(outcomes);
+  assertStringIncludes(svg, "<title>scenario 42: landed");
+});
+
+Deno.test("renderOutcomeBarChartSVG: single-outcome input does not produce NaN", () => {
+  const outcomes: ScenarioOutcome[] = [
+    { scenarioIndex: 0, outcome: "landed", score: 1000 },
+    { scenarioIndex: 1, outcome: "landed", score: 1000 },
+  ];
+  const svg = renderOutcomeBarChartSVG(outcomes);
+  assert(!svg.includes("NaN"), "SVG must not contain NaN");
+});

--- a/docs/archive_test.ts
+++ b/docs/archive_test.ts
@@ -113,6 +113,7 @@ Deno.test("No PR summary files remain in docs/ root", () => {
       if (entry.name === "pr-summary-196.md") continue;
       if (entry.name === "pr-summary-198.md") continue;
       if (entry.name === "pr-summary-199.md") continue;
+      if (entry.name === "pr-summary-200.md") continue;
       throw new Error(
         `Found unexpected PR summary file in docs/ root: ${entry.name}`,
       );

--- a/docs/pr-summary-200.md
+++ b/docs/pr-summary-200.md
@@ -1,0 +1,49 @@
+## Summary
+
+Added a per-validation-scenario outcome bar chart that visualises how robustly the lunar-lander
+champion generalises across all 200 unseen validation scenarios. Pairs with the fitness line chart
+from #199 — the line chart shows the journey, this chart shows where the champion stands at the end.
+Closes #200.
+
+The new shared renderer lives under `common/` so other agent examples can reuse it once
+`lunar_lander` proves the pattern. The layout is the 2x2 split recommended in the issue: a small
+four-bar count chart on the left (`landed` / `crashed` / `out_of_bounds` / `flying`) gives the
+headline "92% landed" number at a glance, while a per-scenario cell strip on the right shows every
+individual outcome — a single red cell in a sea of green is obvious.
+
+## Evidence
+
+```mermaid
+flowchart LR
+    A[validateChampion] --> B[results.json]
+    A --> C[ScenarioOutcome[]]
+    C --> D[renderOutcomeBarChartSVG]
+    D --> E[docs/screenshots/lunar_lander/validation.svg]
+```
+
+The runner now emits `docs/screenshots/lunar_lander/validation.svg` after the validation step writes
+`results.json`. Quick-mode CI runs continue to skip writing the canonical artefact, matching the
+existing behaviour of every other docs SVG the runner emits.
+
+Sample chart (rendered from a short demonstration run — a maintainer regenerates this from a full
+2-minute run when committing canonical artefacts):
+
+![Validation outcome chart](docs/screenshots/lunar_lander/validation.svg)
+
+## Test Plan
+
+- `common/outcome_bar_chart_test.ts` — 11 new "what" tests covering: empty-input rejection,
+  well-formed `<svg>` root, every outcome category renders a count bar, per-scenario cell count
+  matches input length, score-range axis renders min/max, count labels reflect the input
+  distribution, deterministic output for identical input, scales cleanly to 200 scenarios without
+  emitting `NaN` or `Infinity`, legend renders all four labels, tooltips include the scenario index
+  and outcome, and single-outcome input does not produce `NaN`.
+- `lunar_lander/lunar_lander_test.ts` — existing 47 tests still pass; no test was modified or
+  removed.
+- `deno lint`, `deno check **/*.ts`, and `deno fmt` are all clean against the new files.
+
+### Pre-existing failure (not introduced by this PR)
+
+`docs/archive_test.ts` continues to fail on `Develop` because `docs/pr-summary-231.md` is present in
+the `docs/` root but absent from the `archive_test.ts` allowlist. This failure pre-dates this branch
+and is out of scope for #200; tracking is left to #231's archival follow-up.

--- a/docs/screenshots/lunar_lander/validation.svg
+++ b/docs/screenshots/lunar_lander/validation.svg
@@ -1,0 +1,2087 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 800 320"
+  width="800"
+  height="320"
+  role="img"
+  aria-label="Lunar Lander — Validation Outcomes bar chart"
+>
+  <title>Lunar Lander — Validation Outcomes</title>
+  <rect width="800" height="320" fill="#fafafa" />
+  <text
+    x="400"
+    y="24"
+    text-anchor="middle"
+    font-family="sans-serif"
+    font-size="16"
+    font-weight="bold"
+    fill="#222"
+  >Lunar Lander — Validation Outcomes</text>
+  <g class="count-panel" font-family="sans-serif" font-size="11" fill="#333">
+    <rect x="60" y="50" width="251" height="210" fill="#ffffff" stroke="#333" stroke-width="1" />
+    <rect
+      class="count-bar count-bar-landed"
+      x="72.55"
+      y="257.63"
+      width="37.65"
+      height="2.37"
+      fill="#2ca02c"
+    />
+    <text x="91.38" y="253.63" text-anchor="middle" font-weight="bold">2</text>
+    <text x="91.38" y="276" text-anchor="middle">landed</text>
+    <rect
+      class="count-bar count-bar-crashed"
+      x="135.3"
+      y="69.09"
+      width="37.65"
+      height="190.91"
+      fill="#d62728"
+    />
+    <text x="154.13" y="65.09" text-anchor="middle" font-weight="bold">161</text>
+    <text x="154.13" y="276" text-anchor="middle">crashed</text>
+    <rect
+      class="count-bar count-bar-out_of_bounds"
+      x="198.05"
+      y="218.5"
+      width="37.65"
+      height="41.5"
+      fill="#7f7f7f"
+    />
+    <text x="216.88" y="214.5" text-anchor="middle" font-weight="bold">35</text>
+    <text x="216.88" y="276" text-anchor="middle">out_of_bounds</text>
+    <rect
+      class="count-bar count-bar-flying"
+      x="260.8"
+      y="257.63"
+      width="37.65"
+      height="2.37"
+      fill="#1f77b4"
+    />
+    <text x="279.63" y="253.63" text-anchor="middle" font-weight="bold">2</text>
+    <text x="279.63" y="276" text-anchor="middle">flying</text>
+    <text
+      x="50"
+      y="155"
+      text-anchor="middle"
+      dominant-baseline="middle"
+      font-weight="bold"
+      transform="rotate(-90 50 155)"
+    >scenarios (200)</text>
+  </g>
+  <g class="scenario-strip" font-family="sans-serif" font-size="10" fill="#333">
+    <rect x="335" y="50" width="445" height="210" fill="#ffffff" stroke="#333" stroke-width="1" />
+    <rect
+      class="scenario-cell scenario-cell-out_of_bounds"
+      x="336.26"
+      y="51.26"
+      width="18.67"
+      height="18.48"
+      fill="#7f7f7f"
+    >
+      <title>scenario 0: out_of_bounds (score=-1500)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-out_of_bounds"
+      x="357.45"
+      y="51.26"
+      width="18.67"
+      height="18.48"
+      fill="#7f7f7f"
+    >
+      <title>scenario 1: out_of_bounds (score=-1500)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-out_of_bounds"
+      x="378.64"
+      y="51.26"
+      width="18.67"
+      height="18.48"
+      fill="#7f7f7f"
+    >
+      <title>scenario 2: out_of_bounds (score=-1500)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-out_of_bounds"
+      x="399.83"
+      y="51.26"
+      width="18.67"
+      height="18.48"
+      fill="#7f7f7f"
+    >
+      <title>scenario 3: out_of_bounds (score=-1500)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="421.02"
+      y="51.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 4: crashed (score=-292.823)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="442.21"
+      y="51.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 5: crashed (score=-484.42)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="463.4"
+      y="51.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 6: crashed (score=-261.734)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="484.59"
+      y="51.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 7: crashed (score=-429.967)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="505.78"
+      y="51.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 8: crashed (score=-281.358)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-out_of_bounds"
+      x="526.97"
+      y="51.26"
+      width="18.67"
+      height="18.48"
+      fill="#7f7f7f"
+    >
+      <title>scenario 9: out_of_bounds (score=-1500)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="548.16"
+      y="51.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 10: crashed (score=-894.87)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="569.36"
+      y="51.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 11: crashed (score=-346.194)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="590.55"
+      y="51.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 12: crashed (score=-319.713)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="611.74"
+      y="51.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 13: crashed (score=-533.895)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="632.93"
+      y="51.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 14: crashed (score=-340.528)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="654.12"
+      y="51.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 15: crashed (score=-546.403)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="675.31"
+      y="51.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 16: crashed (score=-576.907)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="696.5"
+      y="51.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 17: crashed (score=-506.53)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-out_of_bounds"
+      x="717.69"
+      y="51.26"
+      width="18.67"
+      height="18.48"
+      fill="#7f7f7f"
+    >
+      <title>scenario 18: out_of_bounds (score=-1500)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="738.88"
+      y="51.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 19: crashed (score=-271.77)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="760.07"
+      y="51.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 20: crashed (score=-461.476)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="336.26"
+      y="72.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 21: crashed (score=-428.854)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="357.45"
+      y="72.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 22: crashed (score=-734.455)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="378.64"
+      y="72.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 23: crashed (score=-355.998)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="399.83"
+      y="72.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 24: crashed (score=-333.508)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="421.02"
+      y="72.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 25: crashed (score=-541.354)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="442.21"
+      y="72.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 26: crashed (score=-546.168)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="463.4"
+      y="72.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 27: crashed (score=-470.217)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="484.59"
+      y="72.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 28: crashed (score=-360.139)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="505.78"
+      y="72.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 29: crashed (score=-258.587)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="526.97"
+      y="72.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 30: crashed (score=-402.29)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="548.16"
+      y="72.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 31: crashed (score=-678.848)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="569.36"
+      y="72.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 32: crashed (score=-605.991)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="590.55"
+      y="72.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 33: crashed (score=-219.932)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="611.74"
+      y="72.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 34: crashed (score=-421.956)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-out_of_bounds"
+      x="632.93"
+      y="72.26"
+      width="18.67"
+      height="18.48"
+      fill="#7f7f7f"
+    >
+      <title>scenario 35: out_of_bounds (score=-1500)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="654.12"
+      y="72.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 36: crashed (score=-411.396)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-out_of_bounds"
+      x="675.31"
+      y="72.26"
+      width="18.67"
+      height="18.48"
+      fill="#7f7f7f"
+    >
+      <title>scenario 37: out_of_bounds (score=-1500)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="696.5"
+      y="72.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 38: crashed (score=-607.289)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="717.69"
+      y="72.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 39: crashed (score=-522.979)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="738.88"
+      y="72.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 40: crashed (score=-423.074)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-out_of_bounds"
+      x="760.07"
+      y="72.26"
+      width="18.67"
+      height="18.48"
+      fill="#7f7f7f"
+    >
+      <title>scenario 41: out_of_bounds (score=-1500)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="336.26"
+      y="93.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 42: crashed (score=-439.943)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-out_of_bounds"
+      x="357.45"
+      y="93.26"
+      width="18.67"
+      height="18.48"
+      fill="#7f7f7f"
+    >
+      <title>scenario 43: out_of_bounds (score=-1500)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="378.64"
+      y="93.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 44: crashed (score=-413.713)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="399.83"
+      y="93.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 45: crashed (score=-283.59)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="421.02"
+      y="93.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 46: crashed (score=-598.773)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="442.21"
+      y="93.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 47: crashed (score=-770.856)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="463.4"
+      y="93.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 48: crashed (score=-299.697)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="484.59"
+      y="93.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 49: crashed (score=-323.535)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="505.78"
+      y="93.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 50: crashed (score=-331.592)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="526.97"
+      y="93.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 51: crashed (score=-493.691)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="548.16"
+      y="93.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 52: crashed (score=-363.334)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="569.36"
+      y="93.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 53: crashed (score=-336.492)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="590.55"
+      y="93.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 54: crashed (score=-343.285)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-out_of_bounds"
+      x="611.74"
+      y="93.26"
+      width="18.67"
+      height="18.48"
+      fill="#7f7f7f"
+    >
+      <title>scenario 55: out_of_bounds (score=-1500)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-out_of_bounds"
+      x="632.93"
+      y="93.26"
+      width="18.67"
+      height="18.48"
+      fill="#7f7f7f"
+    >
+      <title>scenario 56: out_of_bounds (score=-1500)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-out_of_bounds"
+      x="654.12"
+      y="93.26"
+      width="18.67"
+      height="18.48"
+      fill="#7f7f7f"
+    >
+      <title>scenario 57: out_of_bounds (score=-1500)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="675.31"
+      y="93.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 58: crashed (score=-601.183)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="696.5"
+      y="93.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 59: crashed (score=-361.465)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-out_of_bounds"
+      x="717.69"
+      y="93.26"
+      width="18.67"
+      height="18.48"
+      fill="#7f7f7f"
+    >
+      <title>scenario 60: out_of_bounds (score=-1500)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="738.88"
+      y="93.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 61: crashed (score=-373.114)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="760.07"
+      y="93.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 62: crashed (score=-447.22)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="336.26"
+      y="114.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 63: crashed (score=-598.581)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="357.45"
+      y="114.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 64: crashed (score=-490.856)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="378.64"
+      y="114.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 65: crashed (score=-390.313)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-out_of_bounds"
+      x="399.83"
+      y="114.26"
+      width="18.67"
+      height="18.48"
+      fill="#7f7f7f"
+    >
+      <title>scenario 66: out_of_bounds (score=-1500)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="421.02"
+      y="114.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 67: crashed (score=-265.684)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="442.21"
+      y="114.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 68: crashed (score=-517.663)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="463.4"
+      y="114.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 69: crashed (score=-269.783)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-out_of_bounds"
+      x="484.59"
+      y="114.26"
+      width="18.67"
+      height="18.48"
+      fill="#7f7f7f"
+    >
+      <title>scenario 70: out_of_bounds (score=-1500)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="505.78"
+      y="114.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 71: crashed (score=-633.686)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="526.97"
+      y="114.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 72: crashed (score=-852.083)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="548.16"
+      y="114.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 73: crashed (score=-655.223)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-out_of_bounds"
+      x="569.36"
+      y="114.26"
+      width="18.67"
+      height="18.48"
+      fill="#7f7f7f"
+    >
+      <title>scenario 74: out_of_bounds (score=-1500)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="590.55"
+      y="114.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 75: crashed (score=-275.497)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-landed"
+      x="611.74"
+      y="114.26"
+      width="18.67"
+      height="18.48"
+      fill="#2ca02c"
+    >
+      <title>scenario 76: landed (score=1419.622)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="632.93"
+      y="114.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 77: crashed (score=-313.407)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="654.12"
+      y="114.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 78: crashed (score=-359.096)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="675.31"
+      y="114.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 79: crashed (score=-275.693)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="696.5"
+      y="114.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 80: crashed (score=-529.831)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="717.69"
+      y="114.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 81: crashed (score=-706.524)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="738.88"
+      y="114.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 82: crashed (score=-255.007)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-out_of_bounds"
+      x="760.07"
+      y="114.26"
+      width="18.67"
+      height="18.48"
+      fill="#7f7f7f"
+    >
+      <title>scenario 83: out_of_bounds (score=-1500)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="336.26"
+      y="135.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 84: crashed (score=-862.718)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="357.45"
+      y="135.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 85: crashed (score=-498.53)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="378.64"
+      y="135.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 86: crashed (score=-764.899)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-out_of_bounds"
+      x="399.83"
+      y="135.26"
+      width="18.67"
+      height="18.48"
+      fill="#7f7f7f"
+    >
+      <title>scenario 87: out_of_bounds (score=-1500)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="421.02"
+      y="135.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 88: crashed (score=-410.657)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="442.21"
+      y="135.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 89: crashed (score=-391.685)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="463.4"
+      y="135.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 90: crashed (score=-334.704)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-out_of_bounds"
+      x="484.59"
+      y="135.26"
+      width="18.67"
+      height="18.48"
+      fill="#7f7f7f"
+    >
+      <title>scenario 91: out_of_bounds (score=-1500)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="505.78"
+      y="135.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 92: crashed (score=-342.454)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="526.97"
+      y="135.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 93: crashed (score=-589.442)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="548.16"
+      y="135.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 94: crashed (score=-640.007)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="569.36"
+      y="135.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 95: crashed (score=-337.751)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="590.55"
+      y="135.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 96: crashed (score=-390.775)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="611.74"
+      y="135.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 97: crashed (score=-593.135)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-out_of_bounds"
+      x="632.93"
+      y="135.26"
+      width="18.67"
+      height="18.48"
+      fill="#7f7f7f"
+    >
+      <title>scenario 98: out_of_bounds (score=-1500)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="654.12"
+      y="135.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 99: crashed (score=-237.389)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="675.31"
+      y="135.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 100: crashed (score=-382.086)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="696.5"
+      y="135.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 101: crashed (score=-422.945)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-out_of_bounds"
+      x="717.69"
+      y="135.26"
+      width="18.67"
+      height="18.48"
+      fill="#7f7f7f"
+    >
+      <title>scenario 102: out_of_bounds (score=-1500)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="738.88"
+      y="135.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 103: crashed (score=-538.697)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-out_of_bounds"
+      x="760.07"
+      y="135.26"
+      width="18.67"
+      height="18.48"
+      fill="#7f7f7f"
+    >
+      <title>scenario 104: out_of_bounds (score=-1500)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="336.26"
+      y="156.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 105: crashed (score=-623.69)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="357.45"
+      y="156.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 106: crashed (score=-798.368)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="378.64"
+      y="156.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 107: crashed (score=-664.456)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-out_of_bounds"
+      x="399.83"
+      y="156.26"
+      width="18.67"
+      height="18.48"
+      fill="#7f7f7f"
+    >
+      <title>scenario 108: out_of_bounds (score=-1500)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="421.02"
+      y="156.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 109: crashed (score=-311.886)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="442.21"
+      y="156.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 110: crashed (score=-606.99)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="463.4"
+      y="156.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 111: crashed (score=-537.298)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="484.59"
+      y="156.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 112: crashed (score=-394.249)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="505.78"
+      y="156.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 113: crashed (score=-545.82)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="526.97"
+      y="156.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 114: crashed (score=-746.973)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="548.16"
+      y="156.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 115: crashed (score=-311.719)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="569.36"
+      y="156.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 116: crashed (score=-264.353)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="590.55"
+      y="156.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 117: crashed (score=-585.315)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="611.74"
+      y="156.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 118: crashed (score=-432.297)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-landed"
+      x="632.93"
+      y="156.26"
+      width="18.67"
+      height="18.48"
+      fill="#2ca02c"
+    >
+      <title>scenario 119: landed (score=1350.666)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="654.12"
+      y="156.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 120: crashed (score=-660.049)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-out_of_bounds"
+      x="675.31"
+      y="156.26"
+      width="18.67"
+      height="18.48"
+      fill="#7f7f7f"
+    >
+      <title>scenario 121: out_of_bounds (score=-1500)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="696.5"
+      y="156.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 122: crashed (score=-240.926)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="717.69"
+      y="156.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 123: crashed (score=-666.062)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="738.88"
+      y="156.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 124: crashed (score=-402.187)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="760.07"
+      y="156.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 125: crashed (score=-313.491)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-out_of_bounds"
+      x="336.26"
+      y="177.26"
+      width="18.67"
+      height="18.48"
+      fill="#7f7f7f"
+    >
+      <title>scenario 126: out_of_bounds (score=-1500)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="357.45"
+      y="177.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 127: crashed (score=-371.459)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="378.64"
+      y="177.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 128: crashed (score=-309.459)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-out_of_bounds"
+      x="399.83"
+      y="177.26"
+      width="18.67"
+      height="18.48"
+      fill="#7f7f7f"
+    >
+      <title>scenario 129: out_of_bounds (score=-1500)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="421.02"
+      y="177.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 130: crashed (score=-298.147)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="442.21"
+      y="177.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 131: crashed (score=-304.851)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="463.4"
+      y="177.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 132: crashed (score=-331.32)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="484.59"
+      y="177.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 133: crashed (score=-616.029)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="505.78"
+      y="177.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 134: crashed (score=-525.075)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="526.97"
+      y="177.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 135: crashed (score=-256.78)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-out_of_bounds"
+      x="548.16"
+      y="177.26"
+      width="18.67"
+      height="18.48"
+      fill="#7f7f7f"
+    >
+      <title>scenario 136: out_of_bounds (score=-1500)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="569.36"
+      y="177.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 137: crashed (score=-318.447)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="590.55"
+      y="177.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 138: crashed (score=-253.747)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="611.74"
+      y="177.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 139: crashed (score=-394.987)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-out_of_bounds"
+      x="632.93"
+      y="177.26"
+      width="18.67"
+      height="18.48"
+      fill="#7f7f7f"
+    >
+      <title>scenario 140: out_of_bounds (score=-1500)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="654.12"
+      y="177.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 141: crashed (score=-265.837)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="675.31"
+      y="177.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 142: crashed (score=-826.528)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="696.5"
+      y="177.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 143: crashed (score=-441.338)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="717.69"
+      y="177.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 144: crashed (score=-277.033)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="738.88"
+      y="177.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 145: crashed (score=-273.416)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-flying"
+      x="760.07"
+      y="177.26"
+      width="18.67"
+      height="18.48"
+      fill="#1f77b4"
+    >
+      <title>scenario 146: flying (score=-132.309)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="336.26"
+      y="198.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 147: crashed (score=-474.036)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-out_of_bounds"
+      x="357.45"
+      y="198.26"
+      width="18.67"
+      height="18.48"
+      fill="#7f7f7f"
+    >
+      <title>scenario 148: out_of_bounds (score=-1500)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="378.64"
+      y="198.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 149: crashed (score=-524.183)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="399.83"
+      y="198.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 150: crashed (score=-846.478)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="421.02"
+      y="198.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 151: crashed (score=-542.06)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="442.21"
+      y="198.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 152: crashed (score=-466.007)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="463.4"
+      y="198.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 153: crashed (score=-921.186)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="484.59"
+      y="198.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 154: crashed (score=-307.668)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="505.78"
+      y="198.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 155: crashed (score=-501.735)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="526.97"
+      y="198.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 156: crashed (score=-363.542)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="548.16"
+      y="198.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 157: crashed (score=-419.245)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="569.36"
+      y="198.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 158: crashed (score=-429.742)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="590.55"
+      y="198.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 159: crashed (score=-289.371)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-flying"
+      x="611.74"
+      y="198.26"
+      width="18.67"
+      height="18.48"
+      fill="#1f77b4"
+    >
+      <title>scenario 160: flying (score=-181.817)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="632.93"
+      y="198.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 161: crashed (score=-338.88)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="654.12"
+      y="198.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 162: crashed (score=-594.31)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="675.31"
+      y="198.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 163: crashed (score=-424.533)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="696.5"
+      y="198.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 164: crashed (score=-765.218)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="717.69"
+      y="198.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 165: crashed (score=-464.911)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="738.88"
+      y="198.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 166: crashed (score=-302.553)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="760.07"
+      y="198.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 167: crashed (score=-595.409)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="336.26"
+      y="219.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 168: crashed (score=-427.046)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="357.45"
+      y="219.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 169: crashed (score=-381.489)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="378.64"
+      y="219.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 170: crashed (score=-401.41)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="399.83"
+      y="219.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 171: crashed (score=-421.062)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="421.02"
+      y="219.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 172: crashed (score=-629.18)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-out_of_bounds"
+      x="442.21"
+      y="219.26"
+      width="18.67"
+      height="18.48"
+      fill="#7f7f7f"
+    >
+      <title>scenario 173: out_of_bounds (score=-1500)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="463.4"
+      y="219.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 174: crashed (score=-336.104)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="484.59"
+      y="219.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 175: crashed (score=-323.544)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="505.78"
+      y="219.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 176: crashed (score=-749.805)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-out_of_bounds"
+      x="526.97"
+      y="219.26"
+      width="18.67"
+      height="18.48"
+      fill="#7f7f7f"
+    >
+      <title>scenario 177: out_of_bounds (score=-1500)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="548.16"
+      y="219.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 178: crashed (score=-331.212)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="569.36"
+      y="219.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 179: crashed (score=-272.67)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="590.55"
+      y="219.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 180: crashed (score=-287.891)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="611.74"
+      y="219.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 181: crashed (score=-257.852)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="632.93"
+      y="219.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 182: crashed (score=-468.32)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="654.12"
+      y="219.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 183: crashed (score=-318.5)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="675.31"
+      y="219.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 184: crashed (score=-337.886)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="696.5"
+      y="219.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 185: crashed (score=-355.058)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="717.69"
+      y="219.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 186: crashed (score=-311.509)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-out_of_bounds"
+      x="738.88"
+      y="219.26"
+      width="18.67"
+      height="18.48"
+      fill="#7f7f7f"
+    >
+      <title>scenario 187: out_of_bounds (score=-1500)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="760.07"
+      y="219.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 188: crashed (score=-476.114)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="336.26"
+      y="240.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 189: crashed (score=-296.404)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="357.45"
+      y="240.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 190: crashed (score=-242.544)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="378.64"
+      y="240.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 191: crashed (score=-668.9)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-out_of_bounds"
+      x="399.83"
+      y="240.26"
+      width="18.67"
+      height="18.48"
+      fill="#7f7f7f"
+    >
+      <title>scenario 192: out_of_bounds (score=-1500)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="421.02"
+      y="240.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 193: crashed (score=-602.145)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="442.21"
+      y="240.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 194: crashed (score=-576.502)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-out_of_bounds"
+      x="463.4"
+      y="240.26"
+      width="18.67"
+      height="18.48"
+      fill="#7f7f7f"
+    >
+      <title>scenario 195: out_of_bounds (score=-1500)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="484.59"
+      y="240.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 196: crashed (score=-519.528)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="505.78"
+      y="240.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 197: crashed (score=-510.09)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="526.97"
+      y="240.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 198: crashed (score=-339.954)</title>
+    </rect>
+    <rect
+      class="scenario-cell scenario-cell-crashed"
+      x="548.16"
+      y="240.26"
+      width="18.67"
+      height="18.48"
+      fill="#d62728"
+    >
+      <title>scenario 199: crashed (score=-604.945)</title>
+    </rect>
+    <text x="335" y="42" text-anchor="start" font-weight="bold">per-scenario outcome (n=200)</text>
+    <text class="score-axis-min" x="335" y="276" text-anchor="start">min score -1500</text>
+    <text class="score-axis-max" x="780" y="276" text-anchor="end">max score 1419.622</text>
+  </g>
+  <g class="legend" font-family="sans-serif" font-size="11" fill="#222">
+    <rect class="legend-swatch" x="60" y="284" width="14" height="12" fill="#2ca02c" />
+    <text x="80" y="294">landed</text>
+    <rect class="legend-swatch" x="240" y="284" width="14" height="12" fill="#d62728" />
+    <text x="260" y="294">crashed</text>
+    <rect class="legend-swatch" x="420" y="284" width="14" height="12" fill="#7f7f7f" />
+    <text x="440" y="294">out_of_bounds</text>
+    <rect class="legend-swatch" x="600" y="284" width="14" height="12" fill="#1f77b4" />
+    <text x="620" y="294">flying</text>
+  </g>
+</svg>

--- a/lunar_lander/lunar_lander.ts
+++ b/lunar_lander/lunar_lander.ts
@@ -42,6 +42,7 @@ import {
 import { renderEvolutionProgressSvg } from "../common/evolution_progress_svg.ts";
 import { type EvolutionSample, renderEvolutionChartSVG } from "../common/evolution_chart.ts";
 import { type FitnessSample, renderFitnessChartSVG } from "../common/fitness_chart.ts";
+import { renderOutcomeBarChartSVG, type ScenarioOutcome } from "../common/outcome_bar_chart.ts";
 import {
   classifyOutcome,
   DEFAULT_PARAMS,
@@ -872,6 +873,13 @@ export const EVOLUTION_CHART_PATH = "docs/screenshots/lunar_lander/evolution.svg
 /** Path to the per-generation fitness-chart SVG the runner emits. */
 export const FITNESS_CHART_PATH = "docs/screenshots/lunar_lander/fitness.svg";
 
+/**
+ * Path to the per-validation-scenario outcome bar chart SVG the runner
+ * emits. Pairs with the descent screenshot and fitness chart to give
+ * readers a one-glance view of how robustly the controller generalises.
+ */
+export const VALIDATION_OUTCOME_SVG_PATH = "docs/screenshots/lunar_lander/validation.svg";
+
 /** Path to the per-generation evolution telemetry CSV the runner emits. */
 export const EVOLUTION_CSV_PATH = "docs/data/lunar_lander/evolution.csv";
 
@@ -1106,6 +1114,29 @@ if (import.meta.main) {
     );
   } else {
     console.log("⏭️  Quick mode: skipped writing validation JSON");
+  }
+
+  // Render the per-validation-scenario outcome bar chart from the same
+  // report. Lives next to the fitness chart so the README can show the
+  // controller's journey (fitness chart) alongside its end-state spread
+  // across all 200 unseen scenarios (this chart).
+  const outcomeSamples: ScenarioOutcome[] = validationReport.scenarios.map((s) => ({
+    scenarioIndex: s.index,
+    outcome: s.outcome,
+    score: s.score,
+  }));
+  if (outcomeSamples.length > 0) {
+    const outcomeSvg = renderOutcomeBarChartSVG(outcomeSamples, {
+      title: "Lunar Lander — Validation Outcomes",
+    });
+    if (!quick) {
+      ensureDirSync("docs/screenshots/lunar_lander");
+      await Deno.writeTextFile(VALIDATION_OUTCOME_SVG_PATH, outcomeSvg);
+      console.log(
+        `📊 Wrote validation outcome chart ${VALIDATION_OUTCOME_SVG_PATH} ` +
+          `(${outcomeSamples.length} scenarios)`,
+      );
+    }
   }
 
   // Render the descent SVG from a representative validation scenario —

--- a/lunar_lander/run.sh
+++ b/lunar_lander/run.sh
@@ -48,6 +48,9 @@ fi
 if [[ -f "docs/screenshots/lunar_lander/fitness.svg" ]]; then
   deno fmt docs/screenshots/lunar_lander/fitness.svg > /dev/null
 fi
+if [[ -f "docs/screenshots/lunar_lander/validation.svg" ]]; then
+  deno fmt docs/screenshots/lunar_lander/validation.svg > /dev/null
+fi
 if [[ -f "docs/data/lunar_lander/evolution.csv" ]]; then
   deno fmt docs/data/lunar_lander/evolution.csv > /dev/null 2>&1 || true
 fi


### PR DESCRIPTION
## Summary

Added a per-validation-scenario outcome bar chart that visualises how robustly the lunar-lander
champion generalises across all 200 unseen validation scenarios. Pairs with the fitness line chart
from #199 — the line chart shows the journey, this chart shows where the champion stands at the end.
Closes #200.

The new shared renderer lives under `common/` so other agent examples can reuse it once
`lunar_lander` proves the pattern. The layout is the 2x2 split recommended in the issue: a small
four-bar count chart on the left (`landed` / `crashed` / `out_of_bounds` / `flying`) gives the
headline "92% landed" number at a glance, while a per-scenario cell strip on the right shows every
individual outcome — a single red cell in a sea of green is obvious.

## Evidence

```mermaid
flowchart LR
    A[validateChampion] --> B[results.json]
    A --> C[ScenarioOutcome[]]
    C --> D[renderOutcomeBarChartSVG]
    D --> E[docs/screenshots/lunar_lander/validation.svg]
```

The runner now emits `docs/screenshots/lunar_lander/validation.svg` after the validation step writes
`results.json`. Quick-mode CI runs continue to skip writing the canonical artefact, matching the
existing behaviour of every other docs SVG the runner emits.

Sample chart (rendered from a short demonstration run — a maintainer regenerates this from a full
2-minute run when committing canonical artefacts):

![Validation outcome chart](docs/screenshots/lunar_lander/validation.svg)

## Test Plan

- `common/outcome_bar_chart_test.ts` — 11 new "what" tests covering: empty-input rejection,
  well-formed `<svg>` root, every outcome category renders a count bar, per-scenario cell count
  matches input length, score-range axis renders min/max, count labels reflect the input
  distribution, deterministic output for identical input, scales cleanly to 200 scenarios without
  emitting `NaN` or `Infinity`, legend renders all four labels, tooltips include the scenario index
  and outcome, and single-outcome input does not produce `NaN`.
- `lunar_lander/lunar_lander_test.ts` — existing 47 tests still pass; no test was modified or
  removed.
- `deno lint`, `deno check **/*.ts`, and `deno fmt` are all clean against the new files.

### Pre-existing failure (not introduced by this PR)

`docs/archive_test.ts` continues to fail on `Develop` because `docs/pr-summary-231.md` is present in
the `docs/` root but absent from the `archive_test.ts` allowlist. This failure pre-dates this branch
and is out of scope for #200; tracking is left to #231's archival follow-up.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-200 -->