### PR TITLE
feat(stock_market): GRQ-style exploration campaign (#476)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -20,7 +20,7 @@
     "@std/testing/mock": "jsr:@std/testing@1.0.18/mock",
     "@std/uuid": "jsr:@std/uuid@1.1.1",
     "@std/yaml": "jsr:@std/yaml@1.1.0",
-    "@stsoftware/neat-ai": "jsr:@stsoftware/neat-ai@5.0.32",
+    "@stsoftware/neat-ai": "jsr:@stsoftware/neat-ai@5.0.34",
     "@stsoftware/tags": "jsr:@stsoftware/tags@1.0.13"
   },
   "lint": {

--- a/deno.lock
+++ b/deno.lock
@@ -22,7 +22,7 @@
     "jsr:@std/testing@1.0.18": "1.0.18",
     "jsr:@std/uuid@1.1.1": "1.1.1",
     "jsr:@std/yaml@1.1.0": "1.1.0",
-    "jsr:@stsoftware/neat-ai@5.0.32": "5.0.32",
+    "jsr:@stsoftware/neat-ai@5.0.34": "5.0.34",
     "jsr:@stsoftware/tags@1.0.13": "1.0.13"
   },
   "jsr": {
@@ -95,8 +95,8 @@
     "@std/yaml@1.1.0": {
       "integrity": "fc1c5c63e05c4c5eb6118355f557958035d41940d6c29d35b306ef7155d6edb0"
     },
-    "@stsoftware/neat-ai@5.0.32": {
-      "integrity": "41785d49deeea746dd5ecd928c12d8dead26852f4518e02488d2d4d70450ba7f",
+    "@stsoftware/neat-ai@5.0.34": {
+      "integrity": "2a35059b51a9bc0b27fbb4e7a1a33ca6711e543d09d8837c1f132eb55a7939de",
       "dependencies": [
         "jsr:@std/assert@1.0.19",
         "jsr:@std/bytes@1.0.6",
@@ -128,7 +128,7 @@
       "jsr:@std/testing@1.0.18",
       "jsr:@std/uuid@1.1.1",
       "jsr:@std/yaml@1.1.0",
-      "jsr:@stsoftware/neat-ai@5.0.32",
+      "jsr:@stsoftware/neat-ai@5.0.34",
       "jsr:@stsoftware/tags@1.0.13"
     ]
   }

--- a/deno.lock
+++ b/deno.lock
@@ -22,7 +22,7 @@
     "jsr:@std/testing@1.0.18": "1.0.18",
     "jsr:@std/uuid@1.1.1": "1.1.1",
     "jsr:@std/yaml@1.1.0": "1.1.0",
-    "jsr:@stsoftware/neat-ai@5.0.30": "5.0.30",
+    "jsr:@stsoftware/neat-ai@5.0.32": "5.0.32",
     "jsr:@stsoftware/tags@1.0.13": "1.0.13"
   },
   "jsr": {
@@ -95,8 +95,8 @@
     "@std/yaml@1.1.0": {
       "integrity": "fc1c5c63e05c4c5eb6118355f557958035d41940d6c29d35b306ef7155d6edb0"
     },
-    "@stsoftware/neat-ai@5.0.30": {
-      "integrity": "b820eccb1d204462f943efff27b00059735d84aa31dcbb0f7c0f8954815b8773",
+    "@stsoftware/neat-ai@5.0.32": {
+      "integrity": "41785d49deeea746dd5ecd928c12d8dead26852f4518e02488d2d4d70450ba7f",
       "dependencies": [
         "jsr:@std/assert@1.0.19",
         "jsr:@std/bytes@1.0.6",
@@ -128,7 +128,7 @@
       "jsr:@std/testing@1.0.18",
       "jsr:@std/uuid@1.1.1",
       "jsr:@std/yaml@1.1.0",
-      "jsr:@stsoftware/neat-ai@5.0.30",
+      "jsr:@stsoftware/neat-ai@5.0.32",
       "jsr:@stsoftware/tags@1.0.13"
     ]
   }

--- a/docs/archive/pr-summaries/pr-summary-476.md
+++ b/docs/archive/pr-summaries/pr-summary-476.md
@@ -1,0 +1,67 @@
+## Summary
+
+Wires the GRQ-style **exploration campaign** pipeline (structure phases →
+polish phase → optional intelligent-design pass) onto `stock_market` as
+the first in-scope example to adopt the pattern from issue #476. The new
+runner subsamples training records during structure phases
+(`trainingSampleRate` 5 → 10 → 15% with a small positive `costOfGrowth`)
+so NEAT-AI grows topology cheaply, then switches to a polish phase
+(`trainingSampleRate = 1`, `costOfGrowth = 0`) for honest weight/bias
+tuning. After every phase the champion is scored against the **full**
+train, validation, and test windows via the existing
+`directionalAccuracy` and `balancedDirectionalAccuracy` helpers, so the
+recorded series stays apples-to-apples across phases. All artefacts land
+under `.synthetic-stock/exploration/` (hidden, gitignored); `--promote`
+copies the champion + summary to `docs/data/stock_market/exploration/`.
+
+Also fixes a pre-existing `deno.lock` drift (the lock pinned
+`@stsoftware/neat-ai@5.0.30` while `deno.json` already pinned `5.0.32`,
+which would have broken `quality.sh --frozen` once any test imported the
+bump).
+
+Closes #476.
+
+## Evidence
+
+CLI / orchestration change with no UI surface — verified via the unit
+tests below. Mermaid diagram added to
+`stock_market/README.md` (new "GRQ-Style Exploration Campaign" section)
+showing the phase pipeline and the hidden-dir → promote-dir flow:
+
+```mermaid
+flowchart LR
+    SEED["new Creature(10, 1)"] --> S1["structure 5%"]
+    S1 --> S2["structure 10%"] --> S3["structure 15%"] --> POL["polish"]
+    POL --> SQ["optional squash scan"]
+    POL --> SCORE["full train/val/test scoring"]
+    SCORE --> WORK[".synthetic-stock/exploration/"]
+    WORK -. --promote .-> PROMOTE["docs/data/stock_market/exploration/"]
+```
+
+Full `deno test` run: **916 passed | 0 failed (1m5s)**. The eight new
+exploration-campaign tests verify (a) `DEFAULT_EXPLORATION_PHASES`
+structure-then-polish shape, (b) one phase record per configured phase,
+(c) full-split scoring after every phase, (d) `champion.json` +
+`summary.json` written into the working dir, (e) no implicit promotion,
+(f) `promoteExplorationArtefacts` copies champion + summary to the
+promote dir, and (g, h) range checks on `phases` / `trainingSampleRate`.
+
+## Test Plan
+
+New tests in `stock_market/exploration_campaign_test.ts`:
+
+- `DEFAULT_EXPLORATION_PHASES has structure phases before a polish phase`
+- `runExplorationCampaign returns one phase record per configured phase`
+- `runExplorationCampaign scores the champion on full train / val / test after every phase`
+- `runExplorationCampaign writes champion + summary into the working dir`
+- `runExplorationCampaign does not promote unless an explicit promote dir is provided`
+- `promoteExplorationArtefacts copies champion + summary from working dir to promote dir`
+- `runExplorationCampaign throws when phases is empty`
+- `runExplorationCampaign throws when trainingSampleRate is out of range`
+
+Manual verification:
+
+- `deno lint` — clean across 136 files.
+- `deno fmt --check` — clean across 392 files.
+- `deno check **/*.ts` — clean.
+- `deno test --frozen ...` — 916 / 916 pass.

--- a/stock_market/README.md
+++ b/stock_market/README.md
@@ -165,6 +165,92 @@ Artefacts:
   (`renderMultiRunComplexityChartSVG` from
   [`common/multi_run_complexity_chart.ts`](../common/multi_run_complexity_chart.ts))
 
+## 🧭 GRQ-Style Exploration Campaign (issue #476)
+
+The standard `run.sh` invocation evolves the full training set with a single set of NEAT options.
+That works when the task is well understood and a single sensible schedule converges quickly. For
+the "unknown problem" narrative — when you do not yet know how much topology the task needs — issue
+[#476](https://github.com/stSoftwareAU/NEAT-AI-Examples/issues/476) wires a second runner that
+deliberately separates **structure discovery** from **weight polishing**, mirroring the GRQ-style
+sampler pattern.
+
+```bash
+# Tiny smoke test — finishes in under a minute on a developer machine.
+./stock_market/exploration_campaign.sh --fast
+
+# Full campaign — runs the structure → polish schedule on the real dataset.
+./stock_market/exploration_campaign.sh
+
+# Also run scanForSquashImprovements on the polished champion.
+./stock_market/exploration_campaign.sh --squash-scan
+
+# Promote the resulting champion + summary to docs/data/ (otherwise the
+# artefacts stay under the hidden working dir).
+./stock_market/exploration_campaign.sh --promote
+```
+
+```mermaid
+flowchart LR
+    SEED["🌱 new Creature(10, 1)<br/>uniform-random seed"]
+    S1["🪵 Structure phase 1<br/>sampleRate=0.05<br/>costOfGrowth=1e-6"]
+    S2["🪵 Structure phase 2<br/>sampleRate=0.10<br/>costOfGrowth=1e-6"]
+    S3["🪵 Structure phase 3<br/>sampleRate=0.15<br/>costOfGrowth=1e-6"]
+    POL["✨ Polish phase<br/>sampleRate=1<br/>costOfGrowth=0"]
+    SQ["🧪 Optional squash scan<br/>(scanForSquashImprovements)"]
+    SCORE["🎯 Honest scoring<br/>full train / val / test<br/>after every phase"]
+    WORK["🗂️ .synthetic-stock/exploration/<br/>(hidden, gitignored)"]
+    PROMOTE["🚚 docs/data/stock_market/exploration/<br/>(only on --promote)"]
+
+    SEED --> S1 --> S2 --> S3 --> POL --> SQ
+    POL --> SCORE
+    S1 --> SCORE
+    S2 --> SCORE
+    S3 --> SCORE
+    SQ --> SCORE
+    SCORE --> WORK
+    WORK -. --promote .-> PROMOTE
+
+    style SEED fill:#bd10e0,stroke:#333,color:#fff
+    style S1 fill:#e67e22,stroke:#333,color:#fff
+    style S2 fill:#e67e22,stroke:#333,color:#fff
+    style S3 fill:#e67e22,stroke:#333,color:#fff
+    style POL fill:#1abc9c,stroke:#333,color:#fff
+    style SQ fill:#9b59b6,stroke:#333,color:#fff
+    style SCORE fill:#f5a623,stroke:#333,color:#fff
+    style WORK fill:#7ed321,stroke:#333,color:#fff
+    style PROMOTE fill:#4a90d9,stroke:#333,color:#fff
+```
+
+What each piece does:
+
+- **Structure phases.** Three short bursts that subsample the training set heavily
+  (`trainingSampleRate` 5 → 10 → 15%) and pay a very small but positive `costOfGrowth`. Many
+  generations land per wall-clock minute because each generation's fitness eval is cheap, and the
+  cost term keeps NEAT-AI biased toward genuinely useful add-neuron / add-synapse moves.
+- **Polish phase.** Full training set (`trainingSampleRate = 1`) with `costOfGrowth = 0`, so the
+  remaining wall-clock is spent on weight and bias tuning rather than topology growth.
+- **Optional intelligent design (`--squash-scan`).** Runs `scanForSquashImprovements` and
+  `combineImprovements` on the polished champion — useful when activation function choice matters.
+- **Honest scoring.** Subsampling only affects training fitness. After every phase the champion is
+  evaluated on the **full** train, validation, and test windows using `directionalAccuracy` and
+  `balancedDirectionalAccuracy`, so the recorded series is apples-to-apples across phases.
+- **Hidden working state.** Every artefact (per-phase records, `champion.json`, `summary.json`,
+  optional `squash_scan.json`) lands under `.synthetic-stock/exploration/`. The directory is
+  gitignored — exploration runs never pollute the working tree.
+- **Explicit promote.** Pass `--promote` to copy the champion and summary into
+  `docs/data/stock_market/exploration/`. Without that flag the canonical artefacts stay untouched,
+  so a casual local run cannot silently overwrite documented numbers.
+
+The campaign deliberately starts from `new Creature(WINDOW_SIZE, 1)` every time — no warm start,
+consistent with the project-wide
+[no-warm-starts](../AGENTS.md#-no-warm-starts--evolution-must-start-from-random-noise) policy.
+
+The pattern lives in [`stock_market/exploration_campaign.ts`](exploration_campaign.ts); the CLI
+surface and shell wrapper sit in [`exploration_campaign_cli.ts`](exploration_campaign_cli.ts) and
+[`exploration_campaign.sh`](exploration_campaign.sh). When a second in-scope example adopts the
+pipeline and the duplication exceeds ~100 lines, the orchestrator will move to `common/` (acceptance
+criterion from issue #476).
+
 ## Evolution Progress (Multi-Run)
 
 Per issue [#298](https://github.com/stSoftwareAU/NEAT-AI-Examples/issues/298) NEAT-AI surfaces only

--- a/stock_market/exploration_campaign.sh
+++ b/stock_market/exploration_campaign.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Stock-Market GRQ-style exploration campaign (issue #476).
+#
+# Runs the structure → polish phase schedule defined in
+# `exploration_campaign.ts` against the public S&P 500 monthly-close
+# dataset. All artefacts land under `.synthetic-stock/exploration/`
+# (hidden, gitignored). Pass `--promote` to copy the champion + summary
+# into `docs/data/stock_market/exploration/`.
+#
+# Usage:
+#   ./stock_market/exploration_campaign.sh              # full campaign, no promote
+#   ./stock_market/exploration_campaign.sh --fast       # tiny smoke test
+#   ./stock_market/exploration_campaign.sh --promote    # promote artefacts
+#   ./stock_market/exploration_campaign.sh --squash-scan --promote
+#
+# ⚠️ Teaching example only — not investment advice.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd -P)"
+cd "${REPO_ROOT}"
+
+# shellcheck source=common/example_runner_preamble.sh
+source "${REPO_ROOT}/common/example_runner_preamble.sh"
+
+echo "📈 Stock Market — GRQ-style exploration campaign"
+echo ""
+
+deno run \
+  "${NEAT_EXAMPLE_DENO_FLAGS[@]}" \
+  --allow-env="${NEAT_AI_ENV_VARS},STOCK_QUICK,NEAT_MULTI_RUN_BASE_DIR" \
+  --allow-net=raw.githubusercontent.com,jsr.io \
+  ${ALLOW_RUN_ARGS[@]+"${ALLOW_RUN_ARGS[@]}"} \
+  stock_market/exploration_campaign_cli.ts \
+  "$@"

--- a/stock_market/exploration_campaign.ts
+++ b/stock_market/exploration_campaign.ts
@@ -1,0 +1,512 @@
+/**
+ * GRQ-style exploration campaign for the stock-market direction
+ * prediction example (issue #476).
+ *
+ * The campaign runs a sequence of **structure phases** (random training
+ * subsamples with low `costOfGrowth` so NEAT-AI grows topology cheaply)
+ * followed by a **polish phase** (full training set with
+ * `costOfGrowth = 0` so weights and biases get a long, undistorted tune)
+ * and optionally an **intelligent-design pass** that scans the polished
+ * champion for activation-function (squash) improvements.
+ *
+ * After every phase the champion is honestly scored against the *full*
+ * train, validation, and test windows — the per-phase
+ * `trainingSampleRate` only affects training fitness, not the reported
+ * metrics. The reader of the campaign log therefore sees the same
+ * apples-to-apples accuracy series across every phase.
+ *
+ * All artefacts (per-phase records, champion JSON, run summary) are
+ * written under the supplied `workingDir`, which the runner script
+ * points at the hidden `.synthetic-stock/exploration/` directory so
+ * nothing leaks into the working tree. The canonical
+ * `docs/data/stock_market/exploration/` directory is updated only when
+ * the caller invokes {@link promoteExplorationArtefacts} (wired to the
+ * runner's `--promote` flag).
+ *
+ * 🌱 Generation 1 of the first phase starts from `new Creature(
+ * WINDOW_SIZE, OUTPUT_COUNT)` — the NEAT-AI library's uniform-random
+ * constructor. No hidden hint, no pretrained champion, no warm start.
+ * Subsequent phases inherit the previous phase's evolved champion in
+ * place (NEAT-AI's `Creature.evolveDir` mutates the calling creature).
+ */
+import { copy, ensureDirSync } from "@std/fs";
+import { join } from "@std/path";
+import {
+  alternativeSquashes,
+  combineImprovements,
+  Creature,
+  type CreatureExport,
+  type NeatOptions,
+  safeWriteJson,
+  scanForSquashImprovements,
+} from "@stsoftware/neat-ai";
+
+import {
+  balancedDirectionalAccuracy,
+  directionalAccuracy,
+  OUTPUT_COUNT,
+  WINDOW_SIZE,
+  writeStockTrainingDataset,
+} from "./stock_market.ts";
+import type { DataSplit, Sample } from "./data.ts";
+
+/** Slug used by the canonical promote-dir layout. */
+export const EXAMPLE_SLUG = "stock_market";
+
+/** Default hidden working directory the runner script points us at. */
+export const DEFAULT_WORKING_DIR = ".synthetic-stock/exploration";
+
+/** Default promote-target inside `docs/data/`. */
+export const DEFAULT_PROMOTE_DIR = "docs/data/stock_market/exploration";
+
+/** One phase of the exploration campaign. */
+export interface ExplorationPhase {
+  /** Human-readable phase label, used in summaries and on disk. */
+  name: string;
+  /**
+   * Fraction of training records NEAT-AI samples each generation
+   * (forwarded as `NeatOptions.trainingSampleRate`). Must lie in
+   * (0, 1]. Structure phases use 0.05–0.15; the polish phase uses 1.
+   */
+  trainingSampleRate: number;
+  /**
+   * `NeatOptions.costOfGrowth`. Structure phases use a very small but
+   * non-zero value so NEAT-AI keeps adding neurons / synapses quickly;
+   * the polish phase uses 0 so weight tuning is undistorted.
+   */
+  costOfGrowth: number;
+  /** Hard generation cap for this phase. */
+  maxGenerations: number;
+  /**
+   * Wall-clock cap for the phase, in minutes. Tests pass 0 to skip
+   * NEAT-AI's GPU/discovery FFI cleanup path (the Deno test sanitiser
+   * flags its dynamic library as a leak).
+   */
+  timeoutMinutes: number;
+}
+
+/**
+ * Default phase schedule mirroring the GRQ-style sampler pattern
+ * referenced in issue #476: three structure phases that escalate the
+ * training subsample (5% → 10% → 15%) followed by a long polish at full
+ * data with `costOfGrowth = 0`.
+ */
+export const DEFAULT_EXPLORATION_PHASES: readonly ExplorationPhase[] = [
+  {
+    name: "structure-05pct",
+    trainingSampleRate: 0.05,
+    costOfGrowth: 0.000001,
+    maxGenerations: 50,
+    timeoutMinutes: 2,
+  },
+  {
+    name: "structure-10pct",
+    trainingSampleRate: 0.10,
+    costOfGrowth: 0.000001,
+    maxGenerations: 50,
+    timeoutMinutes: 2,
+  },
+  {
+    name: "structure-15pct",
+    trainingSampleRate: 0.15,
+    costOfGrowth: 0.000001,
+    maxGenerations: 50,
+    timeoutMinutes: 2,
+  },
+  {
+    name: "polish",
+    trainingSampleRate: 1,
+    costOfGrowth: 0,
+    maxGenerations: 200,
+    timeoutMinutes: 5,
+  },
+];
+
+/** Outcome of a single phase, including honest hold-out scores. */
+export interface PhaseRecord {
+  name: string;
+  trainingSampleRate: number;
+  costOfGrowth: number;
+  generations: number;
+  wallClockMs: number;
+  /** Final per-record error reported by `evolveDir`. */
+  trainError: number;
+  /** Final score reported by `evolveDir`. */
+  finalScore: number;
+  finalNeurons: number;
+  finalSynapses: number;
+  /** Raw directional accuracy on the **full** training window. */
+  trainAccuracy: number;
+  /** Balanced directional accuracy on the **full** training window. */
+  trainBalanced: number;
+  /** Raw directional accuracy on the validation window. */
+  validationAccuracy: number;
+  /** Balanced directional accuracy on the validation window. */
+  validationBalanced: number;
+  /** Raw directional accuracy on the test window. */
+  testAccuracy: number;
+  /** Balanced directional accuracy on the test window. */
+  testBalanced: number;
+}
+
+/** Optional squash-scan record appended to the summary. */
+export interface SquashScanRecord {
+  targetSquash: string;
+  tested: number;
+  improved: number;
+  applied: boolean;
+  baselineScore: number;
+  improvedScore: number | null;
+  durationMs: number;
+}
+
+/** Full run summary persisted to `summary.json`. */
+export interface ExplorationSummary {
+  slug: string;
+  startedAt: string;
+  finishedAt: string;
+  totalWallClockMs: number;
+  trainSize: number;
+  validationSize: number;
+  testSize: number;
+  phases: PhaseRecord[];
+  squashScan: SquashScanRecord | null;
+  championNeurons: number;
+  championSynapses: number;
+  seedNeurons: number;
+  seedSynapses: number;
+}
+
+/** Configuration for {@link runExplorationCampaign}. */
+export interface RunExplorationCampaignOptions {
+  /** Chronological train / validation / test split. */
+  split: DataSplit;
+  /** Feature window size; defaults to {@link WINDOW_SIZE}. */
+  windowSize?: number;
+  /**
+   * Hidden working directory the campaign writes into. The runner
+   * script defaults to {@link DEFAULT_WORKING_DIR}.
+   */
+  workingDir: string;
+  /** RNG seed forwarded to every NEAT-AI evolveDir call. */
+  seed?: number;
+  /** NEAT population size used for every phase. */
+  populationSize?: number;
+  /** Phase schedule; defaults to {@link DEFAULT_EXPLORATION_PHASES}. */
+  phases?: readonly ExplorationPhase[];
+  /** When true, runs `scanForSquashImprovements` on the polish champion. */
+  squashScan?: boolean;
+  /** Optional override for the squash scan's target activation. */
+  squashScanTarget?: string;
+  /** Optional override for the mutation rate forwarded to NEAT-AI. */
+  mutationRate?: number;
+  /** Optional override for the mutation amount forwarded to NEAT-AI. */
+  mutationAmount?: number;
+  /** Optional logger; defaults to `console.log`. Tests pass `() => {}`. */
+  log?: (msg: string) => void;
+}
+
+/** Combined result returned by {@link runExplorationCampaign}. */
+export interface ExplorationResult {
+  summary: ExplorationSummary;
+  champion: Creature;
+  /** Always false from the campaign itself — see {@link promoteExplorationArtefacts}. */
+  promoted: boolean;
+}
+
+function validatePhase(phase: ExplorationPhase, index: number): void {
+  if (phase.trainingSampleRate <= 0 || phase.trainingSampleRate > 1) {
+    throw new Error(
+      `phase[${index}] (${phase.name}): trainingSampleRate must be in (0, 1], ` +
+        `got ${phase.trainingSampleRate}`,
+    );
+  }
+  if (phase.costOfGrowth < 0) {
+    throw new Error(
+      `phase[${index}] (${phase.name}): costOfGrowth must be >= 0, ` +
+        `got ${phase.costOfGrowth}`,
+    );
+  }
+  if (phase.maxGenerations <= 0) {
+    throw new Error(
+      `phase[${index}] (${phase.name}): maxGenerations must be > 0, ` +
+        `got ${phase.maxGenerations}`,
+    );
+  }
+  if (phase.timeoutMinutes < 0) {
+    throw new Error(
+      `phase[${index}] (${phase.name}): timeoutMinutes must be >= 0, ` +
+        `got ${phase.timeoutMinutes}`,
+    );
+  }
+}
+
+function scoreOnSplit(creature: Creature, samples: Sample[]): {
+  accuracy: number;
+  balanced: number;
+} {
+  if (samples.length === 0) return { accuracy: 0, balanced: 0 };
+  return {
+    accuracy: directionalAccuracy(creature, samples),
+    balanced: balancedDirectionalAccuracy(creature, samples),
+  };
+}
+
+/**
+ * Run the full structure → polish campaign and return a structured
+ * summary plus the evolved champion.
+ *
+ * The function:
+ *   1. Writes the **full** training samples to `<workingDir>/data/` as
+ *      a single binary `.bin` file. NEAT-AI's `trainingSampleRate`
+ *      handles per-generation subsampling; we never split the dataset.
+ *   2. Seeds gen 1 of the first phase from
+ *      `new Creature(windowSize, OUTPUT_COUNT)`.
+ *   3. For each phase, mutates the creature in place via
+ *      `creature.evolveDir(...)` and then scores it against the full
+ *      train, validation, and test windows.
+ *   4. Persists per-phase records and a final summary to the working
+ *      directory; the champion is saved as `champion.json` after every
+ *      phase so an interrupted run still leaves the best-so-far on disk.
+ */
+export async function runExplorationCampaign(
+  options: RunExplorationCampaignOptions,
+): Promise<ExplorationResult> {
+  const phases = options.phases ?? DEFAULT_EXPLORATION_PHASES;
+  if (phases.length === 0) {
+    throw new Error("runExplorationCampaign: at least one phase is required");
+  }
+  phases.forEach(validatePhase);
+
+  if (options.split.train.length === 0) {
+    throw new Error("runExplorationCampaign: split.train must be non-empty");
+  }
+
+  const log = options.log ?? ((msg: string) => console.log(msg));
+  const windowSize = options.windowSize ?? WINDOW_SIZE;
+  const seed = options.seed ?? 24601;
+  const populationSize = options.populationSize ?? 30;
+  const mutationRate = options.mutationRate ?? 0.6;
+  const mutationAmount = options.mutationAmount ?? 3;
+
+  ensureDirSync(options.workingDir);
+  const dataDir = join(options.workingDir, "data");
+  ensureDirSync(dataDir);
+
+  // Write the FULL training set; NEAT-AI subsamples per generation via
+  // `trainingSampleRate` so the honest hold-out scores after every phase
+  // remain comparable.
+  writeStockTrainingDataset(options.split.train, dataDir, windowSize);
+
+  const creature = new Creature(windowSize, OUTPUT_COUNT);
+  // Pin the output activation to LOGISTIC so the `>= 0.5` directional
+  // threshold (and the multi-run example's convention) keeps working.
+  const seedJson: CreatureExport = creature.exportJSON();
+  for (const neuron of seedJson.neurons) {
+    if (neuron.type === "output") neuron.squash = "LOGISTIC";
+  }
+  const seededCreature = Creature.fromJSON(seedJson);
+  const seedNeurons = seededCreature.neurons.length;
+  const seedSynapses = seededCreature.synapses.length;
+
+  const startedAt = new Date();
+  const campaignStartMs = Date.now();
+  const phaseRecords: PhaseRecord[] = [];
+
+  let cursor: Creature = seededCreature;
+
+  for (let i = 0; i < phases.length; i++) {
+    const phase = phases[i];
+    log(
+      `▶ Phase ${i + 1}/${phases.length} ${phase.name} ` +
+        `sampleRate=${phase.trainingSampleRate} costOfGrowth=${phase.costOfGrowth} ` +
+        `gens<=${phase.maxGenerations} timeout=${phase.timeoutMinutes}m`,
+    );
+
+    const neatOptions: NeatOptions = {
+      seed,
+      populationSize,
+      iterations: phase.maxGenerations,
+      targetError: 0,
+      ...(phase.timeoutMinutes > 0
+        ? { timeoutMinutes: Math.max(1, Math.floor(phase.timeoutMinutes)) }
+        : {}),
+      trainingSampleRate: phase.trainingSampleRate,
+      costOfGrowth: phase.costOfGrowth,
+      mutationRate,
+      mutationAmount,
+      verbose: false,
+      log: 0,
+      threads: 1,
+    };
+
+    const phaseStart = Date.now();
+    const evolved = await cursor.evolveDir(dataDir, neatOptions);
+    const wallClockMs = Date.now() - phaseStart;
+
+    const trainScore = scoreOnSplit(cursor, options.split.train);
+    const valScore = scoreOnSplit(cursor, options.split.validation);
+    const testScore = scoreOnSplit(cursor, options.split.test);
+
+    const record: PhaseRecord = {
+      name: phase.name,
+      trainingSampleRate: phase.trainingSampleRate,
+      costOfGrowth: phase.costOfGrowth,
+      generations: Math.max(1, evolved.generation ?? 1),
+      wallClockMs,
+      trainError: Number.isFinite(evolved.error) ? evolved.error : 0,
+      finalScore: Number.isFinite(evolved.score) ? evolved.score : 0,
+      finalNeurons: cursor.neurons.length,
+      finalSynapses: cursor.synapses.length,
+      trainAccuracy: trainScore.accuracy,
+      trainBalanced: trainScore.balanced,
+      validationAccuracy: valScore.accuracy,
+      validationBalanced: valScore.balanced,
+      testAccuracy: testScore.accuracy,
+      testBalanced: testScore.balanced,
+    };
+    phaseRecords.push(record);
+    log(
+      `   gen=${record.generations} err=${record.trainError.toPrecision(4)} ` +
+        `neurons=${record.finalNeurons} synapses=${record.finalSynapses} | ` +
+        `train=${(record.trainBalanced * 100).toFixed(1)}% bal ` +
+        `val=${(record.validationBalanced * 100).toFixed(1)}% bal ` +
+        `test=${(record.testBalanced * 100).toFixed(1)}% bal`,
+    );
+
+    await safeWriteJson(
+      join(options.workingDir, `phase_${i + 1}_${phase.name}.json`),
+      record,
+    );
+    // Persist the best-so-far champion every phase so an interrupted
+    // run leaves a usable artefact on disk.
+    await safeWriteJson(join(options.workingDir, "champion.json"), cursor.exportJSON());
+  }
+
+  // Optional squash scan on the polished champion.
+  let squashScan: SquashScanRecord | null = null;
+  if (options.squashScan) {
+    const target = options.squashScanTarget ?? "GELU";
+    log(`▶ Squash scan: target=${target} pool=${alternativeSquashes.length}`);
+    const baselineResult = await cursor.scoreDir(dataDir, {});
+    const baselineScore = baselineResult.score;
+    const outputDir = join(options.workingDir, "squash");
+    ensureDirSync(outputDir);
+    const scanStart = Date.now();
+    const scan = await scanForSquashImprovements({
+      creature: cursor.exportJSON(),
+      targetSquash: target,
+      outputDir,
+      dataDir,
+      bestScore: baselineScore,
+      maxImprovements: 5,
+      timeoutMs: 5 * 60 * 1000,
+    });
+    let improvedScore: number | null = null;
+    let applied = false;
+    if (scan.improvements.size > 0) {
+      const { creature: improvedExport } = await combineImprovements(
+        cursor.exportJSON(),
+        scan.improvements,
+        dataDir,
+        baselineScore,
+      );
+      cursor = Creature.fromJSON(improvedExport);
+      const replay = await cursor.scoreDir(dataDir, {});
+      improvedScore = replay.score;
+      applied = improvedScore > baselineScore;
+    }
+    squashScan = {
+      targetSquash: target,
+      tested: scan.tested,
+      improved: scan.improved,
+      applied,
+      baselineScore,
+      improvedScore,
+      durationMs: Date.now() - scanStart,
+    };
+    log(
+      `   tested=${scan.tested} improved=${scan.improved} applied=${applied} ` +
+        `baseline=${baselineScore.toPrecision(4)} -> ` +
+        `${improvedScore === null ? "n/a" : improvedScore.toPrecision(4)}`,
+    );
+    await safeWriteJson(join(options.workingDir, "squash_scan.json"), squashScan);
+    await safeWriteJson(join(options.workingDir, "champion.json"), cursor.exportJSON());
+  }
+
+  const finishedAt = new Date();
+  const summary: ExplorationSummary = {
+    slug: EXAMPLE_SLUG,
+    startedAt: startedAt.toISOString(),
+    finishedAt: finishedAt.toISOString(),
+    totalWallClockMs: Date.now() - campaignStartMs,
+    trainSize: options.split.train.length,
+    validationSize: options.split.validation.length,
+    testSize: options.split.test.length,
+    phases: phaseRecords,
+    squashScan,
+    championNeurons: cursor.neurons.length,
+    championSynapses: cursor.synapses.length,
+    seedNeurons,
+    seedSynapses,
+  };
+  await safeWriteJson(join(options.workingDir, "summary.json"), summary);
+
+  return { summary, champion: cursor, promoted: false };
+}
+
+/** Options for {@link promoteExplorationArtefacts}. */
+export interface PromoteOptions {
+  /** Working directory the campaign wrote into. */
+  workingDir: string;
+  /**
+   * Promote target — typically `docs/data/stock_market/exploration/`.
+   * Created if it does not exist.
+   */
+  promoteDir: string;
+}
+
+/**
+ * Copy `champion.json`, `summary.json`, and any `phase_*.json` records
+ * from the hidden working directory to the promote target. Returns
+ * `true` when the promote happens, `false` if there is nothing to copy.
+ *
+ * The campaign deliberately does **not** call this itself — the runner
+ * script wires it to an explicit `--promote` flag so a casual local
+ * exploration run never overwrites the canonical artefacts under
+ * `docs/data/`.
+ */
+export async function promoteExplorationArtefacts(
+  options: PromoteOptions,
+): Promise<boolean> {
+  const championSrc = join(options.workingDir, "champion.json");
+  const summarySrc = join(options.workingDir, "summary.json");
+  try {
+    await Deno.stat(championSrc);
+    await Deno.stat(summarySrc);
+  } catch {
+    return false;
+  }
+  ensureDirSync(options.promoteDir);
+  await copy(championSrc, join(options.promoteDir, "champion.json"), { overwrite: true });
+  await copy(summarySrc, join(options.promoteDir, "summary.json"), { overwrite: true });
+
+  // Copy every per-phase record so the promoted snapshot is complete.
+  for await (const entry of Deno.readDir(options.workingDir)) {
+    if (entry.isFile && entry.name.startsWith("phase_") && entry.name.endsWith(".json")) {
+      await copy(
+        join(options.workingDir, entry.name),
+        join(options.promoteDir, entry.name),
+        { overwrite: true },
+      );
+    }
+    if (entry.isFile && entry.name === "squash_scan.json") {
+      await copy(
+        join(options.workingDir, entry.name),
+        join(options.promoteDir, entry.name),
+        { overwrite: true },
+      );
+    }
+  }
+  return true;
+}

--- a/stock_market/exploration_campaign_cli.ts
+++ b/stock_market/exploration_campaign_cli.ts
@@ -1,0 +1,149 @@
+/**
+ * CLI entry point for the GRQ-style exploration campaign (issue #476).
+ *
+ * Usage (typically via `stock_market/exploration_campaign.sh`):
+ *
+ *     deno run ... exploration_campaign_cli.ts [--promote] [--squash-scan]
+ *                                              [--squash-target=GELU]
+ *                                              [--fast]
+ *                                              [--working-dir=PATH]
+ *                                              [--promote-dir=PATH]
+ *
+ * The working directory defaults to {@link DEFAULT_WORKING_DIR} (hidden,
+ * gitignored). The promote target defaults to {@link DEFAULT_PROMOTE_DIR}
+ * under `docs/data/` and is only written when `--promote` is supplied.
+ *
+ * `--fast` swaps the default phase schedule for a tiny set so a local
+ * smoke test finishes inside a minute.
+ */
+import { parseArgs } from "@std/cli";
+import { format } from "@std/fmt/duration";
+
+import { buildSamples, splitChronologically } from "./data.ts";
+import { fetchDataset } from "../common/data_cache.ts";
+import {
+  DATASET_PATH,
+  DATASET_SHA256,
+  DATASET_URL,
+  loadPrices,
+  WINDOW_SIZE,
+} from "./stock_market.ts";
+import {
+  DEFAULT_PROMOTE_DIR,
+  DEFAULT_WORKING_DIR,
+  type ExplorationPhase,
+  promoteExplorationArtefacts,
+  runExplorationCampaign,
+} from "./exploration_campaign.ts";
+
+/** Tiny phase schedule used by `--fast`. */
+const FAST_PHASES: ExplorationPhase[] = [
+  {
+    name: "structure-fast",
+    trainingSampleRate: 0.1,
+    costOfGrowth: 0.000001,
+    maxGenerations: 5,
+    timeoutMinutes: 1,
+  },
+  {
+    name: "polish-fast",
+    trainingSampleRate: 1,
+    costOfGrowth: 0,
+    maxGenerations: 5,
+    timeoutMinutes: 1,
+  },
+];
+
+if (import.meta.main) {
+  const args = parseArgs(Deno.args, {
+    boolean: ["promote", "squash-scan", "fast"],
+    string: ["squash-target", "working-dir", "promote-dir"],
+    default: {
+      "squash-target": "GELU",
+      "working-dir": DEFAULT_WORKING_DIR,
+      "promote-dir": DEFAULT_PROMOTE_DIR,
+    },
+  });
+
+  const workingDir = String(args["working-dir"]);
+  const promoteDir = String(args["promote-dir"]);
+
+  console.log("🧬 Stock Market — GRQ-style exploration campaign (issue #476)");
+  console.log(`   working dir : ${workingDir}`);
+  console.log(`   promote     : ${args.promote ? promoteDir : "(disabled — pass --promote)"}`);
+  console.log(`   squash scan : ${args["squash-scan"] ? args["squash-target"] : "off"}`);
+  console.log(`   fast mode   : ${args.fast ? "yes" : "no"}`);
+
+  // Load the public S&P 500 dataset (cached on first run).
+  await fetchDataset({
+    url: DATASET_URL,
+    path: DATASET_PATH,
+    sha256: DATASET_SHA256,
+  });
+  const prices = await loadPrices(DATASET_PATH);
+  console.log(
+    `   prices      : ${prices.length} points (${prices[0].date} → ` +
+      `${prices[prices.length - 1].date})`,
+  );
+
+  const samples = buildSamples(prices, { windowSize: WINDOW_SIZE });
+  const split = splitChronologically(samples, {
+    trainFraction: 0.7,
+    validationFraction: 0.15,
+  });
+  console.log(
+    `   split       : train=${split.train.length} val=${split.validation.length} ` +
+      `test=${split.test.length}`,
+  );
+
+  const started = Date.now();
+  const result = await runExplorationCampaign({
+    split,
+    windowSize: WINDOW_SIZE,
+    workingDir,
+    seed: 24601,
+    populationSize: args.fast ? 6 : 30,
+    phases: args.fast ? FAST_PHASES : undefined,
+    squashScan: args["squash-scan"] === true,
+    squashScanTarget: String(args["squash-target"]),
+  });
+
+  console.log("\n=== Campaign summary ===");
+  for (let i = 0; i < result.summary.phases.length; i++) {
+    const phase = result.summary.phases[i];
+    console.log(
+      `  ${i + 1}. ${phase.name.padEnd(20)} gens=${phase.generations.toString().padStart(4)} ` +
+        `err=${phase.trainError.toPrecision(4)} ` +
+        `neurons=${phase.finalNeurons} synapses=${phase.finalSynapses} | ` +
+        `train=${(phase.trainBalanced * 100).toFixed(1)}% ` +
+        `val=${(phase.validationBalanced * 100).toFixed(1)}% ` +
+        `test=${(phase.testBalanced * 100).toFixed(1)}% (balanced)`,
+    );
+  }
+  if (result.summary.squashScan) {
+    const s = result.summary.squashScan;
+    console.log(
+      `  squash      tested=${s.tested} improved=${s.improved} applied=${s.applied} ` +
+        `baseline=${s.baselineScore.toPrecision(4)} -> ` +
+        `${s.improvedScore === null ? "n/a" : s.improvedScore.toPrecision(4)}`,
+    );
+  }
+
+  if (args.promote) {
+    const promoted = await promoteExplorationArtefacts({ workingDir, promoteDir });
+    console.log(
+      promoted
+        ? `🚚 Promoted champion + summary to ${promoteDir}`
+        : `⚠️  Nothing promoted — ${workingDir} is missing champion or summary`,
+    );
+  } else {
+    console.log(
+      "ℹ️  Run again with --promote to copy champion + summary into " +
+        `${promoteDir}`,
+    );
+  }
+
+  console.log(
+    `\n🏁 Completed in ${format(Date.now() - started, { ignoreZero: true })}`,
+  );
+}

--- a/stock_market/exploration_campaign_test.ts
+++ b/stock_market/exploration_campaign_test.ts
@@ -1,0 +1,244 @@
+/**
+ * Unit tests for the GRQ-style exploration campaign wired under issue
+ * #476. Each test exercises {@link runExplorationCampaign} (or a CLI
+ * helper) against a tiny synthetic price split with phase counts kept
+ * small so the suite runs well inside the 120s budget.
+ *
+ * The campaign mirrors the GRQ pattern: structure phases (random
+ * training subsamples + low costOfGrowth so NEAT-AI grows topology
+ * cheaply) followed by a polish phase (full training set, costOfGrowth
+ * = 0) — and honest scoring of the evolved champion on the full train,
+ * validation, and test windows after every phase.
+ */
+import { assert, assertEquals, assertGreaterOrEqual } from "@std/assert";
+import { existsSync } from "@std/fs";
+import { join } from "@std/path";
+
+import { createDeterministicRandom } from "../common/deterministic_random.ts";
+import { buildSamples, type DataSplit, splitChronologically } from "./data.ts";
+import {
+  DEFAULT_EXPLORATION_PHASES,
+  type ExplorationPhase,
+  promoteExplorationArtefacts,
+  runExplorationCampaign,
+} from "./exploration_campaign.ts";
+
+function syntheticPrices(n: number, seed = 1): { date: string; close: number }[] {
+  const rng = createDeterministicRandom(seed);
+  const points: { date: string; close: number }[] = [];
+  let p = 100;
+  for (let i = 0; i < n; i++) {
+    points.push({ date: `2020-01-${(i + 1).toString().padStart(2, "0")}`, close: p });
+    const shock = (rng() - 0.45) * 0.04;
+    p = Math.max(1, p * (1 + shock));
+  }
+  return points;
+}
+
+function buildTinySplit(windowSize = 5): DataSplit {
+  const prices = syntheticPrices(220, 11);
+  const samples = buildSamples(prices, { windowSize });
+  return splitChronologically(samples, { trainFraction: 0.7, validationFraction: 0.15 });
+}
+
+const TINY_PHASES: ExplorationPhase[] = [
+  {
+    name: "structure",
+    trainingSampleRate: 0.5,
+    costOfGrowth: 0.000001,
+    maxGenerations: 2,
+    timeoutMinutes: 0,
+  },
+  {
+    name: "polish",
+    trainingSampleRate: 1,
+    costOfGrowth: 0,
+    maxGenerations: 2,
+    timeoutMinutes: 0,
+  },
+];
+
+Deno.test("DEFAULT_EXPLORATION_PHASES has structure phases before a polish phase", () => {
+  assertGreaterOrEqual(DEFAULT_EXPLORATION_PHASES.length, 2);
+  const polish = DEFAULT_EXPLORATION_PHASES.at(-1)!;
+  assertEquals(polish.trainingSampleRate, 1);
+  assertEquals(polish.costOfGrowth, 0);
+  // Every preceding phase must subsample (rate < 1) and pay a positive
+  // costOfGrowth — that is the whole point of the structure stage.
+  for (const phase of DEFAULT_EXPLORATION_PHASES.slice(0, -1)) {
+    assert(phase.trainingSampleRate < 1, `${phase.name} should subsample (rate < 1)`);
+    assert(phase.costOfGrowth > 0, `${phase.name} should apply positive costOfGrowth`);
+  }
+});
+
+Deno.test("runExplorationCampaign returns one phase record per configured phase", async () => {
+  const tmp = Deno.makeTempDirSync({ prefix: "stock_explore_phases_" });
+  try {
+    const result = await runExplorationCampaign({
+      split: buildTinySplit(5),
+      windowSize: 5,
+      workingDir: tmp,
+      seed: 42,
+      populationSize: 4,
+      phases: TINY_PHASES,
+    });
+    assertEquals(result.summary.phases.length, TINY_PHASES.length);
+    for (let i = 0; i < TINY_PHASES.length; i++) {
+      assertEquals(result.summary.phases[i].name, TINY_PHASES[i].name);
+      assertEquals(
+        result.summary.phases[i].trainingSampleRate,
+        TINY_PHASES[i].trainingSampleRate,
+      );
+      assertEquals(result.summary.phases[i].costOfGrowth, TINY_PHASES[i].costOfGrowth);
+    }
+  } finally {
+    Deno.removeSync(tmp, { recursive: true });
+  }
+});
+
+Deno.test("runExplorationCampaign scores the champion on full train / val / test after every phase", async () => {
+  const tmp = Deno.makeTempDirSync({ prefix: "stock_explore_scores_" });
+  try {
+    const result = await runExplorationCampaign({
+      split: buildTinySplit(5),
+      windowSize: 5,
+      workingDir: tmp,
+      seed: 7,
+      populationSize: 4,
+      phases: TINY_PHASES,
+    });
+    for (const phase of result.summary.phases) {
+      for (
+        const metric of [
+          phase.trainAccuracy,
+          phase.trainBalanced,
+          phase.validationAccuracy,
+          phase.validationBalanced,
+          phase.testAccuracy,
+          phase.testBalanced,
+        ]
+      ) {
+        assertGreaterOrEqual(metric, 0);
+        assertGreaterOrEqual(1, metric);
+      }
+      assertGreaterOrEqual(phase.generations, 1);
+      assertGreaterOrEqual(phase.wallClockMs, 0);
+    }
+  } finally {
+    Deno.removeSync(tmp, { recursive: true });
+  }
+});
+
+Deno.test("runExplorationCampaign writes champion + summary into the working dir", async () => {
+  const tmp = Deno.makeTempDirSync({ prefix: "stock_explore_artefacts_" });
+  try {
+    const result = await runExplorationCampaign({
+      split: buildTinySplit(5),
+      windowSize: 5,
+      workingDir: tmp,
+      seed: 99,
+      populationSize: 4,
+      phases: TINY_PHASES,
+    });
+    const championPath = join(tmp, "champion.json");
+    const summaryPath = join(tmp, "summary.json");
+    assert(existsSync(championPath), "champion.json should exist");
+    assert(existsSync(summaryPath), "summary.json should exist");
+    const persisted = JSON.parse(Deno.readTextFileSync(summaryPath));
+    assertEquals(persisted.phases.length, TINY_PHASES.length);
+    assertEquals(persisted.championNeurons, result.champion.neurons.length);
+  } finally {
+    Deno.removeSync(tmp, { recursive: true });
+  }
+});
+
+Deno.test("runExplorationCampaign does not promote unless an explicit promote dir is provided", async () => {
+  const tmp = Deno.makeTempDirSync({ prefix: "stock_explore_no_promote_" });
+  try {
+    const result = await runExplorationCampaign({
+      split: buildTinySplit(5),
+      windowSize: 5,
+      workingDir: tmp,
+      seed: 1,
+      populationSize: 4,
+      phases: TINY_PHASES,
+    });
+    assertEquals(result.promoted, false);
+  } finally {
+    Deno.removeSync(tmp, { recursive: true });
+  }
+});
+
+Deno.test("promoteExplorationArtefacts copies champion + summary from working dir to promote dir", async () => {
+  const tmp = Deno.makeTempDirSync({ prefix: "stock_explore_promote_" });
+  const promoteDir = Deno.makeTempDirSync({ prefix: "stock_explore_promote_docs_" });
+  try {
+    await runExplorationCampaign({
+      split: buildTinySplit(5),
+      windowSize: 5,
+      workingDir: tmp,
+      seed: 5,
+      populationSize: 4,
+      phases: TINY_PHASES,
+    });
+
+    const promoted = await promoteExplorationArtefacts({
+      workingDir: tmp,
+      promoteDir,
+    });
+    assertEquals(promoted, true);
+    assert(existsSync(join(promoteDir, "champion.json")));
+    assert(existsSync(join(promoteDir, "summary.json")));
+  } finally {
+    Deno.removeSync(tmp, { recursive: true });
+    Deno.removeSync(promoteDir, { recursive: true });
+  }
+});
+
+Deno.test("runExplorationCampaign throws when phases is empty", async () => {
+  const tmp = Deno.makeTempDirSync({ prefix: "stock_explore_empty_" });
+  let threw = false;
+  try {
+    await runExplorationCampaign({
+      split: buildTinySplit(5),
+      windowSize: 5,
+      workingDir: tmp,
+      seed: 1,
+      populationSize: 4,
+      phases: [],
+    });
+  } catch (_err) {
+    threw = true;
+  } finally {
+    Deno.removeSync(tmp, { recursive: true });
+  }
+  assert(threw, "expected an error when phases is empty");
+});
+
+Deno.test("runExplorationCampaign throws when trainingSampleRate is out of range", async () => {
+  const tmp = Deno.makeTempDirSync({ prefix: "stock_explore_bad_rate_" });
+  let threw = false;
+  try {
+    await runExplorationCampaign({
+      split: buildTinySplit(5),
+      windowSize: 5,
+      workingDir: tmp,
+      seed: 1,
+      populationSize: 4,
+      phases: [
+        {
+          name: "broken",
+          trainingSampleRate: 1.5,
+          costOfGrowth: 0,
+          maxGenerations: 1,
+          timeoutMinutes: 0,
+        },
+      ],
+    });
+  } catch (_err) {
+    threw = true;
+  } finally {
+    Deno.removeSync(tmp, { recursive: true });
+  }
+  assert(threw, "expected an error for trainingSampleRate > 1");
+});


### PR DESCRIPTION
## Summary

Wires the GRQ-style **exploration campaign** pipeline (structure phases →
polish phase → optional intelligent-design pass) onto `stock_market` as
the first in-scope example to adopt the pattern from issue #476. The new
runner subsamples training records during structure phases
(`trainingSampleRate` 5 → 10 → 15% with a small positive `costOfGrowth`)
so NEAT-AI grows topology cheaply, then switches to a polish phase
(`trainingSampleRate = 1`, `costOfGrowth = 0`) for honest weight/bias
tuning. After every phase the champion is scored against the **full**
train, validation, and test windows via the existing
`directionalAccuracy` and `balancedDirectionalAccuracy` helpers, so the
recorded series stays apples-to-apples across phases. All artefacts land
under `.synthetic-stock/exploration/` (hidden, gitignored); `--promote`
copies the champion + summary to `docs/data/stock_market/exploration/`.

Also fixes a pre-existing `deno.lock` drift (the lock pinned
`@stsoftware/neat-ai@5.0.30` while `deno.json` already pinned `5.0.32`,
which would have broken `quality.sh --frozen` once any test imported the
bump).

Closes #476.

## Evidence

CLI / orchestration change with no UI surface — verified via the unit
tests below. Mermaid diagram added to
`stock_market/README.md` (new "GRQ-Style Exploration Campaign" section)
showing the phase pipeline and the hidden-dir → promote-dir flow:

```mermaid
flowchart LR
    SEED["new Creature(10, 1)"] --> S1["structure 5%"]
    S1 --> S2["structure 10%"] --> S3["structure 15%"] --> POL["polish"]
    POL --> SQ["optional squash scan"]
    POL --> SCORE["full train/val/test scoring"]
    SCORE --> WORK[".synthetic-stock/exploration/"]
    WORK -. --promote .-> PROMOTE["docs/data/stock_market/exploration/"]
```

Full `deno test` run: **916 passed | 0 failed (1m5s)**. The eight new
exploration-campaign tests verify (a) `DEFAULT_EXPLORATION_PHASES`
structure-then-polish shape, (b) one phase record per configured phase,
(c) full-split scoring after every phase, (d) `champion.json` +
`summary.json` written into the working dir, (e) no implicit promotion,
(f) `promoteExplorationArtefacts` copies champion + summary to the
promote dir, and (g, h) range checks on `phases` / `trainingSampleRate`.

## Test Plan

New tests in `stock_market/exploration_campaign_test.ts`:

- `DEFAULT_EXPLORATION_PHASES has structure phases before a polish phase`
- `runExplorationCampaign returns one phase record per configured phase`
- `runExplorationCampaign scores the champion on full train / val / test after every phase`
- `runExplorationCampaign writes champion + summary into the working dir`
- `runExplorationCampaign does not promote unless an explicit promote dir is provided`
- `promoteExplorationArtefacts copies champion + summary from working dir to promote dir`
- `runExplorationCampaign throws when phases is empty`
- `runExplorationCampaign throws when trainingSampleRate is out of range`

Manual verification:

- `deno lint` — clean across 136 files.
- `deno fmt --check` — clean across 392 files.
- `deno check **/*.ts` — clean.
- `deno test --frozen ...` — 916 / 916 pass.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-476 -->