### PR TITLE
common: add evolveDir return-value summary chart helper (#284)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,6 +231,8 @@ common/
   outcome_bar_chart_test.ts        — Unit tests for the outcome bar chart renderer
   milestone_chart.ts               — Dual-axis SVG renderer for evolveRL() milestone statistics
   milestone_chart_test.ts          — Unit tests for the milestone chart renderer
+  evolve_dir_summary.ts            — SVG summary chart for evolveDir() return values
+  evolve_dir_summary_test.ts       — Unit tests for the evolveDir summary renderer
 
 crossover/
   crossover_example.ts             — Example: breed two creatures (crossover)

--- a/common/evolve_dir_summary.ts
+++ b/common/evolve_dir_summary.ts
@@ -1,0 +1,402 @@
+/**
+ * Shared SVG summary chart for the return value of `Creature.evolveDir`.
+ *
+ * `Creature.evolveDir` resolves with `{ error, score, time, generation }`
+ * after the run terminates (either because `targetError` was reached or
+ * the `timeoutMinutes` budget expired). Combined with the seed and final
+ * creature's topology (neurons / synapses counts captured by the caller),
+ * that is enough to summarise the whole run at a glance.
+ *
+ * This module renders a deterministic, dependency-free SVG with:
+ *
+ *   - A "before vs after" topology bar pair (seed vs final, for both
+ *     neurons and synapses).
+ *   - Numeric callouts for `finalError`, `finalScore`, `generations` and
+ *     a human-friendly `wallClockMs` duration.
+ *   - An optional caption quoting the configured `targetError` and
+ *     `timeoutMinutes` stop conditions.
+ *
+ * Output is byte-identical for identical inputs — no timestamps, no
+ * random IDs, no DOM. Pure string emission, matching the convention of
+ * the other helpers in `common/`.
+ */
+
+/** Statistics captured around a single `Creature.evolveDir` run. */
+export interface EvolveDirSummary {
+  /** Final error returned by `evolveDir` (the `error` field). */
+  finalError: number;
+  /** Final score returned by `evolveDir` (the `score` field). */
+  finalScore: number;
+  /** Wall-clock duration in milliseconds (sourced from the returned `time`). */
+  wallClockMs: number;
+  /** Generations completed (the returned `generation`). */
+  generations: number;
+  /** Neuron count of the starting creature, captured before `evolveDir`. */
+  seedNeurons: number;
+  /** Synapse count of the starting creature, captured before `evolveDir`. */
+  seedSynapses: number;
+  /** Neuron count of the final creature, read after `evolveDir` resolves. */
+  finalNeurons: number;
+  /** Synapse count of the final creature, read after `evolveDir` resolves. */
+  finalSynapses: number;
+  /** Configured target error threshold, if any (caption only). */
+  targetError?: number;
+  /** Configured timeout in minutes, if any (caption only). */
+  timeoutMinutes?: number;
+}
+
+/** Options controlling {@link renderEvolveDirSummarySvg}. */
+export interface RenderEvolveDirSummaryOptions {
+  /** Total SVG width in user units. Default 720. */
+  width?: number;
+  /** Total SVG height in user units. Default 360. */
+  height?: number;
+  /** Chart title rendered at the top. Default "evolveDir Run Summary". */
+  title?: string;
+}
+
+const DEFAULT_WIDTH = 720;
+const DEFAULT_HEIGHT = 360;
+
+/** Plot-area inset from the SVG edges, leaving room for the title and caption. */
+const MARGIN = { top: 48, right: 24, bottom: 56, left: 24 } as const;
+
+/** Bar colour for the seed (before) topology. */
+const SEED_COLOUR = "#9ecae1";
+/** Bar colour for the final (after) topology. */
+const FINAL_COLOUR = "#1f77b4";
+/** Accent colour for numeric callouts. */
+const CALLOUT_COLOUR = "#2ca02c";
+
+/** Numeric fields that must be finite — checked before any rendering. */
+const REQUIRED_NUMERIC_FIELDS: ReadonlyArray<keyof EvolveDirSummary> = [
+  "finalError",
+  "finalScore",
+  "wallClockMs",
+  "generations",
+  "seedNeurons",
+  "seedSynapses",
+  "finalNeurons",
+  "finalSynapses",
+];
+
+/** Optional numeric fields — validated only when provided. */
+const OPTIONAL_NUMERIC_FIELDS: ReadonlyArray<keyof EvolveDirSummary> = [
+  "targetError",
+  "timeoutMinutes",
+];
+
+/**
+ * Render a deterministic SVG summary of an `evolveDir` run.
+ *
+ * Throws if any required numeric field is non-finite (`NaN` or `±Infinity`),
+ * or if an optional field is supplied but non-finite. The error message
+ * names the offending field so callers can fix the upstream capture.
+ */
+export function renderEvolveDirSummarySvg(
+  summary: EvolveDirSummary,
+  options: RenderEvolveDirSummaryOptions = {},
+): string {
+  validateSummary(summary);
+
+  const width = options.width ?? DEFAULT_WIDTH;
+  const height = options.height ?? DEFAULT_HEIGHT;
+  const title = options.title ?? "evolveDir Run Summary";
+
+  const plotX = MARGIN.left;
+  const plotY = MARGIN.top;
+  const plotW = Math.max(1, width - MARGIN.left - MARGIN.right);
+  const plotH = Math.max(1, height - MARGIN.top - MARGIN.bottom);
+
+  // 55/45 split: topology bars on the left, numeric callouts on the right.
+  const topoW = Math.max(160, Math.floor(plotW * 0.55));
+  const calloutX = plotX + topoW + 16;
+  const calloutW = Math.max(120, plotX + plotW - calloutX);
+
+  const lines: string[] = [];
+  lines.push(
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ${height}" ` +
+      `width="${width}" height="${height}" role="img" ` +
+      `aria-label="${escapeAttr(title)} summary chart">`,
+    `  <title>${escapeText(title)}</title>`,
+    `  <rect width="${width}" height="${height}" fill="#fafafa"/>`,
+    `  <text x="${fmt(width / 2)}" y="24" text-anchor="middle" ` +
+      `font-family="sans-serif" font-size="16" font-weight="bold" fill="#222">` +
+      escapeText(title) +
+      `</text>`,
+  );
+
+  lines.push(renderTopologyPanel(summary, plotX, plotY, topoW, plotH));
+  lines.push(renderCalloutPanel(summary, calloutX, plotY, calloutW, plotH));
+
+  if (summary.targetError !== undefined || summary.timeoutMinutes !== undefined) {
+    lines.push(renderCaption(summary, width, height));
+  }
+
+  lines.push(`</svg>`, "");
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+function validateSummary(summary: EvolveDirSummary): void {
+  for (const field of REQUIRED_NUMERIC_FIELDS) {
+    const value = summary[field] as number;
+    if (!Number.isFinite(value)) {
+      throw new Error(
+        `EvolveDirSummary.${field} must be a finite number, got ${String(value)}`,
+      );
+    }
+  }
+  for (const field of OPTIONAL_NUMERIC_FIELDS) {
+    const value = summary[field];
+    if (value !== undefined && !Number.isFinite(value as number)) {
+      throw new Error(
+        `EvolveDirSummary.${field} must be a finite number when provided, got ${String(value)}`,
+      );
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Topology panel — before / after bars for neurons and synapses
+// ---------------------------------------------------------------------------
+
+function renderTopologyPanel(
+  summary: EvolveDirSummary,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+): string {
+  const out: string[] = [];
+  out.push(`  <g class="topology" font-family="sans-serif" font-size="11" fill="#333">`);
+  out.push(
+    `    <rect x="${fmt(x)}" y="${fmt(y)}" width="${fmt(w)}" height="${fmt(h)}" ` +
+      `fill="#ffffff" stroke="#333" stroke-width="1"/>`,
+  );
+
+  // Panel heading.
+  out.push(
+    `    <text x="${fmt(x + 10)}" y="${fmt(y + 16)}" font-weight="bold">topology</text>`,
+  );
+
+  // Two groups side by side: neurons (left) and synapses (right). Each
+  // group has a seed bar and a final bar with a count label above and a
+  // group label below.
+  const groupW = w / 2;
+  drawTopologyGroup(
+    out,
+    x,
+    y + 24,
+    groupW,
+    h - 36,
+    "neurons",
+    summary.seedNeurons,
+    summary.finalNeurons,
+  );
+  drawTopologyGroup(
+    out,
+    x + groupW,
+    y + 24,
+    groupW,
+    h - 36,
+    "synapses",
+    summary.seedSynapses,
+    summary.finalSynapses,
+  );
+
+  out.push(`  </g>`);
+  return out.join("\n");
+}
+
+function drawTopologyGroup(
+  out: string[],
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  label: string,
+  seed: number,
+  final: number,
+): void {
+  // Reserve a strip at the bottom for labels.
+  const labelStripH = 22;
+  const barAreaH = Math.max(1, h - labelStripH);
+  const ceiling = Math.max(1, seed, final) * 1.1;
+
+  // Two bars: seed (left) and final (right), with padding either side.
+  const slotW = w / 2;
+  const barW = slotW * 0.5;
+
+  const seedBarH = (seed / ceiling) * barAreaH;
+  const seedBarX = x + (slotW - barW) / 2;
+  const seedBarY = y + barAreaH - seedBarH;
+  out.push(
+    `    <rect class="topo-bar topo-bar-seed-${label}" ` +
+      `x="${fmt(seedBarX)}" y="${fmt(seedBarY)}" width="${fmt(barW)}" height="${fmt(seedBarH)}" ` +
+      `fill="${SEED_COLOUR}"/>`,
+  );
+  out.push(
+    `    <text x="${fmt(seedBarX + barW / 2)}" y="${fmt(seedBarY - 4)}" text-anchor="middle" ` +
+      `font-weight="bold">${seed}</text>`,
+  );
+  out.push(
+    `    <text x="${fmt(seedBarX + barW / 2)}" y="${
+      fmt(y + barAreaH + 12)
+    }" text-anchor="middle">` +
+      `seed</text>`,
+  );
+
+  const finalBarH = (final / ceiling) * barAreaH;
+  const finalBarX = x + slotW + (slotW - barW) / 2;
+  const finalBarY = y + barAreaH - finalBarH;
+  out.push(
+    `    <rect class="topo-bar topo-bar-final-${label}" ` +
+      `x="${fmt(finalBarX)}" y="${fmt(finalBarY)}" width="${fmt(barW)}" height="${
+        fmt(finalBarH)
+      }" ` +
+      `fill="${FINAL_COLOUR}"/>`,
+  );
+  out.push(
+    `    <text x="${fmt(finalBarX + barW / 2)}" y="${fmt(finalBarY - 4)}" text-anchor="middle" ` +
+      `font-weight="bold">${final}</text>`,
+  );
+  out.push(
+    `    <text x="${fmt(finalBarX + barW / 2)}" y="${
+      fmt(y + barAreaH + 12)
+    }" text-anchor="middle">` +
+      `final</text>`,
+  );
+
+  // Group label centred below the pair.
+  out.push(
+    `    <text x="${fmt(x + w / 2)}" y="${fmt(y + barAreaH + 22)}" text-anchor="middle" ` +
+      `font-weight="bold">${escapeText(label)}</text>`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Numeric-callout panel — finalError, finalScore, generations, wallClock
+// ---------------------------------------------------------------------------
+
+function renderCalloutPanel(
+  summary: EvolveDirSummary,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+): string {
+  const out: string[] = [];
+  out.push(`  <g class="callouts" font-family="sans-serif" font-size="11" fill="#333">`);
+  out.push(
+    `    <rect x="${fmt(x)}" y="${fmt(y)}" width="${fmt(w)}" height="${fmt(h)}" ` +
+      `fill="#ffffff" stroke="#333" stroke-width="1"/>`,
+  );
+
+  out.push(
+    `    <text x="${fmt(x + 10)}" y="${fmt(y + 16)}" font-weight="bold">summary</text>`,
+  );
+
+  // Four rows of label + value. Spaced evenly across the available
+  // height below the heading.
+  const headerH = 28;
+  const rows: Array<[string, string]> = [
+    ["final error", formatScore(summary.finalError)],
+    ["final score", formatScore(summary.finalScore)],
+    ["generations", String(Math.round(summary.generations))],
+    ["wall clock", formatDuration(summary.wallClockMs)],
+  ];
+  const rowH = Math.max(20, (h - headerH - 8) / rows.length);
+  for (let i = 0; i < rows.length; i++) {
+    const [label, value] = rows[i];
+    const rowY = y + headerH + i * rowH + rowH / 2;
+    out.push(
+      `    <text class="callout-label" x="${fmt(x + 12)}" y="${fmt(rowY)}" ` +
+        `dominant-baseline="middle">${escapeText(label)}</text>`,
+    );
+    out.push(
+      `    <text class="callout-value" x="${fmt(x + w - 12)}" y="${fmt(rowY)}" ` +
+        `text-anchor="end" dominant-baseline="middle" font-weight="bold" ` +
+        `fill="${CALLOUT_COLOUR}">${escapeText(value)}</text>`,
+    );
+  }
+
+  out.push(`  </g>`);
+  return out.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Caption — stop-condition footer
+// ---------------------------------------------------------------------------
+
+function renderCaption(
+  summary: EvolveDirSummary,
+  width: number,
+  height: number,
+): string {
+  const parts: string[] = [];
+  if (summary.targetError !== undefined) {
+    parts.push(`target error ${formatScore(summary.targetError)}`);
+  }
+  if (summary.timeoutMinutes !== undefined) {
+    parts.push(`timeout ${summary.timeoutMinutes} min`);
+  }
+  const text = `stop conditions: ${parts.join(" · ")}`;
+  return [
+    `  <g class="caption" font-family="sans-serif" font-size="12" fill="#555">`,
+    `    <text x="${fmt(width / 2)}" y="${fmt(height - 12)}" text-anchor="middle">` +
+    escapeText(text) +
+    `</text>`,
+    `  </g>`,
+  ].join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Number / text formatting
+// ---------------------------------------------------------------------------
+
+/** Round a numeric coordinate to two decimal places for compact output. */
+function fmt(v: number): string {
+  if (!Number.isFinite(v)) return "0";
+  return (Math.round(v * 100) / 100).toString();
+}
+
+/** Format a score / error to three decimal places. */
+function formatScore(v: number): string {
+  if (!Number.isFinite(v)) return "0";
+  return (Math.round(v * 1000) / 1000).toString();
+}
+
+/**
+ * Format a millisecond duration as a short, human-friendly string:
+ *   - < 1 second   → "Xms"
+ *   - < 1 minute   → "Xs"
+ *   - < 1 hour     → "Xm Ys"
+ *   - >= 1 hour    → "Xh Ym"
+ */
+function formatDuration(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return "0ms";
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  const totalSeconds = Math.floor(ms / 1000);
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (totalMinutes < 60) return `${totalMinutes}m ${seconds}s`;
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return `${hours}h ${minutes}m`;
+}
+
+function escapeText(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function escapeAttr(s: string): string {
+  return escapeText(s).replace(/"/g, "&quot;");
+}

--- a/common/evolve_dir_summary_test.ts
+++ b/common/evolve_dir_summary_test.ts
@@ -1,0 +1,240 @@
+/**
+ * Unit tests for the `evolveDir` return-value summary SVG renderer.
+ *
+ * These are "what" tests — they verify the observable behaviour of
+ * `renderEvolveDirSummarySvg` (returned SVG string contents, structure,
+ * deterministic output, error handling) without inspecting how the
+ * renderer builds it.
+ */
+
+import { assert, assertEquals, assertStringIncludes, assertThrows } from "@std/assert";
+
+import { type EvolveDirSummary, renderEvolveDirSummarySvg } from "./evolve_dir_summary.ts";
+
+/** A canonical, well-formed summary used as the happy-path baseline. */
+function makeSummary(overrides: Partial<EvolveDirSummary> = {}): EvolveDirSummary {
+  return {
+    finalError: 0.0125,
+    finalScore: 0.876,
+    wallClockMs: 123_456,
+    generations: 1000,
+    seedNeurons: 5,
+    seedSynapses: 4,
+    finalNeurons: 12,
+    finalSynapses: 23,
+    targetError: 0.01,
+    timeoutMinutes: 5,
+    ...overrides,
+  };
+}
+
+Deno.test("renderEvolveDirSummarySvg: happy path emits SVG containing every numeric callout", () => {
+  const summary = makeSummary();
+  const svg = renderEvolveDirSummarySvg(summary);
+
+  assertStringIncludes(svg, "<svg");
+  assertStringIncludes(svg, "</svg>");
+
+  // Numeric callouts — all four required values present in the output.
+  assertStringIncludes(svg, "0.013"); // finalError, 3 dp
+  assertStringIncludes(svg, "0.876"); // finalScore, 3 dp
+  assertStringIncludes(svg, "1000"); // generations
+  // Wall-clock is formatted (e.g. "2m 3s" or "123456 ms"); the raw count
+  // of milliseconds is the floor — we expect a human-friendly form
+  // mentioning minutes or seconds for >= 1 second.
+  assert(
+    /\b\d+m \d+s\b|\b\d+s\b/.test(svg),
+    "SVG must contain a formatted wall-clock duration",
+  );
+
+  // Topology bars — both seed and final counts surface in the SVG.
+  assertStringIncludes(svg, "topology");
+  assertStringIncludes(svg, "5"); // seedNeurons
+  assertStringIncludes(svg, "4"); // seedSynapses
+  assertStringIncludes(svg, "12"); // finalNeurons
+  assertStringIncludes(svg, "23"); // finalSynapses
+
+  // No NaN/Infinity leaks into the output.
+  assert(!svg.includes("NaN"), "SVG must not contain NaN");
+  assert(!svg.includes("Infinity"), "SVG must not contain Infinity");
+});
+
+Deno.test("renderEvolveDirSummarySvg: stop-condition caption appears when targetError/timeoutMinutes set", () => {
+  const summary = makeSummary({ targetError: 0.005, timeoutMinutes: 3 });
+  const svg = renderEvolveDirSummarySvg(summary);
+
+  assertStringIncludes(svg, "caption");
+  // Caption surfaces the configured stop conditions.
+  assertStringIncludes(svg, "0.005");
+  assertStringIncludes(svg, "3");
+});
+
+Deno.test("renderEvolveDirSummarySvg: caption omitted when stop conditions are absent", () => {
+  const summary = makeSummary({ targetError: undefined, timeoutMinutes: undefined });
+  const svg = renderEvolveDirSummarySvg(summary);
+  assert(
+    !svg.includes('class="caption"'),
+    "caption must not appear when both stop-condition fields are absent",
+  );
+});
+
+Deno.test("renderEvolveDirSummarySvg: rejects non-finite finalError", () => {
+  assertThrows(
+    () => renderEvolveDirSummarySvg(makeSummary({ finalError: Number.NaN })),
+    Error,
+    "finalError",
+  );
+  assertThrows(
+    () => renderEvolveDirSummarySvg(makeSummary({ finalError: Number.POSITIVE_INFINITY })),
+    Error,
+    "finalError",
+  );
+});
+
+Deno.test("renderEvolveDirSummarySvg: rejects non-finite finalScore", () => {
+  assertThrows(
+    () => renderEvolveDirSummarySvg(makeSummary({ finalScore: Number.NaN })),
+    Error,
+    "finalScore",
+  );
+});
+
+Deno.test("renderEvolveDirSummarySvg: rejects non-finite wallClockMs", () => {
+  assertThrows(
+    () => renderEvolveDirSummarySvg(makeSummary({ wallClockMs: Number.NEGATIVE_INFINITY })),
+    Error,
+    "wallClockMs",
+  );
+});
+
+Deno.test("renderEvolveDirSummarySvg: rejects non-finite generations", () => {
+  assertThrows(
+    () => renderEvolveDirSummarySvg(makeSummary({ generations: Number.NaN })),
+    Error,
+    "generations",
+  );
+});
+
+Deno.test("renderEvolveDirSummarySvg: rejects non-finite topology counts", () => {
+  assertThrows(
+    () => renderEvolveDirSummarySvg(makeSummary({ seedNeurons: Number.NaN })),
+    Error,
+    "seedNeurons",
+  );
+  assertThrows(
+    () => renderEvolveDirSummarySvg(makeSummary({ seedSynapses: Number.POSITIVE_INFINITY })),
+    Error,
+    "seedSynapses",
+  );
+  assertThrows(
+    () => renderEvolveDirSummarySvg(makeSummary({ finalNeurons: Number.NaN })),
+    Error,
+    "finalNeurons",
+  );
+  assertThrows(
+    () => renderEvolveDirSummarySvg(makeSummary({ finalSynapses: Number.NaN })),
+    Error,
+    "finalSynapses",
+  );
+});
+
+Deno.test("renderEvolveDirSummarySvg: rejects non-finite optional fields when provided", () => {
+  assertThrows(
+    () => renderEvolveDirSummarySvg(makeSummary({ targetError: Number.NaN })),
+    Error,
+    "targetError",
+  );
+  assertThrows(
+    () => renderEvolveDirSummarySvg(makeSummary({ timeoutMinutes: Number.POSITIVE_INFINITY })),
+    Error,
+    "timeoutMinutes",
+  );
+});
+
+Deno.test("renderEvolveDirSummarySvg: edge case — seed equals final topology (no growth)", () => {
+  const summary = makeSummary({
+    seedNeurons: 7,
+    seedSynapses: 9,
+    finalNeurons: 7,
+    finalSynapses: 9,
+  });
+  const svg = renderEvolveDirSummarySvg(summary);
+
+  assertStringIncludes(svg, "<svg");
+  assertStringIncludes(svg, "</svg>");
+  // Both seed and final values appear; the bar pair must still render.
+  assertStringIncludes(svg, "topology");
+  assertStringIncludes(svg, "7");
+  assertStringIncludes(svg, "9");
+  assert(!svg.includes("NaN"), "SVG must not contain NaN");
+  assert(!svg.includes("Infinity"), "SVG must not contain Infinity");
+});
+
+Deno.test("renderEvolveDirSummarySvg: edge case — very large topology values", () => {
+  const summary = makeSummary({
+    seedNeurons: 1,
+    seedSynapses: 1,
+    finalNeurons: 5000,
+    finalSynapses: 10_000,
+    generations: 50_000,
+    wallClockMs: 3_600_000,
+  });
+  const svg = renderEvolveDirSummarySvg(summary);
+
+  assertStringIncludes(svg, "5000");
+  assertStringIncludes(svg, "10000");
+  assertStringIncludes(svg, "50000");
+  assert(!svg.includes("NaN"));
+});
+
+Deno.test("renderEvolveDirSummarySvg: edge case — very small numeric ranges (sub-millisecond)", () => {
+  const summary = makeSummary({
+    finalError: 1e-9,
+    finalScore: 1e-9,
+    wallClockMs: 0,
+    generations: 1,
+    seedNeurons: 2,
+    seedSynapses: 1,
+    finalNeurons: 2,
+    finalSynapses: 1,
+    targetError: undefined,
+    timeoutMinutes: undefined,
+  });
+  const svg = renderEvolveDirSummarySvg(summary);
+
+  assertStringIncludes(svg, "<svg");
+  assertStringIncludes(svg, "</svg>");
+  assert(!svg.includes("NaN"));
+  assert(!svg.includes("Infinity"));
+});
+
+Deno.test("renderEvolveDirSummarySvg: deterministic — identical input produces identical output", () => {
+  const summary = makeSummary();
+  const a = renderEvolveDirSummarySvg(summary);
+  const b = renderEvolveDirSummarySvg(summary);
+  assertEquals(a, b);
+});
+
+Deno.test("renderEvolveDirSummarySvg: pure string emission — no DOM, no Date.now()", () => {
+  const summary = makeSummary();
+  const first = renderEvolveDirSummarySvg(summary);
+  // Sleep briefly (synchronously, in a benign busy-wait via a tight
+  // arithmetic loop). If the renderer embeds the current time, the
+  // second call would differ even though the input did not.
+  let _spin = 0;
+  for (let i = 0; i < 1_000_000; i++) _spin += i;
+  const second = renderEvolveDirSummarySvg(summary);
+  assertEquals(first, second, `byte-identical output required; spin=${_spin}`);
+});
+
+Deno.test("renderEvolveDirSummarySvg: option overrides for width/height/title flow through", () => {
+  const summary = makeSummary();
+  const svg = renderEvolveDirSummarySvg(summary, {
+    width: 600,
+    height: 320,
+    title: "Custom Title",
+  });
+  assertStringIncludes(svg, 'width="600"');
+  assertStringIncludes(svg, 'height="320"');
+  assertStringIncludes(svg, "Custom Title");
+});

--- a/docs/pr-summary-284.md
+++ b/docs/pr-summary-284.md
@@ -1,0 +1,59 @@
+# Add shared `evolveDir` return-value summary chart helper (#284)
+
+## Summary
+
+Added a new shared helper `common/evolve_dir_summary.ts` that renders a
+deterministic, dependency-free SVG summary chart for the return value
+of `Creature.evolveDir` (final error, final score, generations,
+wall-clock time) plus before/after topology (neurons and synapses) of
+the seed and final creature. An optional caption surfaces the
+configured `targetError` and `timeoutMinutes` stop conditions.
+
+The helper is the foundation reused by the `mnist_classification` and
+`adaptive_mutation` example rewrites tracked in #272, #273, and #263, so
+both examples share one consistent summary chart. Closes #284.
+
+## Evidence
+
+This change is a backend/utility addition with no web interface to
+screenshot — the helper emits SVG strings that callers persist
+alongside their other run artefacts. Verification is via the new unit
+test suite below, which asserts on the SVG content (numeric callouts,
+topology bars, caption presence, deterministic output, non-finite
+rejection).
+
+Layout of the produced SVG:
+
+```mermaid
+flowchart LR
+    A[evolveDir result\n{error, score, time, generation}] --> S[EvolveDirSummary]
+    T[Seed + Final creature\nneurons / synapses] --> S
+    S --> R[renderEvolveDirSummarySvg]
+    R --> SVG[Deterministic SVG\ntopology bars + numeric callouts + caption]
+```
+
+## Test Plan
+
+Added `common/evolve_dir_summary_test.ts` with 15 tests covering:
+
+- Happy path — well-formed summary renders an SVG containing each numeric
+  value and the topology bars.
+- Stop-condition caption present when `targetError`/`timeoutMinutes` are
+  set, and omitted when both are absent.
+- Error path — `NaN`/`±Infinity` rejected for every required numeric
+  field (`finalError`, `finalScore`, `wallClockMs`, `generations`,
+  `seedNeurons`, `seedSynapses`, `finalNeurons`, `finalSynapses`) and
+  for optional fields (`targetError`, `timeoutMinutes`) when supplied.
+- Edge case — seed and final topology equal (no growth) still renders
+  the bar pair without artefacts.
+- Edge case — very large topology values (5k/10k counts, 50k generations)
+  format correctly.
+- Edge case — very small numeric ranges (1e-9 error/score, sub-second
+  duration) render without `NaN` or `Infinity` leaking through.
+- Determinism — repeated calls and calls separated by a synchronous
+  busy-wait produce byte-identical output.
+- Option overrides — `width`, `height`, `title` flow through.
+
+All 15 new tests pass; the broader `common/` suite (100 tests) still
+passes. `deno fmt`, `deno lint`, and `deno check` all pass cleanly on
+the new files.


### PR DESCRIPTION
# Add shared `evolveDir` return-value summary chart helper (#284)

## Summary

Added a new shared helper `common/evolve_dir_summary.ts` that renders a
deterministic, dependency-free SVG summary chart for the return value
of `Creature.evolveDir` (final error, final score, generations,
wall-clock time) plus before/after topology (neurons and synapses) of
the seed and final creature. An optional caption surfaces the
configured `targetError` and `timeoutMinutes` stop conditions.

The helper is the foundation reused by the `mnist_classification` and
`adaptive_mutation` example rewrites tracked in #272, #273, and #263, so
both examples share one consistent summary chart. Closes #284.

## Evidence

This change is a backend/utility addition with no web interface to
screenshot — the helper emits SVG strings that callers persist
alongside their other run artefacts. Verification is via the new unit
test suite below, which asserts on the SVG content (numeric callouts,
topology bars, caption presence, deterministic output, non-finite
rejection).

Layout of the produced SVG:

```mermaid
flowchart LR
    A[evolveDir result\n{error, score, time, generation}] --> S[EvolveDirSummary]
    T[Seed + Final creature\nneurons / synapses] --> S
    S --> R[renderEvolveDirSummarySvg]
    R --> SVG[Deterministic SVG\ntopology bars + numeric callouts + caption]
```

## Test Plan

Added `common/evolve_dir_summary_test.ts` with 15 tests covering:

- Happy path — well-formed summary renders an SVG containing each numeric
  value and the topology bars.
- Stop-condition caption present when `targetError`/`timeoutMinutes` are
  set, and omitted when both are absent.
- Error path — `NaN`/`±Infinity` rejected for every required numeric
  field (`finalError`, `finalScore`, `wallClockMs`, `generations`,
  `seedNeurons`, `seedSynapses`, `finalNeurons`, `finalSynapses`) and
  for optional fields (`targetError`, `timeoutMinutes`) when supplied.
- Edge case — seed and final topology equal (no growth) still renders
  the bar pair without artefacts.
- Edge case — very large topology values (5k/10k counts, 50k generations)
  format correctly.
- Edge case — very small numeric ranges (1e-9 error/score, sub-second
  duration) render without `NaN` or `Infinity` leaking through.
- Determinism — repeated calls and calls separated by a synchronous
  busy-wait produce byte-identical output.
- Option overrides — `width`, `height`, `title` flow through.

All 15 new tests pass; the broader `common/` suite (100 tests) still
passes. `deno fmt`, `deno lint`, and `deno check` all pass cleanly on
the new files.



---

🤖 Processed by: VibeCoderST<!-- vibe-worker-issue-284 -->