### PR TITLE
common: add multi-run persistence helper and CLI flag parser for cross-run evolution (Issue #318)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,17 +151,18 @@ programs. See [README.md](README.md#-quality-check) for full details.
 The `common/` directory holds helpers that every example may reuse. Reach for these before
 reinventing equivalent logic in a new example.
 
-| Module                           | Purpose                                                                                                                                                                   |
-| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `common/deterministic_random.ts` | Seeded PRNG for reproducible data generation.                                                                                                                             |
-| `common/synthetic_data.ts`       | Synthetic dataset generation and scoring.                                                                                                                                 |
-| `common/working_dirs.ts`         | Standard hidden working-directory layout for examples.                                                                                                                    |
-| `common/data_cache.ts`           | Download datasets into hidden directories with on-disk cache.                                                                                                             |
-| `common/evolve_dir_summary.ts`   | Summarise the milestone stats returned by `evolveDir` (from [#284](https://github.com/stSoftwareAU/NEAT-AI-Examples/issues/284)).                                         |
-| `common/large_creature.ts`       | Deterministic large creatures (~10k synapses) for size demos.                                                                                                             |
-| `common/episode_runner.ts`       | Shared per-episode rollout loop for agent examples.                                                                                                                       |
-| `common/outcome_bar_chart.ts`    | Per-scenario outcome bar chart (count panel + cell strip).                                                                                                                |
-| `common/milestone_chart.ts`      | Dual-axis SVG renderer for milestone statistics from `evolveDir` and `evolveRL` / `evolveEnv` (from [#287](https://github.com/stSoftwareAU/NEAT-AI-Examples/issues/287)). |
+| Module                           | Purpose                                                                                                                                                                                                                         |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `common/deterministic_random.ts` | Seeded PRNG for reproducible data generation.                                                                                                                                                                                   |
+| `common/synthetic_data.ts`       | Synthetic dataset generation and scoring.                                                                                                                                                                                       |
+| `common/working_dirs.ts`         | Standard hidden working-directory layout for examples.                                                                                                                                                                          |
+| `common/data_cache.ts`           | Download datasets into hidden directories with on-disk cache.                                                                                                                                                                   |
+| `common/evolve_dir_summary.ts`   | Summarise the milestone stats returned by `evolveDir` (from [#284](https://github.com/stSoftwareAU/NEAT-AI-Examples/issues/284)).                                                                                               |
+| `common/large_creature.ts`       | Deterministic large creatures (~10k synapses) for size demos.                                                                                                                                                                   |
+| `common/episode_runner.ts`       | Shared per-episode rollout loop for agent examples.                                                                                                                                                                             |
+| `common/outcome_bar_chart.ts`    | Per-scenario outcome bar chart (count panel + cell strip).                                                                                                                                                                      |
+| `common/milestone_chart.ts`      | Dual-axis SVG renderer for milestone statistics from `evolveDir` and `evolveRL` / `evolveEnv` (from [#287](https://github.com/stSoftwareAU/NEAT-AI-Examples/issues/287)).                                                       |
+| `common/multi_run_state.ts`      | Multi-run persistence helper: load/save champion + merged milestones across runs, plus a `--fresh` / `--timeout` / `--target-error` CLI flag parser (from [#318](https://github.com/stSoftwareAU/NEAT-AI-Examples/issues/318)). |
 
 ### `common/data_cache.ts`
 
@@ -233,6 +234,8 @@ common/
   milestone_chart_test.ts          — Unit tests for the milestone chart renderer
   evolve_dir_summary.ts            — SVG summary chart for evolveDir() return values
   evolve_dir_summary_test.ts       — Unit tests for the evolveDir summary renderer
+  multi_run_state.ts               — Multi-run persistence helper (cross-run evolution)
+  multi_run_state_test.ts          — Unit tests for the multi-run state helper
 
 crossover/
   crossover_example.ts             — Example: breed two creatures (crossover)

--- a/common/multi_run_state.ts
+++ b/common/multi_run_state.ts
@@ -1,0 +1,240 @@
+/**
+ * Multi-run persistence helper for cross-run NEAT-AI evolution.
+ *
+ * Lets an example resume evolution from a previous run by reloading the
+ * latest champion and appending new milestones to a merged history. Each
+ * milestone carries both a per-run generation number and a cumulative
+ * generation across all runs, so charts can plot the true x-axis.
+ *
+ * Artefact layout (relative to a configurable base directory, defaulting
+ * to `docs`):
+ *
+ * - `data/<exampleSlug>/creature.json`        — latest champion (overwritten)
+ * - `data/<exampleSlug>/milestones.json`      — merged milestone history
+ * - `screenshots/<exampleSlug>/milestones.svg` — chart artefact (wiped on --fresh)
+ * - `screenshots/<exampleSlug>/complexity.svg` — chart artefact (wiped on --fresh)
+ *
+ * The base directory can be overridden via the optional second argument
+ * (used by tests) or the `NEAT_MULTI_RUN_BASE_DIR` environment variable.
+ */
+
+import { ensureDirSync } from "@std/fs";
+import { join } from "@std/path";
+
+import { type CreatureExport, safeWriteJson } from "@stsoftware/neat-ai";
+
+/** Per-sample schema for a single milestone, across all runs. */
+export interface MultiRunMilestone {
+  /** 1-based run index — 1 for the first run, increases each subsequent resume. */
+  runIndex: number;
+  /** Generation number within this run (1, 10, 100, ...). */
+  runGen: number;
+  /** Cumulative generation across all runs combined (true x-axis). */
+  cumulativeGen: number;
+  /** Normalised error (0 = perfect, 1 = chance). */
+  error: number;
+  /** Raw best score reported by the library, kept for readability. */
+  bestScore: number;
+  /** Neuron count of the best creature at this milestone. */
+  neurons: number;
+  /** Synapse count of the best creature at this milestone. */
+  synapses: number;
+  /** Optional mean episode steps (RL examples only). */
+  meanEpisodeSteps?: number;
+  /** Wall-clock duration of the generation that produced this milestone (ms). */
+  generationWallClockMs: number;
+}
+
+/** Loaded multi-run state. */
+export interface MultiRunState {
+  /** Latest champion creature export, or `undefined` if no prior run exists. */
+  creatureExport?: CreatureExport;
+  /** Merged milestone history across all prior runs (in order). */
+  milestones: MultiRunMilestone[];
+  /** 1-based index to assign to the next run (1 for the first run). */
+  nextRunIndex: number;
+  /** Highest `cumulativeGen` seen so far (0 if no prior runs). */
+  lastCumulativeGen: number;
+}
+
+/** Subset of {@link MultiRunMilestone} supplied by callers — the helper
+ * fills in `runIndex` and `cumulativeGen`. */
+export type NewMultiRunSample = Omit<MultiRunMilestone, "runIndex" | "cumulativeGen">;
+
+/** Arguments for {@link appendMultiRunRun}. */
+export interface AppendMultiRunRunArgs {
+  /** Champion creature to persist (overwrites any prior champion). */
+  creatureExport: CreatureExport;
+  /** New milestone samples produced by this run, in generation order. */
+  newSamples: readonly NewMultiRunSample[];
+  /** 1-based index for this run (use {@link MultiRunState.nextRunIndex}). */
+  runIndex: number;
+  /** Cumulative generation total before this run started
+   * (use {@link MultiRunState.lastCumulativeGen}). */
+  baseCumulativeGen: number;
+}
+
+/** Flags parsed from a CLI invocation. */
+export interface MultiRunFlags {
+  /** `--fresh` — wipe prior state before running. */
+  fresh: boolean;
+  /** `--timeout=<minutes>` — wall-clock budget in minutes. */
+  timeoutMinutes?: number;
+  /** `--target-error=<value>` — early-stop normalised error threshold. */
+  targetError?: number;
+}
+
+/** Resolve the base directory used for artefact paths. */
+function resolveBaseDir(baseDir?: string): string {
+  if (baseDir !== undefined) return baseDir;
+  const fromEnv = Deno.env.get("NEAT_MULTI_RUN_BASE_DIR");
+  if (fromEnv !== undefined && fromEnv !== "") return fromEnv;
+  return "docs";
+}
+
+function creaturePath(slug: string, baseDir: string): string {
+  return join(baseDir, "data", slug, "creature.json");
+}
+
+function milestonesPath(slug: string, baseDir: string): string {
+  return join(baseDir, "data", slug, "milestones.json");
+}
+
+function milestoneSvgPath(slug: string, baseDir: string): string {
+  return join(baseDir, "screenshots", slug, "milestones.svg");
+}
+
+function complexitySvgPath(slug: string, baseDir: string): string {
+  return join(baseDir, "screenshots", slug, "complexity.svg");
+}
+
+async function readJsonIfPresent<T>(path: string): Promise<T | undefined> {
+  let text: string;
+  try {
+    text = await Deno.readTextFile(path);
+  } catch (err) {
+    if (err instanceof Deno.errors.NotFound) return undefined;
+    throw err;
+  }
+  // Malformed JSON: let SyntaxError propagate (acceptance: "Throws on malformed JSON").
+  return JSON.parse(text) as T;
+}
+
+/**
+ * Loads multi-run state for an example. Returns documented defaults when
+ * no prior artefacts exist. Throws if either JSON file is malformed.
+ */
+export async function loadMultiRunState(
+  exampleSlug: string,
+  baseDir?: string,
+): Promise<MultiRunState> {
+  const base = resolveBaseDir(baseDir);
+  const creatureExport = await readJsonIfPresent<CreatureExport>(
+    creaturePath(exampleSlug, base),
+  );
+  const milestones = await readJsonIfPresent<MultiRunMilestone[]>(
+    milestonesPath(exampleSlug, base),
+  ) ?? [];
+
+  let nextRunIndex = 1;
+  let lastCumulativeGen = 0;
+  for (const m of milestones) {
+    if (m.runIndex >= nextRunIndex) nextRunIndex = m.runIndex + 1;
+    if (m.cumulativeGen > lastCumulativeGen) lastCumulativeGen = m.cumulativeGen;
+  }
+
+  return { creatureExport, milestones, nextRunIndex, lastCumulativeGen };
+}
+
+/**
+ * Appends a run's milestones to the merged history and overwrites the
+ * champion artefact. Each new sample is stamped with the supplied
+ * `runIndex` and a computed `cumulativeGen = baseCumulativeGen + runGen`.
+ *
+ * Uses {@link safeWriteJson} for atomic temp + rename writes.
+ */
+export async function appendMultiRunRun(
+  exampleSlug: string,
+  args: AppendMultiRunRunArgs,
+  baseDir?: string,
+): Promise<void> {
+  const base = resolveBaseDir(baseDir);
+  const { creatureExport, newSamples, runIndex, baseCumulativeGen } = args;
+
+  const dir = join(base, "data", exampleSlug);
+  ensureDirSync(dir);
+
+  const existing = await readJsonIfPresent<MultiRunMilestone[]>(
+    milestonesPath(exampleSlug, base),
+  ) ?? [];
+
+  const appended: MultiRunMilestone[] = newSamples.map((s) => ({
+    ...s,
+    runIndex,
+    cumulativeGen: baseCumulativeGen + s.runGen,
+  }));
+
+  const merged = [...existing, ...appended];
+
+  await safeWriteJson(creaturePath(exampleSlug, base), creatureExport);
+  await safeWriteJson(milestonesPath(exampleSlug, base), merged);
+}
+
+/** Remove a path if it exists; missing files are not an error. */
+async function removeIfExists(path: string): Promise<void> {
+  try {
+    await Deno.remove(path);
+  } catch (err) {
+    if (err instanceof Deno.errors.NotFound) return;
+    throw err;
+  }
+}
+
+/**
+ * Wipe every multi-run artefact for an example: champion JSON, merged
+ * milestones JSON, and the two chart SVGs. Missing files are silently
+ * skipped — used by `--fresh` to start over.
+ */
+export async function wipeMultiRunState(
+  exampleSlug: string,
+  baseDir?: string,
+): Promise<void> {
+  const base = resolveBaseDir(baseDir);
+  await removeIfExists(creaturePath(exampleSlug, base));
+  await removeIfExists(milestonesPath(exampleSlug, base));
+  await removeIfExists(milestoneSvgPath(exampleSlug, base));
+  await removeIfExists(complexitySvgPath(exampleSlug, base));
+}
+
+/** Parse a numeric `--name=value` argument; returns `undefined` if missing,
+ * malformed, or `NaN`. */
+function parseNumericFlag(args: readonly string[], name: string): number | undefined {
+  const prefix = `--${name}=`;
+  for (const arg of args) {
+    if (arg.startsWith(prefix)) {
+      const raw = arg.slice(prefix.length);
+      const n = Number(raw);
+      if (Number.isFinite(n)) return n;
+      return undefined;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Extract the three multi-run CLI flags from an argv-style array.
+ *
+ * Recognised:
+ * - `--fresh`                  → `fresh: true`
+ * - `--timeout=<minutes>`      → `timeoutMinutes: number`
+ * - `--target-error=<value>`   → `targetError: number`
+ *
+ * Unknown flags are passed through unchanged — callers strip them as needed.
+ * Invalid numeric values (non-finite / NaN / malformed) yield `undefined`.
+ */
+export function parseMultiRunFlags(args: readonly string[]): MultiRunFlags {
+  const fresh = args.includes("--fresh");
+  const timeoutMinutes = parseNumericFlag(args, "timeout");
+  const targetError = parseNumericFlag(args, "target-error");
+  return { fresh, timeoutMinutes, targetError };
+}

--- a/common/multi_run_state_test.ts
+++ b/common/multi_run_state_test.ts
@@ -1,0 +1,306 @@
+/**
+ * Unit tests for the multi-run state persistence helper.
+ *
+ * These are "what" tests — they create real artefacts on disk under a
+ * temporary base directory and assert on the resulting state.
+ */
+
+import { assertEquals, assertNotEquals, assertRejects } from "@std/assert";
+import { existsSync } from "@std/fs";
+import { join } from "@std/path";
+
+import type { CreatureExport } from "@stsoftware/neat-ai";
+
+import {
+  appendMultiRunRun,
+  loadMultiRunState,
+  type MultiRunMilestone,
+  parseMultiRunFlags,
+  wipeMultiRunState,
+} from "./multi_run_state.ts";
+
+/** Tiny stand-in for a real CreatureExport (the helper does not validate the shape). */
+function tinyCreatureExport(seed: number): CreatureExport {
+  return {
+    neurons: [
+      { uuid: `n-${seed}-out`, type: "output", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [],
+    input: 1,
+    output: 1,
+  } as unknown as CreatureExport;
+}
+
+function tinyMilestone(runGen: number, error: number): Omit<
+  MultiRunMilestone,
+  "runIndex" | "cumulativeGen"
+> {
+  return {
+    runGen,
+    error,
+    bestScore: 1 - error,
+    neurons: 2 + runGen,
+    synapses: 1 + runGen,
+    generationWallClockMs: 100 * runGen,
+  };
+}
+
+Deno.test("loadMultiRunState returns documented defaults when no files exist", async () => {
+  const tmp = Deno.makeTempDirSync({ prefix: "neat_multirun_" });
+  try {
+    const state = await loadMultiRunState("xor_classification", tmp);
+    assertEquals(state.creatureExport, undefined);
+    assertEquals(state.milestones, []);
+    assertEquals(state.nextRunIndex, 1);
+    assertEquals(state.lastCumulativeGen, 0);
+  } finally {
+    Deno.removeSync(tmp, { recursive: true });
+  }
+});
+
+Deno.test("appendMultiRunRun → loadMultiRunState round trip preserves data", async () => {
+  const tmp = Deno.makeTempDirSync({ prefix: "neat_multirun_" });
+  try {
+    const slug = "xor_classification";
+    const creatureExport = tinyCreatureExport(1);
+    const newSamples = [tinyMilestone(1, 0.5), tinyMilestone(10, 0.2)];
+
+    await appendMultiRunRun(slug, {
+      creatureExport,
+      newSamples,
+      runIndex: 1,
+      baseCumulativeGen: 0,
+    }, tmp);
+
+    const state = await loadMultiRunState(slug, tmp);
+    assertEquals(state.creatureExport, creatureExport);
+    assertEquals(state.milestones.length, 2);
+    assertEquals(state.milestones[0].runIndex, 1);
+    assertEquals(state.milestones[0].cumulativeGen, 1);
+    assertEquals(state.milestones[0].runGen, 1);
+    assertEquals(state.milestones[1].runIndex, 1);
+    assertEquals(state.milestones[1].cumulativeGen, 10);
+    assertEquals(state.nextRunIndex, 2);
+    assertEquals(state.lastCumulativeGen, 10);
+  } finally {
+    Deno.removeSync(tmp, { recursive: true });
+  }
+});
+
+Deno.test("runIndex increments and cumulativeGen is monotonic across runs", async () => {
+  const tmp = Deno.makeTempDirSync({ prefix: "neat_multirun_" });
+  try {
+    const slug = "cart_pole";
+
+    await appendMultiRunRun(slug, {
+      creatureExport: tinyCreatureExport(1),
+      newSamples: [tinyMilestone(1, 0.5), tinyMilestone(10, 0.3)],
+      runIndex: 1,
+      baseCumulativeGen: 0,
+    }, tmp);
+
+    const first = await loadMultiRunState(slug, tmp);
+    assertEquals(first.nextRunIndex, 2);
+    assertEquals(first.lastCumulativeGen, 10);
+
+    await appendMultiRunRun(slug, {
+      creatureExport: tinyCreatureExport(2),
+      newSamples: [tinyMilestone(1, 0.2), tinyMilestone(5, 0.1)],
+      runIndex: first.nextRunIndex,
+      baseCumulativeGen: first.lastCumulativeGen,
+    }, tmp);
+
+    const merged = await loadMultiRunState(slug, tmp);
+    assertEquals(merged.milestones.length, 4);
+    assertEquals(merged.milestones[2].runIndex, 2);
+    assertEquals(merged.milestones[2].cumulativeGen, 11);
+    assertEquals(merged.milestones[3].runIndex, 2);
+    assertEquals(merged.milestones[3].cumulativeGen, 15);
+    assertEquals(merged.nextRunIndex, 3);
+    assertEquals(merged.lastCumulativeGen, 15);
+
+    // Monotonic cumulativeGen.
+    for (let i = 1; i < merged.milestones.length; i++) {
+      const prev = merged.milestones[i - 1].cumulativeGen;
+      const curr = merged.milestones[i].cumulativeGen;
+      assertEquals(curr > prev, true, `cumulativeGen must increase: ${prev} → ${curr}`);
+    }
+  } finally {
+    Deno.removeSync(tmp, { recursive: true });
+  }
+});
+
+Deno.test("wipeMultiRunState removes all four canonical artefact paths", async () => {
+  const tmp = Deno.makeTempDirSync({ prefix: "neat_multirun_" });
+  try {
+    const slug = "snake_game";
+
+    // Seed creature.json and milestones.json via appendMultiRunRun.
+    await appendMultiRunRun(slug, {
+      creatureExport: tinyCreatureExport(1),
+      newSamples: [tinyMilestone(1, 0.5)],
+      runIndex: 1,
+      baseCumulativeGen: 0,
+    }, tmp);
+
+    // Manually create the two chart SVGs the helper should also remove.
+    const screenshotsDir = join(tmp, "screenshots", slug);
+    Deno.mkdirSync(screenshotsDir, { recursive: true });
+    const milestonesSvg = join(screenshotsDir, "milestones.svg");
+    const complexitySvg = join(screenshotsDir, "complexity.svg");
+    Deno.writeTextFileSync(milestonesSvg, "<svg/>");
+    Deno.writeTextFileSync(complexitySvg, "<svg/>");
+
+    const creatureJson = join(tmp, "data", slug, "creature.json");
+    const milestonesJson = join(tmp, "data", slug, "milestones.json");
+    assertEquals(existsSync(creatureJson), true, "creature.json should exist before wipe");
+    assertEquals(existsSync(milestonesJson), true, "milestones.json should exist before wipe");
+
+    await wipeMultiRunState(slug, tmp);
+
+    assertEquals(existsSync(creatureJson), false, "creature.json removed");
+    assertEquals(existsSync(milestonesJson), false, "milestones.json removed");
+    assertEquals(existsSync(milestonesSvg), false, "milestones.svg removed");
+    assertEquals(existsSync(complexitySvg), false, "complexity.svg removed");
+  } finally {
+    Deno.removeSync(tmp, { recursive: true });
+  }
+});
+
+Deno.test("wipeMultiRunState tolerates missing files", async () => {
+  const tmp = Deno.makeTempDirSync({ prefix: "neat_multirun_" });
+  try {
+    // No files exist yet — should not throw.
+    await wipeMultiRunState("never_seen", tmp);
+  } finally {
+    Deno.removeSync(tmp, { recursive: true });
+  }
+});
+
+Deno.test("loadMultiRunState throws on malformed milestones.json", async () => {
+  const tmp = Deno.makeTempDirSync({ prefix: "neat_multirun_" });
+  try {
+    const slug = "cart_pole";
+    const dir = join(tmp, "data", slug);
+    Deno.mkdirSync(dir, { recursive: true });
+    Deno.writeTextFileSync(join(dir, "milestones.json"), "{not json");
+
+    await assertRejects(
+      () => loadMultiRunState(slug, tmp),
+      Error,
+    );
+  } finally {
+    Deno.removeSync(tmp, { recursive: true });
+  }
+});
+
+Deno.test("loadMultiRunState throws on malformed creature.json", async () => {
+  const tmp = Deno.makeTempDirSync({ prefix: "neat_multirun_" });
+  try {
+    const slug = "cart_pole";
+    const dir = join(tmp, "data", slug);
+    Deno.mkdirSync(dir, { recursive: true });
+    Deno.writeTextFileSync(join(dir, "creature.json"), "{not json");
+
+    await assertRejects(
+      () => loadMultiRunState(slug, tmp),
+      Error,
+    );
+  } finally {
+    Deno.removeSync(tmp, { recursive: true });
+  }
+});
+
+Deno.test("parseMultiRunFlags — --fresh", () => {
+  const flags = parseMultiRunFlags(["--fresh"]);
+  assertEquals(flags.fresh, true);
+  assertEquals(flags.timeoutMinutes, undefined);
+  assertEquals(flags.targetError, undefined);
+});
+
+Deno.test("parseMultiRunFlags — --timeout=<minutes>", () => {
+  const flags = parseMultiRunFlags(["--timeout=15"]);
+  assertEquals(flags.fresh, false);
+  assertEquals(flags.timeoutMinutes, 15);
+  assertEquals(flags.targetError, undefined);
+});
+
+Deno.test("parseMultiRunFlags — --target-error=<value>", () => {
+  const flags = parseMultiRunFlags(["--target-error=0.04"]);
+  assertEquals(flags.fresh, false);
+  assertEquals(flags.timeoutMinutes, undefined);
+  assertEquals(flags.targetError, 0.04);
+});
+
+Deno.test("parseMultiRunFlags — combinations", () => {
+  const flags = parseMultiRunFlags([
+    "--fresh",
+    "--timeout=30",
+    "--target-error=0.1",
+  ]);
+  assertEquals(flags.fresh, true);
+  assertEquals(flags.timeoutMinutes, 30);
+  assertEquals(flags.targetError, 0.1);
+});
+
+Deno.test("parseMultiRunFlags — absent flags yield false / undefined", () => {
+  const flags = parseMultiRunFlags([]);
+  assertEquals(flags.fresh, false);
+  assertEquals(flags.timeoutMinutes, undefined);
+  assertEquals(flags.targetError, undefined);
+});
+
+Deno.test("parseMultiRunFlags — invalid numeric values yield undefined", () => {
+  const flags = parseMultiRunFlags([
+    "--timeout=not-a-number",
+    "--target-error=NaN",
+  ]);
+  assertEquals(flags.timeoutMinutes, undefined);
+  assertEquals(flags.targetError, undefined);
+});
+
+Deno.test("parseMultiRunFlags — passes unknown flags through (does not throw)", () => {
+  // Helper extracts only the flags it cares about; the rest are left for callers.
+  const flags = parseMultiRunFlags([
+    "--fresh",
+    "--other-flag=foo",
+    "positional",
+  ]);
+  assertEquals(flags.fresh, true);
+});
+
+Deno.test("appendMultiRunRun writes deterministic JSON (round-trip identical)", async () => {
+  const tmp = Deno.makeTempDirSync({ prefix: "neat_multirun_" });
+  try {
+    const slug = "xor_classification";
+    const creatureExport = tinyCreatureExport(7);
+    const newSamples = [tinyMilestone(1, 0.5)];
+
+    await appendMultiRunRun(slug, {
+      creatureExport,
+      newSamples,
+      runIndex: 1,
+      baseCumulativeGen: 0,
+    }, tmp);
+    const firstBytes = Deno.readTextFileSync(join(tmp, "data", slug, "milestones.json"));
+
+    // Reload and rewrite — same input must produce same bytes.
+    const state = await loadMultiRunState(slug, tmp);
+    assertNotEquals(state.milestones.length, 0);
+
+    // Second run should append, not corrupt.
+    await appendMultiRunRun(slug, {
+      creatureExport,
+      newSamples: [tinyMilestone(1, 0.4)],
+      runIndex: 2,
+      baseCumulativeGen: state.lastCumulativeGen,
+    }, tmp);
+    const secondBytes = Deno.readTextFileSync(join(tmp, "data", slug, "milestones.json"));
+    assertNotEquals(secondBytes, firstBytes, "second run must change the file");
+
+    const reloaded = await loadMultiRunState(slug, tmp);
+    assertEquals(reloaded.milestones.length, 2);
+  } finally {
+    Deno.removeSync(tmp, { recursive: true });
+  }
+});

--- a/docs/pr-summary-318.md
+++ b/docs/pr-summary-318.md
@@ -1,0 +1,73 @@
+# PR Summary — Issue #318
+
+## Summary
+
+Adds `common/multi_run_state.ts`, a shared persistence helper that lets every NEAT-AI example resume
+evolution across multiple runs. It exports four functions plus a `MultiRunMilestone` interface, all
+backed by atomic JSON writes via `safeWriteJson`. The helper is the foundation every multi-run
+example will build on (charts, run.sh wrappers, `--fresh` wipes). Closes #318.
+
+## What was added
+
+- `loadMultiRunState(slug, baseDir?)` — reads `docs/data/<slug>/creature.json` and
+  `docs/data/<slug>/milestones.json` if present. Returns documented defaults when files are missing;
+  throws on malformed JSON.
+- `appendMultiRunRun(slug, args, baseDir?)` — stamps each new sample with `runIndex` and
+  `cumulativeGen = baseCumulativeGen + runGen`, then overwrites `creature.json` and rewrites
+  `milestones.json` (atomic temp + rename via `safeWriteJson`).
+- `wipeMultiRunState(slug, baseDir?)` — removes the two JSON files and both chart SVGs
+  (`docs/screenshots/<slug>/milestones.svg`, `complexity.svg`). Missing files are not an error.
+- `parseMultiRunFlags(args)` — extracts `--fresh`, `--timeout=<minutes>`, `--target-error=<value>`.
+  Unknown flags pass through unchanged. Invalid numeric values yield `undefined`.
+- `MultiRunMilestone` interface — per-sample schema with `runIndex`, `runGen`, `cumulativeGen`,
+  `error`, `bestScore`, `neurons`, `synapses`, optional `meanEpisodeSteps`, and
+  `generationWallClockMs`.
+
+The base directory is configurable via the optional second argument or the `NEAT_MULTI_RUN_BASE_DIR`
+environment variable, so tests isolate state under `Deno.makeTempDirSync` without polluting the
+working tree.
+
+## Evidence
+
+This is a backend / shared-helper change with no UI. The behaviour is verified by 15 unit tests in
+`common/multi_run_state_test.ts`, all passing under the same permissions as `./quality.sh`:
+
+```text
+ok | 15 passed | 0 failed (16ms)
+```
+
+### Data flow
+
+```mermaid
+flowchart LR
+    runShell["run.sh"] -->|parseMultiRunFlags| flags["--fresh / --timeout / --target-error"]
+    flags -->|--fresh| wipe["wipeMultiRunState"]
+    flags --> load["loadMultiRunState"]
+    load --> creature["docs/data/&lt;slug&gt;/creature.json"]
+    load --> milestones["docs/data/&lt;slug&gt;/milestones.json"]
+    creature --> evolveRun["evolveRL / evolveDir"]
+    evolveRun --> append["appendMultiRunRun"]
+    append --> creature
+    append --> milestones
+```
+
+## Test Plan
+
+Tests added in `common/multi_run_state_test.ts`:
+
+- `loadMultiRunState` returns documented defaults when no files exist.
+- `appendMultiRunRun` → `loadMultiRunState` round trip preserves the champion and milestones.
+- `runIndex` increments and `cumulativeGen` is monotonic across two simulated runs.
+- `wipeMultiRunState` removes all four canonical artefact paths.
+- `wipeMultiRunState` tolerates missing files.
+- `loadMultiRunState` throws on malformed `milestones.json` and malformed `creature.json`.
+- `parseMultiRunFlags`: each flag parsed correctly; combinations work; absent flags yield `false` /
+  `undefined`; invalid numeric values yield `undefined`; unknown flags pass through.
+- Round trip after two `appendMultiRunRun` calls produces the expected merged length.
+
+## Notes for reviewers
+
+- The helper is dependency-free aside from `@stsoftware/neat-ai` (`safeWriteJson`, `CreatureExport`)
+  and `@std/fs` / `@std/path`.
+- No existing examples have been wired up yet — that work is tracked under the #311 sub-issue tree.
+- All new code uses Australian English (e.g. "behaviour", "artefact").


### PR DESCRIPTION
# PR Summary — Issue #318

## Summary

Adds `common/multi_run_state.ts`, a shared persistence helper that lets every NEAT-AI example resume
evolution across multiple runs. It exports four functions plus a `MultiRunMilestone` interface, all
backed by atomic JSON writes via `safeWriteJson`. The helper is the foundation every multi-run
example will build on (charts, run.sh wrappers, `--fresh` wipes). Closes #318.

## What was added

- `loadMultiRunState(slug, baseDir?)` — reads `docs/data/<slug>/creature.json` and
  `docs/data/<slug>/milestones.json` if present. Returns documented defaults when files are missing;
  throws on malformed JSON.
- `appendMultiRunRun(slug, args, baseDir?)` — stamps each new sample with `runIndex` and
  `cumulativeGen = baseCumulativeGen + runGen`, then overwrites `creature.json` and rewrites
  `milestones.json` (atomic temp + rename via `safeWriteJson`).
- `wipeMultiRunState(slug, baseDir?)` — removes the two JSON files and both chart SVGs
  (`docs/screenshots/<slug>/milestones.svg`, `complexity.svg`). Missing files are not an error.
- `parseMultiRunFlags(args)` — extracts `--fresh`, `--timeout=<minutes>`, `--target-error=<value>`.
  Unknown flags pass through unchanged. Invalid numeric values yield `undefined`.
- `MultiRunMilestone` interface — per-sample schema with `runIndex`, `runGen`, `cumulativeGen`,
  `error`, `bestScore`, `neurons`, `synapses`, optional `meanEpisodeSteps`, and
  `generationWallClockMs`.

The base directory is configurable via the optional second argument or the `NEAT_MULTI_RUN_BASE_DIR`
environment variable, so tests isolate state under `Deno.makeTempDirSync` without polluting the
working tree.

## Evidence

This is a backend / shared-helper change with no UI. The behaviour is verified by 15 unit tests in
`common/multi_run_state_test.ts`, all passing under the same permissions as `./quality.sh`:

```text
ok | 15 passed | 0 failed (16ms)
```

### Data flow

```mermaid
flowchart LR
    runShell["run.sh"] -->|parseMultiRunFlags| flags["--fresh / --timeout / --target-error"]
    flags -->|--fresh| wipe["wipeMultiRunState"]
    flags --> load["loadMultiRunState"]
    load --> creature["docs/data/&lt;slug&gt;/creature.json"]
    load --> milestones["docs/data/&lt;slug&gt;/milestones.json"]
    creature --> evolveRun["evolveRL / evolveDir"]
    evolveRun --> append["appendMultiRunRun"]
    append --> creature
    append --> milestones
```

## Test Plan

Tests added in `common/multi_run_state_test.ts`:

- `loadMultiRunState` returns documented defaults when no files exist.
- `appendMultiRunRun` → `loadMultiRunState` round trip preserves the champion and milestones.
- `runIndex` increments and `cumulativeGen` is monotonic across two simulated runs.
- `wipeMultiRunState` removes all four canonical artefact paths.
- `wipeMultiRunState` tolerates missing files.
- `loadMultiRunState` throws on malformed `milestones.json` and malformed `creature.json`.
- `parseMultiRunFlags`: each flag parsed correctly; combinations work; absent flags yield `false` /
  `undefined`; invalid numeric values yield `undefined`; unknown flags pass through.
- Round trip after two `appendMultiRunRun` calls produces the expected merged length.

## Notes for reviewers

- The helper is dependency-free aside from `@stsoftware/neat-ai` (`safeWriteJson`, `CreatureExport`)
  and `@std/fs` / `@std/path`.
- No existing examples have been wired up yet — that work is tracked under the #311 sub-issue tree.
- All new code uses Australian English (e.g. "behaviour", "artefact").



---

🤖 Processed by: stservice<!-- vibe-worker-issue-318 -->