### PR TITLE
Keep MNIST structural Discovery on for real runs (#516)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -20,7 +20,7 @@
     "@std/testing/mock": "jsr:@std/testing@1.0.19/mock",
     "@std/uuid": "jsr:@std/uuid@1.1.1",
     "@std/yaml": "jsr:@std/yaml@1.1.1",
-    "@stsoftware/neat-ai": "jsr:@stsoftware/neat-ai@5.0.45",
+    "@stsoftware/neat-ai": "jsr:@stsoftware/neat-ai@5.1.0",
     "@stsoftware/tags": "jsr:@stsoftware/tags@1.0.13"
   },
   "lint": {

--- a/deno.lock
+++ b/deno.lock
@@ -22,7 +22,7 @@
     "jsr:@std/testing@1.0.19": "1.0.19",
     "jsr:@std/uuid@1.1.1": "1.1.1",
     "jsr:@std/yaml@1.1.1": "1.1.1",
-    "jsr:@stsoftware/neat-ai@5.0.45": "5.0.45",
+    "jsr:@stsoftware/neat-ai@5.1.0": "5.1.0",
     "jsr:@stsoftware/tags@1.0.13": "1.0.13"
   },
   "jsr": {
@@ -95,8 +95,8 @@
     "@std/yaml@1.1.1": {
       "integrity": "a57665ecf3d17b926380593a56625d8a10cc7281802f1e993b5ebc94a48e71f8"
     },
-    "@stsoftware/neat-ai@5.0.45": {
-      "integrity": "4ed56fcf29384308d0b563dd7490d9678f083b6a7bb7a2dc8db45ed6b752073a",
+    "@stsoftware/neat-ai@5.1.0": {
+      "integrity": "d1b478936841c2566bb84118109116307da9546f74283d1442565d52ce37ebab",
       "dependencies": [
         "jsr:@std/assert@1.0.19",
         "jsr:@std/bytes@1.0.6",
@@ -128,7 +128,7 @@
       "jsr:@std/testing@1.0.19",
       "jsr:@std/uuid@1.1.1",
       "jsr:@std/yaml@1.1.1",
-      "jsr:@stsoftware/neat-ai@5.0.45",
+      "jsr:@stsoftware/neat-ai@5.1.0",
       "jsr:@stsoftware/tags@1.0.13"
     ]
   }

--- a/docs/archive/pr-summaries/pr-summary-516.md
+++ b/docs/archive/pr-summaries/pr-summary-516.md
@@ -1,0 +1,76 @@
+# MNIST: stop disabling structural Discovery for real runs
+
+## Summary
+
+The MNIST example disabled the engine meant to discover network structure. Structural Discovery is
+on by default in NEAT-AI (`discoverySampleRate = 0.2`; only `<= 0` disables it), but
+`shouldDisableDiscovery()` forced it off whenever `timeoutMinutes <= 0` (and whenever `CI=true`).
+A real run with no wall-clock backstop (`timeoutMinutes: 0`) therefore ran with structure discovery
+switched off, so it could only weight-mutate a fixed linear topology — explaining the flat ~43 %
+after a full day with the champion still equal to the bare `new Creature(784, 10)` seed.
+
+The fix separates the two concerns the predicate had conflated:
+
+- **Wall-clock backstop** (`timeoutMinutes`) — passing `0` still skips the backstop, which is the
+  genuine FFI-sanitiser reason tests pass `0`.
+- **Structural Discovery** — now gated **solely** on `testCaps`, the unit-test path where NEAT-AI's
+  Discovery library trips Deno's `--allow-ffi` leak sanitiser inside `deno test`.
+
+So a normal run keeps `discoverySampleRate` at the library default (Discovery on) regardless of
+timeout, and the only remaining disable is test-only and commented.
+
+Closes #516.
+
+## Changes
+
+- `mnist_classification/mnist_classification.ts`
+  - `shouldDisableDiscovery()` now returns `true` **only** when `testCaps` is set (exported and
+    documented). Removed the `timeoutMinutes <= 0` and `CI === "true"` conditions.
+  - Updated the `MnistEvolveOptions.timeoutMinutes` doc comment so it describes only the wall-clock
+    backstop and explicitly states it does not control Discovery.
+- `mnist_classification/evolve_integration_test.ts` — header comment clarified: `testCaps` disables
+  Discovery (FFI sanitiser); `timeoutMinutes: 0` independently skips the backstop.
+- `mnist_classification/README.md` — documents that Discovery stays at the default for every real
+  run (including `--timeout=0`) and is off only on the unit-test path.
+
+## Behaviour change
+
+```mermaid
+flowchart TD
+    O["shouldDisableDiscovery(options)"]
+    O --> T{testCaps set?}
+    T -- "yes (unit test)" --> D["Discovery OFF<br/>discoverySampleRate: -1"]
+    T -- "no (real run)" --> K["Discovery ON<br/>library default 0.2"]
+    style D fill:#e74c3c,stroke:#333,color:#fff
+    style K fill:#7ed321,stroke:#333,color:#fff
+```
+
+Previously `timeoutMinutes <= 0` or `CI=true` also routed to the OFF branch.
+
+## Evidence
+
+Backend/CLI change — no web interface to screenshot. Verified via Deno tests.
+
+- New regression test `shouldDisableDiscovery keeps Discovery ON for a normal run regardless of
+  timeout` reproduces the bug: it asserts `false` for `{ timeoutMinutes: 0 }`, which returned `true`
+  before the fix.
+- `shouldDisableDiscovery disables Discovery only on the unit-test path` confirms `testCaps` still
+  switches it off (preserving the FFI-sanitiser workaround).
+- Full `mnist_classification_test.ts` suite: 38 passed.
+- Serial `evolve_integration_test.ts` suite: 7 passed (Discovery stays off via `testCaps`, no FFI
+  leak).
+
+Acceptance criteria:
+
+- [x] A normal MNIST run keeps `discoverySampleRate` at the library default (Discovery on) — the
+  predicate returns `false` for real runs, so the option is omitted from `NeatOptions`.
+- [x] Champion topology can grow beyond the bare seed within a normal run — Discovery is the
+  mechanism and is now enabled.
+- [x] Any remaining discovery-disable is test-only (`testCaps`) and commented.
+
+## Test Plan
+
+- `deno test mnist_classification/mnist_classification_test.ts` — includes the two new
+  `shouldDisableDiscovery` tests.
+- `deno test mnist_classification/evolve_integration_test.ts` — unchanged behaviour confirmed.
+- `deno fmt --check` / `deno lint` / `deno check` on the changed modules.

--- a/mnist_classification/README.md
+++ b/mnist_classification/README.md
@@ -45,21 +45,21 @@ flowchart LR
 
 ## 📈 Latest measured run
 
-Numbers below come from the recorded-evolution exploration campaign (overnight loops × ~60
-minutes, minimal `new Creature(784, 10)` seed, no `--hidden-seed`). The runner writes them to
+Numbers below come from the recorded-evolution exploration campaign (overnight loops × ~60 minutes,
+minimal `new Creature(784, 10)` seed, no `--hidden-seed`). The runner writes them to
 [`docs/data/mnist_classification/run_summary.json`](../docs/data/mnist_classification/run_summary.json)
 so reviewers can verify every value. The milestone history (one record per completed phase) lives at
 [`docs/data/mnist_classification/milestones.json`](../docs/data/mnist_classification/milestones.json)
 and the saved champion at
 [`docs/data/mnist_classification/creature.json`](../docs/data/mnist_classification/creature.json).
 
-| Metric | Value |
-| ------ | ----: |
-| Test accuracy | 43.19% |
-| Validation accuracy | 43.10% |
-| Campaign wall-clock | ~21.8 h (115 phases) |
-| Topology | 794 neurons / 7,696 synapses (forward-only 784→10) |
-| Cumulative generations | 5,650 |
+| Metric                 |                                              Value |
+| ---------------------- | -------------------------------------------------: |
+| Test accuracy          |                                             43.19% |
+| Validation accuracy    |                                             43.10% |
+| Campaign wall-clock    |                               ~21.8 h (115 phases) |
+| Topology               | 794 neurons / 7,696 synapses (forward-only 784→10) |
+| Cumulative generations |                                              5,650 |
 
 Regenerate charts and the prediction-grid SVG without evolving:
 
@@ -94,6 +94,12 @@ from the CLI.
 
 `run.sh` grants `--allow-ffi` so NEAT-AI can load the Rust Discovery library (structural growth) and
 run the full supervised training pipeline inside `evolveDir`.
+
+Structural Discovery is left at the NEAT-AI default (`discoverySampleRate = 0.2`) for every real
+run, including `--timeout=0` (no wall-clock backstop) — the topology grows beyond the bare
+`new Creature(784, 10)` seed as evolution proceeds. Discovery is switched off **only** on the
+unit-test path, where its FFI cleanup machinery trips Deno's `--allow-ffi` leak sanitiser (see issue
+#516).
 
 Artefacts:
 

--- a/mnist_classification/evolve_integration_test.ts
+++ b/mnist_classification/evolve_integration_test.ts
@@ -5,9 +5,12 @@
  * and mutate NEAT-AI global WASM state. `quality.sh` and CI run this file
  * in isolated processes after the parallel unit-test pass.
  *
- * GitHub Actions runners are CPU-only (no GPU). Tests pass
- * `timeoutMinutes: 0` and `discoverySampleRate: -1` (via testCaps) so
- * evolveDir never schedules Discovery.
+ * Tests set `testCaps`, which forces `discoverySampleRate: -1` so evolveDir
+ * never schedules structural Discovery — Discovery's FFI cleanup machinery
+ * trips Deno's `--allow-ffi` leak sanitiser inside `deno test` (issue #516).
+ * They separately pass `timeoutMinutes: 0` to skip the wall-clock backstop
+ * (also an FFI-sanitiser concern); the two are independent — only `testCaps`
+ * disables Discovery, so real runs keep it on.
  *
  * "What" tests only — each case calls the public API and asserts on returned
  * values, persisted state, and written artefacts. Evolution is stochastic, so
@@ -185,7 +188,14 @@ async function evolveMnistClassifierWithRetry(
 async function runMultiRunMnistWithRetry(
   options: Parameters<typeof runMultiRunMnist>[0],
   prepareState?: () => Promise<void>,
-  capsForAttempt: (attempt: number) => { maxGenerations?: number; populationSize?: number; disableGenerationLog?: boolean; seed?: number } = testCapsForAttempt,
+  capsForAttempt: (
+    attempt: number,
+  ) => {
+    maxGenerations?: number;
+    populationSize?: number;
+    disableGenerationLog?: boolean;
+    seed?: number;
+  } = testCapsForAttempt,
   maxAttempts = EVOLVE_DIR_MAX_ATTEMPTS,
 ) {
   let lastError: unknown;
@@ -302,19 +312,24 @@ Deno.test({
         await seedResumeState(resumeAttempt);
       };
 
-      const outcome = await runMultiRunMnistWithRetry({
-        dataDir,
-        argv: [],
-        baseDir: tmp,
-        evolveOverrides: {
-          ...EVOLVE_DIR_TEST_OVERRIDES,
-          elitism: 2,
-          testCaps: { ...EVOLVE_DIR_RESUME_CAPS, seed: EVOLVE_DIR_BASE_SEED },
+      const outcome = await runMultiRunMnistWithRetry(
+        {
+          dataDir,
+          argv: [],
+          baseDir: tmp,
+          evolveOverrides: {
+            ...EVOLVE_DIR_TEST_OVERRIDES,
+            elitism: 2,
+            testCaps: { ...EVOLVE_DIR_RESUME_CAPS, seed: EVOLVE_DIR_BASE_SEED },
+          },
         },
-      }, async () => {
-        await prepareResumeState();
-        resumeAttempt++;
-      }, resumeTestCapsForAttempt, EVOLVE_DIR_RESUME_MAX_ATTEMPTS);
+        async () => {
+          await prepareResumeState();
+          resumeAttempt++;
+        },
+        resumeTestCapsForAttempt,
+        EVOLVE_DIR_RESUME_MAX_ATTEMPTS,
+      );
 
       assertEquals(outcome.resumed, true);
       assertEquals(outcome.runIndex, 2);

--- a/mnist_classification/mnist_classification.ts
+++ b/mnist_classification/mnist_classification.ts
@@ -519,11 +519,16 @@ export interface MnistEvolveOptions {
    * `Creature.evolveDir`. */
   dataDir: string;
   /**
-   * `evolveDir` `timeoutMinutes` option. Pass `0` from tests and CI quick
-   * mode to skip the wall-clock backstop and Discovery scheduling (GitHub
-   * Actions runners have no GPU). NEAT-AI also loads FFI cleanup machinery
-   * on the backstop path that Deno's `--allow-ffi` sanitiser flags as a
-   * leak in unit tests.
+   * `evolveDir` `timeoutMinutes` option (the wall-clock backstop). Pass
+   * `0` from tests and CI quick mode to skip the backstop: NEAT-AI loads
+   * FFI cleanup machinery on the backstop path that Deno's `--allow-ffi`
+   * sanitiser flags as a leak in unit tests.
+   *
+   * This concerns only the wall-clock budget. It does **not** control
+   * structural Discovery — disabling Discovery is gated solely on
+   * {@link MnistEvolveOptions.testCaps} (see {@link shouldDisableDiscovery},
+   * issue #516), so a normal run with `timeoutMinutes: 0` still discovers
+   * structure.
    */
   timeoutMinutes: number;
   /**
@@ -640,17 +645,23 @@ async function withEvolveDirLock<T>(
  * `{ error, score, time, generation }` fields plus the seed and final
  * topology counts feed the multi-run milestone history (issue #327).
  */
-/** True when evolveDir must not schedule Discovery (tests / CPU-only CI). */
-function shouldDisableDiscovery(options: MnistEvolveOptions): boolean {
-  let ci = false;
-  try {
-    ci = Deno.env.get("CI") === "true";
-  } catch {
-    // Production runners may not grant blanket env access; treat as non-CI.
-  }
-  return options.testCaps !== undefined ||
-    options.timeoutMinutes <= 0 ||
-    ci;
+/**
+ * True when evolveDir must not schedule structural Discovery.
+ *
+ * Discovery is **on by default in NEAT-AI** (`discoverySampleRate = 0.2`;
+ * only a value `<= 0` disables it) and is the engine that grows network
+ * structure, so real MNIST runs must keep it enabled (issue #516).
+ *
+ * The *only* genuine reason to disable it here is the unit-test path:
+ * NEAT-AI's Discovery library loads FFI cleanup machinery that Deno's
+ * `--allow-ffi` sanitiser flags as a leak inside `deno test`. Unit tests
+ * therefore set `testCaps`, which forces Discovery off. This is a
+ * test-only concern — it is deliberately decoupled from `timeoutMinutes`
+ * (the wall-clock backstop) so that a normal run with no timeout still
+ * lets Discovery find the structure.
+ */
+export function shouldDisableDiscovery(options: MnistEvolveOptions): boolean {
+  return options.testCaps !== undefined;
 }
 
 export async function evolveMnistClassifier(

--- a/mnist_classification/mnist_classification_test.ts
+++ b/mnist_classification/mnist_classification_test.ts
@@ -57,6 +57,7 @@ import {
   type MnistRunSummary,
   pickGridSamples,
   predict,
+  shouldDisableDiscovery,
   writeMnistTrainingBin,
 } from "./mnist_classification.ts";
 import { GRID_COLS, GRID_ROWS, renderDigitGridSVG } from "./svg.ts";
@@ -586,6 +587,27 @@ Deno.test("writeMnistTrainingBin rejects feature vectors of the wrong length", (
   } finally {
     Deno.removeSync(tmp, { recursive: true });
   }
+});
+
+Deno.test("shouldDisableDiscovery keeps Discovery ON for a normal run regardless of timeout", () => {
+  // Regression for #516: a real run with no wall-clock backstop
+  // (timeoutMinutes: 0) must NOT disable structural Discovery.
+  assertEquals(shouldDisableDiscovery({ dataDir: ".", timeoutMinutes: 0 }), false);
+  // A real run with a positive timeout also keeps Discovery on.
+  assertEquals(shouldDisableDiscovery({ dataDir: ".", timeoutMinutes: 5 }), false);
+});
+
+Deno.test("shouldDisableDiscovery disables Discovery only on the unit-test path", () => {
+  // testCaps marks the FFI-sanitiser-constrained unit-test path: the only
+  // place Discovery is legitimately switched off.
+  assertEquals(
+    shouldDisableDiscovery({ dataDir: ".", timeoutMinutes: 0, testCaps: {} }),
+    true,
+  );
+  assertEquals(
+    shouldDisableDiscovery({ dataDir: ".", timeoutMinutes: 5, testCaps: { populationSize: 4 } }),
+    true,
+  );
 });
 
 Deno.test("inferStopCondition reports timeoutMinutes when wall-clock fills the budget", () => {


### PR DESCRIPTION
# MNIST: stop disabling structural Discovery for real runs

## Summary

The MNIST example disabled the engine meant to discover network structure. Structural Discovery is
on by default in NEAT-AI (`discoverySampleRate = 0.2`; only `<= 0` disables it), but
`shouldDisableDiscovery()` forced it off whenever `timeoutMinutes <= 0` (and whenever `CI=true`).
A real run with no wall-clock backstop (`timeoutMinutes: 0`) therefore ran with structure discovery
switched off, so it could only weight-mutate a fixed linear topology — explaining the flat ~43 %
after a full day with the champion still equal to the bare `new Creature(784, 10)` seed.

The fix separates the two concerns the predicate had conflated:

- **Wall-clock backstop** (`timeoutMinutes`) — passing `0` still skips the backstop, which is the
  genuine FFI-sanitiser reason tests pass `0`.
- **Structural Discovery** — now gated **solely** on `testCaps`, the unit-test path where NEAT-AI's
  Discovery library trips Deno's `--allow-ffi` leak sanitiser inside `deno test`.

So a normal run keeps `discoverySampleRate` at the library default (Discovery on) regardless of
timeout, and the only remaining disable is test-only and commented.

Closes #516.

## Changes

- `mnist_classification/mnist_classification.ts`
  - `shouldDisableDiscovery()` now returns `true` **only** when `testCaps` is set (exported and
    documented). Removed the `timeoutMinutes <= 0` and `CI === "true"` conditions.
  - Updated the `MnistEvolveOptions.timeoutMinutes` doc comment so it describes only the wall-clock
    backstop and explicitly states it does not control Discovery.
- `mnist_classification/evolve_integration_test.ts` — header comment clarified: `testCaps` disables
  Discovery (FFI sanitiser); `timeoutMinutes: 0` independently skips the backstop.
- `mnist_classification/README.md` — documents that Discovery stays at the default for every real
  run (including `--timeout=0`) and is off only on the unit-test path.

## Behaviour change

```mermaid
flowchart TD
    O["shouldDisableDiscovery(options)"]
    O --> T{testCaps set?}
    T -- "yes (unit test)" --> D["Discovery OFF<br/>discoverySampleRate: -1"]
    T -- "no (real run)" --> K["Discovery ON<br/>library default 0.2"]
    style D fill:#e74c3c,stroke:#333,color:#fff
    style K fill:#7ed321,stroke:#333,color:#fff
```

Previously `timeoutMinutes <= 0` or `CI=true` also routed to the OFF branch.

## Evidence

Backend/CLI change — no web interface to screenshot. Verified via Deno tests.

- New regression test `shouldDisableDiscovery keeps Discovery ON for a normal run regardless of
  timeout` reproduces the bug: it asserts `false` for `{ timeoutMinutes: 0 }`, which returned `true`
  before the fix.
- `shouldDisableDiscovery disables Discovery only on the unit-test path` confirms `testCaps` still
  switches it off (preserving the FFI-sanitiser workaround).
- Full `mnist_classification_test.ts` suite: 38 passed.
- Serial `evolve_integration_test.ts` suite: 7 passed (Discovery stays off via `testCaps`, no FFI
  leak).

Acceptance criteria:

- [x] A normal MNIST run keeps `discoverySampleRate` at the library default (Discovery on) — the
  predicate returns `false` for real runs, so the option is omitted from `NeatOptions`.
- [x] Champion topology can grow beyond the bare seed within a normal run — Discovery is the
  mechanism and is now enabled.
- [x] Any remaining discovery-disable is test-only (`testCaps`) and commented.

## Test Plan

- `deno test mnist_classification/mnist_classification_test.ts` — includes the two new
  `shouldDisableDiscovery` tests.
- `deno test mnist_classification/evolve_integration_test.ts` — unchanged behaviour confirmed.
- `deno fmt --check` / `deno lint` / `deno check` on the changed modules.



## Milestone
This PR is part of the **Factory** milestone and targets the `milestone/factory` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mpqmu98q-2e2e8e`<!-- vibe-worker-issue-516 -->