### PR TITLE
evolution_showcase: refresh artefacts for Refresh-2026-05 (#377)

### DIFF
--- a/docs/pr-summary-377.md
+++ b/docs/pr-summary-377.md
@@ -1,0 +1,80 @@
+## Summary
+
+Refresh the `evolution_showcase` artefacts for the `Refresh-2026-05` milestone (parent #369). Grant
+the +15 minutes of additional wall-clock requested by issue #377 by raising the example's evolution
+backstop from 5 → 20 minutes (and lifting the iteration cap in lock-step so wall-clock remains the
+genuine limiter), then re-ran `./evolution_showcase/run.sh` end-to-end against the freshly bumped
+`@stsoftware/neat-ai`, regenerated the milestone-summary SVG, and refreshed the README with the
+measured numbers from the new run. Closes #377.
+
+### Why a literal "+15 minutes" warm continuation does not apply
+
+`evolution_showcase` is listed under [AGENTS.md] as an exempt example because the hand-crafted
+teacher creature is the demo's hand-crafted state, but the NEAT seed itself is still mandated by
+issue #211 to be the minimal `new Creature(INPUT_COUNT, OUTPUT_COUNT)` — there is no
+`multi_run_state` resume path, and warm-starting from the persisted
+`.synthetic-evolution-showcase/creatures/champion.json` would violate that seed contract.
+
+The honest interpretation of the issue's "+15 minutes wall-clock" is therefore **+15 minutes of
+additional evolution budget on the next fresh policy-compliant run** — i.e. raising
+`DEFAULT_SHOWCASE_EVOLUTION_CONFIG.timeoutMinutes` from 5 → 20 (the documented justification
+permitted by the audit's stop-condition rule). `maxIterations` was lifted in lock-step from
+3 000 → 20 000 so wall-clock is the limiter, and the matching test was relaxed from
+`assertEquals(timeoutMinutes, 5)` to `assertGreaterOrEqual(timeoutMinutes, 5)` with the #377
+justification recorded in the comment.
+
+[AGENTS.md]: ../AGENTS.md
+
+### Measured run
+
+| Metric                   | Before (`Refresh-2026-05` baseline) | After (this PR)                                  |
+| ------------------------ | ----------------------------------- | ------------------------------------------------ |
+| Generations              | (5 min budget)                      | 14 368                                           |
+| Wall-clock               | ≤ 5 min                             | 20 m 17 s                                        |
+| Final per-record error   | n/a                                 | 0.1070 (target 0.05 — not reached in backstop)   |
+| Final score              | n/a                                 | 0.8930                                           |
+| Seed neurons / synapses  | 5 / 4                               | 5 / 4                                            |
+| Final neurons / synapses | (smaller)                           | 41 / 230                                         |
+| `targetError` / timeout  | 0.05 / 5 min                        | 0.05 / 20 min                                    |
+
+NEAT-AI added substantial structure on top of the minimal seed (5 → 41 neurons, 4 → 230 synapses)
+even though the run did not reach `targetError` inside the 20-minute backstop — the long-form
+fitness arc plus the topology bars in the milestone summary chart are the headline visual. Issue
+#377 explicitly permits raising the PR even with no fitness gain.
+
+## Evidence
+
+```mermaid
+flowchart LR
+    A["Issue #377<br/>+15m budget"] --> B["timeoutMinutes 5 → 20<br/>maxIterations 3 000 → 20 000"]
+    B --> C["./evolution_showcase/run.sh<br/>(fresh minimal seed)"]
+    C --> D["Champion 41 neurons / 230 synapses<br/>error 0.1070, score 0.8930"]
+    D --> E["📈 evolution_summary.svg regenerated"]
+    D --> F["README refreshed<br/>(Latest Measured Run)"]
+    style A fill:#bd10e0,stroke:#333,color:#fff
+    style B fill:#f5a623,stroke:#333,color:#fff
+    style C fill:#4a90d9,stroke:#333,color:#fff
+    style D fill:#7ed321,stroke:#333,color:#fff
+    style E fill:#50e3c2,stroke:#333,color:#fff
+    style F fill:#50e3c2,stroke:#333,color:#fff
+```
+
+- `docs/screenshots/evolution_showcase/evolution_summary.svg` — milestone-summary SVG regenerated;
+  topology bars show 5 → 41 neurons and 4 → 230 synapses, callouts show final error 0.1070, final
+  score 0.8930, generations 14 368, wall clock 20 m 17 s, with the configured stop conditions
+  (`targetError=0.05`, `timeoutMinutes=20`) in the caption.
+- `./quality.sh < /dev/null` was run end-to-end after the changes and exited cleanly
+  (`All examples passed!`).
+- The NEAT seed remains `new Creature(INPUT_COUNT, OUTPUT_COUNT)` — no warm start, no hidden hint,
+  no resumed checkpoint.
+
+## Test Plan
+
+- `evolution_showcase/evolution_showcase_test.ts::DEFAULT_SHOWCASE_EVOLUTION_CONFIG honours the audit's stop-condition rule`
+  — assertion relaxed from `assertEquals(timeoutMinutes, 5)` to `assertGreaterOrEqual(timeoutMinutes, 5)`
+  with the issue #377 justification recorded in the comment; the rest of the stop-condition
+  contract (positive `targetError`, positive `populationSize`, positive `maxIterations`) is
+  unchanged.
+- All other `evolution_showcase_test.ts` tests are unchanged and continue to pass via
+  `./quality.sh`.
+- `./quality.sh < /dev/null` — passes cleanly with the updated defaults.

--- a/docs/screenshots/evolution_showcase/evolution_summary.svg
+++ b/docs/screenshots/evolution_showcase/evolution_summary.svg
@@ -1,117 +1,38 @@
-<svg
-  xmlns="http://www.w3.org/2000/svg"
-  viewBox="0 0 720 360"
-  width="720"
-  height="360"
-  role="img"
-  aria-label="Evolution Showcase — evolveDir Run Summary summary chart"
->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 360" width="720" height="360" role="img" aria-label="Evolution Showcase — evolveDir Run Summary summary chart">
   <title>Evolution Showcase — evolveDir Run Summary</title>
-  <rect width="720" height="360" fill="#fafafa" />
-  <text
-    x="360"
-    y="24"
-    text-anchor="middle"
-    font-family="sans-serif"
-    font-size="16"
-    font-weight="bold"
-    fill="#222"
-  >Evolution Showcase — evolveDir Run Summary</text>
+  <rect width="720" height="360" fill="#fafafa"/>
+  <text x="360" y="24" text-anchor="middle" font-family="sans-serif" font-size="16" font-weight="bold" fill="#222">Evolution Showcase — evolveDir Run Summary</text>
   <g class="topology" font-family="sans-serif" font-size="11" fill="#333">
-    <rect x="24" y="48" width="369" height="256" fill="#ffffff" stroke="#333" stroke-width="1" />
+    <rect x="24" y="48" width="369" height="256" fill="#ffffff" stroke="#333" stroke-width="1"/>
     <text x="34" y="64" font-weight="bold">topology</text>
-    <rect
-      class="topo-bar topo-bar-seed-neurons"
-      x="47.06"
-      y="241.88"
-      width="46.13"
-      height="28.12"
-      fill="#9ecae1"
-    />
-    <text x="70.13" y="237.88" text-anchor="middle" font-weight="bold">5</text>
+    <rect class="topo-bar topo-bar-seed-neurons" x="47.06" y="248.05" width="46.13" height="21.95" fill="#9ecae1"/>
+    <text x="70.13" y="244.05" text-anchor="middle" font-weight="bold">5</text>
     <text x="70.13" y="282" text-anchor="middle">seed</text>
-    <rect
-      class="topo-bar topo-bar-final-neurons"
-      x="139.31"
-      y="90"
-      width="46.13"
-      height="180"
-      fill="#1f77b4"
-    />
-    <text x="162.38" y="86" text-anchor="middle" font-weight="bold">32</text>
+    <rect class="topo-bar topo-bar-final-neurons" x="139.31" y="90" width="46.13" height="180" fill="#1f77b4"/>
+    <text x="162.38" y="86" text-anchor="middle" font-weight="bold">41</text>
     <text x="162.38" y="282" text-anchor="middle">final</text>
     <text x="116.25" y="292" text-anchor="middle" font-weight="bold">neurons</text>
-    <rect
-      class="topo-bar topo-bar-seed-synapses"
-      x="231.56"
-      y="263.85"
-      width="46.13"
-      height="6.15"
-      fill="#9ecae1"
-    />
-    <text x="254.63" y="259.85" text-anchor="middle" font-weight="bold">4</text>
+    <rect class="topo-bar topo-bar-seed-synapses" x="231.56" y="266.87" width="46.13" height="3.13" fill="#9ecae1"/>
+    <text x="254.63" y="262.87" text-anchor="middle" font-weight="bold">4</text>
     <text x="254.63" y="282" text-anchor="middle">seed</text>
-    <rect
-      class="topo-bar topo-bar-final-synapses"
-      x="323.81"
-      y="90"
-      width="46.13"
-      height="180"
-      fill="#1f77b4"
-    />
-    <text x="346.88" y="86" text-anchor="middle" font-weight="bold">117</text>
+    <rect class="topo-bar topo-bar-final-synapses" x="323.81" y="90" width="46.13" height="180" fill="#1f77b4"/>
+    <text x="346.88" y="86" text-anchor="middle" font-weight="bold">230</text>
     <text x="346.88" y="282" text-anchor="middle">final</text>
     <text x="300.75" y="292" text-anchor="middle" font-weight="bold">synapses</text>
   </g>
   <g class="callouts" font-family="sans-serif" font-size="11" fill="#333">
-    <rect x="409" y="48" width="287" height="256" fill="#ffffff" stroke="#333" stroke-width="1" />
+    <rect x="409" y="48" width="287" height="256" fill="#ffffff" stroke="#333" stroke-width="1"/>
     <text x="419" y="64" font-weight="bold">summary</text>
     <text class="callout-label" x="421" y="103.5" dominant-baseline="middle">final error</text>
-    <text
-      class="callout-value"
-      x="684"
-      y="103.5"
-      text-anchor="end"
-      dominant-baseline="middle"
-      font-weight="bold"
-      fill="#2ca02c"
-    >0.162</text>
+    <text class="callout-value" x="684" y="103.5" text-anchor="end" dominant-baseline="middle" font-weight="bold" fill="#2ca02c">0.107</text>
     <text class="callout-label" x="421" y="158.5" dominant-baseline="middle">final score</text>
-    <text
-      class="callout-value"
-      x="684"
-      y="158.5"
-      text-anchor="end"
-      dominant-baseline="middle"
-      font-weight="bold"
-      fill="#2ca02c"
-    >0.838</text>
+    <text class="callout-value" x="684" y="158.5" text-anchor="end" dominant-baseline="middle" font-weight="bold" fill="#2ca02c">0.893</text>
     <text class="callout-label" x="421" y="213.5" dominant-baseline="middle">generations</text>
-    <text
-      class="callout-value"
-      x="684"
-      y="213.5"
-      text-anchor="end"
-      dominant-baseline="middle"
-      font-weight="bold"
-      fill="#2ca02c"
-    >3003</text>
+    <text class="callout-value" x="684" y="213.5" text-anchor="end" dominant-baseline="middle" font-weight="bold" fill="#2ca02c">14368</text>
     <text class="callout-label" x="421" y="268.5" dominant-baseline="middle">wall clock</text>
-    <text
-      class="callout-value"
-      x="684"
-      y="268.5"
-      text-anchor="end"
-      dominant-baseline="middle"
-      font-weight="bold"
-      fill="#2ca02c"
-    >1m 1s</text>
+    <text class="callout-value" x="684" y="268.5" text-anchor="end" dominant-baseline="middle" font-weight="bold" fill="#2ca02c">20m 16s</text>
   </g>
   <g class="caption" font-family="sans-serif" font-size="12" fill="#555">
-    <text
-      x="360"
-      y="348"
-      text-anchor="middle"
-    >stop conditions: target error 0.05 · timeout 5 min</text>
+    <text x="360" y="348" text-anchor="middle">stop conditions: target error 0.05 · timeout 20 min</text>
   </g>
 </svg>

--- a/evolution_showcase/README.md
+++ b/evolution_showcase/README.md
@@ -17,7 +17,7 @@ flowchart LR
     REF["🧬 Hand-crafted teacher creature<br/>(only used to label the .bin set)"]
     DATA["📦 Binary .bin training set"]
     SEED["🌱 new Creature(4, 1)<br/>minimal seed — no hidden hint"]
-    EVOLVE["🧪 Creature.evolveDir(...)<br/>forward-only, targetError=0.05,<br/>timeoutMinutes=5"]
+    EVOLVE["🧪 Creature.evolveDir(...)<br/>forward-only, targetError=0.05,<br/>timeoutMinutes=20"]
     SUMMARY["📈 Milestone summary SVG<br/>(from evolveDir return value)"]
     REF --> DATA
     DATA --> EVOLVE
@@ -38,8 +38,9 @@ flowchart LR
 2. Seed evolution with `new Creature(INPUT_COUNT, OUTPUT_COUNT)` — four inputs, one output, no
    hidden neurons, no warm start.
 3. Call `Creature.evolveDir(dataDir, options)` over the `.bin` directory in forward-only mode until
-   either the per-example `targetError` is reached or the `timeoutMinutes: 5` backstop fires (issue
-   #211 stop-condition rule).
+   either the per-example `targetError` is reached or the `timeoutMinutes: 20` wall-clock backstop
+   fires (issue #211 stop-condition rule; backstop raised from 5 → 20 under #377 for the
+   Refresh-2026-05 milestone).
 4. Build an `EvolveDirSummary` from the call's `{ error, score, time, generation }` return value
    plus the seed and final topology counts, and render it via the shared
    `common/evolve_dir_summary.ts` helper from
@@ -89,21 +90,43 @@ In addition, the milestone summary SVG is committed under `docs/`:
 ## ⚙️ Configuration
 
 `DEFAULT_SHOWCASE_EVOLUTION_CONFIG` in [`evolution_showcase.ts`](evolution_showcase.ts) holds the
-canonical values. The audit (#211) mandates `targetError` plus `timeoutMinutes: 5` as the stop
+canonical values. The audit (#211) mandates `targetError` plus a wall-clock backstop as the stop
 conditions — both are set, with `maxIterations` acting as a secondary safety net so the run cannot
-loop forever even if the targetError is unreachable.
+loop forever even if the targetError is unreachable. Issue
+[#377](https://github.com/stSoftwareAU/NEAT-AI-Examples/issues/377) (Refresh-2026-05) raised the
+backstop from 5 → 20 minutes to grant the milestone's +15 minutes of additional evolution.
 
-| Field            | Default | Notes                                                 |
-| ---------------- | ------- | ----------------------------------------------------- |
-| `targetError`    | 0.05    | Per-example reasonable target error.                  |
-| `timeoutMinutes` | 5       | Audit-mandated wall-clock backstop.                   |
-| `populationSize` | 24      | Population fed to `evolveDir`.                        |
-| `maxIterations`  | 3000    | Hard iteration cap; reached in ~30 s on a dev laptop. |
-| `seed`           | 211 211 | Driving the seeded PRNG inside NEAT-AI.               |
+| Field            | Default | Notes                                                                                             |
+| ---------------- | ------- | ------------------------------------------------------------------------------------------------- |
+| `targetError`    | 0.05    | Per-example reasonable target error.                                                              |
+| `timeoutMinutes` | 20      | Wall-clock backstop (raised from 5 → 20 under #377 to grant +15 minutes of additional evolution). |
+| `populationSize` | 24      | Population fed to `evolveDir`.                                                                    |
+| `maxIterations`  | 20 000  | Hard iteration cap, lifted in lock-step with the backstop so wall-clock is the genuine limiter.   |
+| `seed`           | 211 211 | Driving the seeded PRNG inside NEAT-AI.                                                           |
 
-Why `maxIterations: 3000` and not more? On a developer laptop the run completes in roughly 30
-seconds at the current cap, comfortably inside the `timeoutMinutes: 5` backstop. The cap exists so
-the example terminates promptly on unattended CI machines.
+Why `maxIterations: 20 000` and not more? Newer NEAT-AI builds complete ~14 000 generations inside
+the 20-minute backstop on a developer laptop, so the cap comfortably exceeds the wall-clock budget
+without letting the run loop forever if the budget is ever lifted.
+
+## 📊 Latest measured run
+
+Run reproduced end-to-end via `./evolution_showcase/run.sh` on the freshly bumped
+`@stsoftware/neat-ai` for issue #377 (Refresh-2026-05):
+
+| Metric                   | Value                                              |
+| ------------------------ | -------------------------------------------------- |
+| Generations              | 14 368                                             |
+| Wall-clock               | 20 m 17 s                                          |
+| Final per-record error   | 0.1070 (target 0.05 — not reached inside backstop) |
+| Final score              | 0.8930                                             |
+| Seed neurons / synapses  | 5 / 4                                              |
+| Final neurons / synapses | 41 / 230                                           |
+| `targetError` / timeout  | 0.05 / 20 min                                      |
+
+NEAT-AI added substantial structure on top of the minimal seed (5 → 41 neurons, 4 → 230 synapses)
+even though the run did not reach `targetError` inside the 20-minute backstop — the long-form
+fitness arc plus the topology bars in the milestone summary chart are the headline visual. Issue
+#377 explicitly permits raising the PR even with no fitness gain.
 
 ## 🧰 NEAT-AI features used
 

--- a/evolution_showcase/evolution_showcase.ts
+++ b/evolution_showcase/evolution_showcase.ts
@@ -67,7 +67,9 @@ export const SYNTHETIC_CONFIG: SyntheticConfig = {
 export interface ShowcaseEvolutionConfig {
   /** Per-example reasonable target error driving early exit. */
   targetError: number;
-  /** Wall-clock backstop in minutes (issue #211 mandates 5 as upper bound). */
+  /** Wall-clock backstop in minutes. Issue #211 mandates a backstop; the
+   * specific value is per-example (issue #377 raised it from 5 → 20 for
+   * the Refresh-2026-05 milestone). */
   timeoutMinutes: number;
   /** NEAT population size. */
   populationSize: number;
@@ -87,15 +89,23 @@ export interface ShowcaseEvolutionConfig {
  * that a hidden-less direct seed plateaus quickly. The default
  * `targetError` of 0.05 is reasonable for the task: it forces real
  * structural growth (a direct seed plateaus around per-record error
- * 0.27) but is still reachable inside the 5-minute backstop. Runs that
- * hit the `maxIterations` cap before the target is met still produce
- * the milestone summary chart.
+ * 0.27) but is still reachable inside the wall-clock backstop. Runs
+ * that hit the `maxIterations` cap before the target is met still
+ * produce the milestone summary chart.
+ *
+ * Per issue #377 (Refresh-2026-05), the wall-clock backstop was raised
+ * from the original 5 → 20 minutes to grant the +15 minutes of
+ * additional evolution requested by the refresh milestone, and the
+ * iteration cap was lifted in lock-step so wall-clock remains the
+ * genuine limiter on newer NEAT-AI builds. The audit (#211) mandates
+ * `targetError` plus a wall-clock backstop as the stop conditions;
+ * 20 minutes is the per-example justified value documented here.
  */
 export const DEFAULT_SHOWCASE_EVOLUTION_CONFIG: ShowcaseEvolutionConfig = {
   targetError: 0.05,
-  timeoutMinutes: 5,
+  timeoutMinutes: 20,
   populationSize: 24,
-  maxIterations: 3000,
+  maxIterations: 20_000,
   seed: 211_211,
 };
 

--- a/evolution_showcase/evolution_showcase_test.ts
+++ b/evolution_showcase/evolution_showcase_test.ts
@@ -12,7 +12,13 @@
  * the rendered SVG, and missing-field errors are caught.
  */
 
-import { assert, assertEquals, assertGreater, assertThrows } from "@std/assert";
+import {
+  assert,
+  assertEquals,
+  assertGreater,
+  assertGreaterOrEqual,
+  assertThrows,
+} from "@std/assert";
 import { ensureDirSync, existsSync } from "@std/fs";
 import { join } from "@std/path";
 import { Creature } from "@stsoftware/neat-ai";
@@ -84,10 +90,15 @@ Deno.test("DEFAULT_SHOWCASE_EVOLUTION_CONFIG honours the audit's stop-condition 
     0,
     "targetError must be positive",
   );
-  assertEquals(
+  // Issue #211 mandates a wall-clock backstop; the specific value is
+  // per-example. Issue #377 (Refresh-2026-05) raised this example's
+  // backstop from 5 → 20 minutes to grant the +15 minutes of additional
+  // evolution requested by the refresh milestone, so the contract here
+  // is a lower-bound check rather than an exact match.
+  assertGreaterOrEqual(
     DEFAULT_SHOWCASE_EVOLUTION_CONFIG.timeoutMinutes,
     5,
-    "timeoutMinutes must default to the issue #211 backstop",
+    "timeoutMinutes must satisfy the issue #211 backstop lower bound (≥5)",
   );
   assertGreater(
     DEFAULT_SHOWCASE_EVOLUTION_CONFIG.populationSize,

--- a/evolution_showcase/run.sh
+++ b/evolution_showcase/run.sh
@@ -7,9 +7,9 @@ set -euo pipefail
 # Builds a hand-crafted teacher creature, synthesises a deterministic
 # binary `.bin` training set from it, evolves a minimal NEAT-AI seed
 # (`new Creature(INPUT, OUTPUT)`) via `Creature.evolveDir` until either
-# the per-example `targetError` is reached or the `timeoutMinutes: 5`
-# backstop fires, and renders a single milestone summary SVG built from
-# the call's return value:
+# the per-example `targetError` is reached or the wall-clock backstop
+# fires (20 minutes per issue #377, Refresh-2026-05), and renders a
+# single milestone summary SVG built from the call's return value:
 #
 #   - docs/screenshots/evolution_showcase/evolution_summary.svg
 #


### PR DESCRIPTION
## Summary

Refresh the `evolution_showcase` artefacts for the `Refresh-2026-05` milestone (parent #369). Grant
the +15 minutes of additional wall-clock requested by issue #377 by raising the example's evolution
backstop from 5 → 20 minutes (and lifting the iteration cap in lock-step so wall-clock remains the
genuine limiter), then re-ran `./evolution_showcase/run.sh` end-to-end against the freshly bumped
`@stsoftware/neat-ai`, regenerated the milestone-summary SVG, and refreshed the README with the
measured numbers from the new run. Closes #377.

### Why a literal "+15 minutes" warm continuation does not apply

`evolution_showcase` is listed under [AGENTS.md] as an exempt example because the hand-crafted
teacher creature is the demo's hand-crafted state, but the NEAT seed itself is still mandated by
issue #211 to be the minimal `new Creature(INPUT_COUNT, OUTPUT_COUNT)` — there is no
`multi_run_state` resume path, and warm-starting from the persisted
`.synthetic-evolution-showcase/creatures/champion.json` would violate that seed contract.

The honest interpretation of the issue's "+15 minutes wall-clock" is therefore **+15 minutes of
additional evolution budget on the next fresh policy-compliant run** — i.e. raising
`DEFAULT_SHOWCASE_EVOLUTION_CONFIG.timeoutMinutes` from 5 → 20 (the documented justification
permitted by the audit's stop-condition rule). `maxIterations` was lifted in lock-step from
3 000 → 20 000 so wall-clock is the limiter, and the matching test was relaxed from
`assertEquals(timeoutMinutes, 5)` to `assertGreaterOrEqual(timeoutMinutes, 5)` with the #377
justification recorded in the comment.

[AGENTS.md]: ../AGENTS.md

### Measured run

| Metric                   | Before (`Refresh-2026-05` baseline) | After (this PR)                                  |
| ------------------------ | ----------------------------------- | ------------------------------------------------ |
| Generations              | (5 min budget)                      | 14 368                                           |
| Wall-clock               | ≤ 5 min                             | 20 m 17 s                                        |
| Final per-record error   | n/a                                 | 0.1070 (target 0.05 — not reached in backstop)   |
| Final score              | n/a                                 | 0.8930                                           |
| Seed neurons / synapses  | 5 / 4                               | 5 / 4                                            |
| Final neurons / synapses | (smaller)                           | 41 / 230                                         |
| `targetError` / timeout  | 0.05 / 5 min                        | 0.05 / 20 min                                    |

NEAT-AI added substantial structure on top of the minimal seed (5 → 41 neurons, 4 → 230 synapses)
even though the run did not reach `targetError` inside the 20-minute backstop — the long-form
fitness arc plus the topology bars in the milestone summary chart are the headline visual. Issue
#377 explicitly permits raising the PR even with no fitness gain.

## Evidence

```mermaid
flowchart LR
    A["Issue #377<br/>+15m budget"] --> B["timeoutMinutes 5 → 20<br/>maxIterations 3 000 → 20 000"]
    B --> C["./evolution_showcase/run.sh<br/>(fresh minimal seed)"]
    C --> D["Champion 41 neurons / 230 synapses<br/>error 0.1070, score 0.8930"]
    D --> E["📈 evolution_summary.svg regenerated"]
    D --> F["README refreshed<br/>(Latest Measured Run)"]
    style A fill:#bd10e0,stroke:#333,color:#fff
    style B fill:#f5a623,stroke:#333,color:#fff
    style C fill:#4a90d9,stroke:#333,color:#fff
    style D fill:#7ed321,stroke:#333,color:#fff
    style E fill:#50e3c2,stroke:#333,color:#fff
    style F fill:#50e3c2,stroke:#333,color:#fff
```

- `docs/screenshots/evolution_showcase/evolution_summary.svg` — milestone-summary SVG regenerated;
  topology bars show 5 → 41 neurons and 4 → 230 synapses, callouts show final error 0.1070, final
  score 0.8930, generations 14 368, wall clock 20 m 17 s, with the configured stop conditions
  (`targetError=0.05`, `timeoutMinutes=20`) in the caption.
- `./quality.sh < /dev/null` was run end-to-end after the changes and exited cleanly
  (`All examples passed!`).
- The NEAT seed remains `new Creature(INPUT_COUNT, OUTPUT_COUNT)` — no warm start, no hidden hint,
  no resumed checkpoint.

## Test Plan

- `evolution_showcase/evolution_showcase_test.ts::DEFAULT_SHOWCASE_EVOLUTION_CONFIG honours the audit's stop-condition rule`
  — assertion relaxed from `assertEquals(timeoutMinutes, 5)` to `assertGreaterOrEqual(timeoutMinutes, 5)`
  with the issue #377 justification recorded in the comment; the rest of the stop-condition
  contract (positive `targetError`, positive `populationSize`, positive `maxIterations`) is
  unchanged.
- All other `evolution_showcase_test.ts` tests are unchanged and continue to pass via
  `./quality.sh`.
- `./quality.sh < /dev/null` — passes cleanly with the updated defaults.



## Milestone
This PR is part of the **Refresh-2026-05** milestone and targets the `milestone/refresh-2026-05` feature branch.

---

🤖 Processed by: VibeCoderST<!-- vibe-worker-issue-377 -->