### PR TITLE
Stock Market: build the initial creature via the NEAT-AI factory (#519)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,11 @@ These examples exist to demonstrate evolution from noise → competent and must 
 - `cart_pole`
 - `snake_game`
 - `mnist_classification`
-- `stock_market`
+- `stock_market` — **exception (issue #519, factory-adoption tracker #517):** the fresh-run seed is
+  built via the data-derived `Creature.forDataset(...)` factory (linear output, target-mean bias,
+  data-derived hidden capacity) rather than uniform-random noise. Adopting the factory _is_ the
+  demonstration; structural growth beyond the seed still comes purely from `evolveDir`'s mutation
+  operators. The `evolveDir` configuration is unchanged.
 - `lunar_lander`
 - `mountain_car`
 - `maze_navigation`

--- a/docs/archive/pr-summaries/pr-summary-519.md
+++ b/docs/archive/pr-summaries/pr-summary-519.md
@@ -1,0 +1,96 @@
+## Summary
+
+Build the Stock-Market example's fresh-run seed via the NEAT-AI **dataset-aware factory**
+(`Creature.forDataset(records, { cost: "MSE" })`) instead of a bare `new Creature(WINDOW_SIZE, 1)`,
+and add **robust, frozen input normalisation** that travels with the model into inference. This is
+the closest example to the private GRQ market-prediction use case, so it is the most valuable
+demonstration of data-derived initialisation on a regression / time-series problem (part of the
+factory-adoption tracker #517). **Only the seed and the input transform change — the `evolveDir`
+configuration (population, mutation, stop conditions, seed) is untouched.**
+
+Closes #519.
+
+### What changed
+
+- **Factory seed (`buildSeedCreature`).** The fresh-run seed is now built by scanning the training
+  data. The factory derives, from problem-intrinsic facts only:
+  - a **linear (IDENTITY) regression output** (picked from the `MSE` cost);
+  - an **output bias warm-started to the target mean** (≈ 0.63 on the up-skewed S&P 500), so the
+    seed predicts the base rate before any training;
+  - a **conservative, data-derived hidden-capacity budget** (markets = limited, non-stationary
+    samples → overfitting is the main risk);
+  - **constant-feature pruning** (synapses from zero-variance inputs are zeroed).
+- **Frozen robust normalisation (`computeNormalizationStats` / `applyNormalization` /
+  `normalizeSamples`).** Per-feature **median / IQR** statistics are computed on the **training
+  window only**, then frozen and reused unchanged for validation, test, and live inference. Median /
+  IQR resist the fat-tailed outliers typical of returns; freezing the stats is the
+  **non-stationarity safeguard** — the model always sees the exact transform it was trained against,
+  and no future information leaks backwards. The stats are persisted to
+  `.synthetic-stock/creatures/normalization.json` and embedded in `signals.json`, so the
+  normalisation **travels with the model into inference**.
+- **`readTrainingRecords`** reconstructs factory records from the written `.bin`, so the factory
+  scans exactly the data `evolveDir` trains on.
+- The bare-constructor seed (`buildRandomSeedCreature`) is **retained** as the historical baseline
+  and for synthetic test/resume fixtures.
+
+### Deliberate departure from the no-warm-start policy
+
+`stock_market` is listed as an in-scope "noise → competent" example in `AGENTS.md`. Adopting the
+data-derived factory seed is a **deliberate, milestone-sanctioned exception** under the
+factory-adoption tracker (#517): the data-derived seed _is_ the demonstration. `AGENTS.md` and the
+example README are updated to record the exception. Structural growth beyond the seed still comes
+purely from `evolveDir`'s mutation operators.
+
+## Evidence
+
+This is a backend / CLI change — no web UI to screenshot. Verified via unit tests and an end-to-end
+quick-mode run (`STOCK_QUICK=1 ... --fresh`).
+
+### Baseline comparison (seed topology)
+
+| Seed (fresh run)        | Output activation | Output bias        | Hidden neurons | Neurons / synapses\* |
+| ----------------------- | ----------------- | ------------------ | -------------- | -------------------- |
+| Prior `new Creature`    | LOGISTIC          | random             | 0              | 11 / 10              |
+| **Factory (this PR)**   | IDENTITY (linear) | target mean (≈0.63)| 8              | **19 / 88**          |
+
+\* Neurons counted on the live `Creature` (10 inputs + hidden + 1 output). End-to-end quick run
+reported `seed=19/88` for `WINDOW_SIZE=10`, confirming the data-derived hidden layer.
+
+Inputs are now robustly standardised with frozen train-window median/IQR stats, persisted to
+`normalization.json` and `signals.json` so the transform is reproducible from the run artefacts.
+
+### Seed + normalisation data flow
+
+```mermaid
+flowchart LR
+    TRAIN["Train window"] -->|median / IQR| STATS["Frozen stats<br/>normalization.json"]
+    STATS --> NT["Train (normalised)"]
+    STATS --> NV["Val / Test / live (normalised)"]
+    NT --> BIN["Binary .bin"]
+    BIN --> FACT["Creature.forDataset()<br/>linear output, target-mean bias,<br/>data-derived capacity"]
+    BIN --> EV["evolveDir (unchanged)"]
+    FACT --> EV
+    NV --> INF["Inference (same frozen stats)"]
+```
+
+## Test Plan
+
+New "what" tests (all call real functions and assert on observable outputs):
+
+- `stock_market/data_test.ts`
+  - `computeNormalizationStats` returns per-feature median and IQR; throws on empty input.
+  - `applyNormalization` robustly standardises, is robust to a large outlier, guards a constant
+    (zero-IQR) feature, and rejects a width mismatch.
+  - `normalizeSamples` freezes train stats and reuses them on unseen samples, and does not mutate the
+    input.
+- `stock_market/stock_market_test.ts`
+  - `buildSeedCreature` builds the right arity, sizes a data-derived hidden layer, picks a linear
+    (IDENTITY) output, warm-starts the output bias to the target mean, is deterministic
+    (weights/biases) for a given seed, produces a valid creature with finite outputs, and throws on
+    empty records.
+  - `readTrainingRecords` round-trips a written `.bin` into factory records.
+  - `evolveStockController` seeds via the factory when not resuming (`seedNeurons > OUTPUT_COUNT`).
+
+Existing tests are unchanged and still pass (the bare-constructor baseline and all multi-run wiring
+remain green). Full `./quality.sh` run (fmt, lint, type-check, unit tests, every example in quick
+mode) passes.

--- a/stock_market/README.md
+++ b/stock_market/README.md
@@ -1,19 +1,27 @@
 # 📈 Stock Market — Direction Prediction
 
-> 🌱 **Generation 1 starts from random noise** — the seed is built by NEAT-AI's uniform-random
-> `new Creature(WINDOW_SIZE, 1)` constructor with **no hand-crafted topology, no `hiddenLayers`
-> hint, no pre-built `network.json`, and no domain-tuned narrow weight init**. Hidden neurons are
-> not hand-crafted — they emerge purely from NEAT-AI's own structural mutation operators while
-> `Creature.evolveDir(...)` runs.
+> 🌱 **Generation 1 starts from a data-derived factory seed (issue #519).** Instead of a bare
+> `new Creature(WINDOW_SIZE, 1)`, the seed is built by NEAT-AI's
+> `Creature.forDataset(records, { cost: "MSE" })` factory, which scans the training data and seeds
+> **problem-intrinsic** defaults: a **linear (IDENTITY) regression output**, an **output bias
+> warm-started to the target mean**, a **conservative hidden-capacity budget**, and
+> **constant-feature pruning**. **No dataset-specific architecture is hand-coded** — every default
+> is derived from the observation count, output count, cost, and a scan of the training file, so the
+> same approach transfers to private/unknown problems (this is the closest example to the private
+> GRQ market-prediction use case). **Only the seed changes; the `evolveDir` configuration is
+> untouched** and structural growth still comes from NEAT-AI's own mutation operators.
 
 **Acronyms.** _NEAT_ = NeuroEvolution of Augmenting Topologies. _MSE_ = Mean Squared Error. _SVG_ =
 Scalable Vector Graphics. _S&P 500_ = Standard & Poor's 500-stock market index.
 
-`stock_market.ts` evolves a NEAT-AI network from a minimal seed to predict next-period direction (up
-vs. down) on the public S&P 500 monthly-close dataset. The dataset is downloaded once into
-`.synthetic-stock/data/prices.csv` (with a SHA-256 digest pinned to a specific upstream commit so
-runs are deterministic), the labelled training samples are written as a binary `.bin` file, and the
-evolutionary loop is delegated to `Creature.evolveDir(...)`.
+`stock_market.ts` evolves a NEAT-AI network from a **data-derived factory seed** to predict
+next-period direction (up vs. down) on the public S&P 500 monthly-close dataset. The dataset is
+downloaded once into `.synthetic-stock/data/prices.csv` (with a SHA-256 digest pinned to a specific
+upstream commit so runs are deterministic). Feature windows are **robustly standardised** (median /
+IQR statistics frozen on the training window — see
+[Frozen input normalisation](#-frozen-input-normalisation)), the samples are written as a binary
+`.bin` file, the seed is built via `Creature.forDataset(...)`, and the evolutionary loop is
+delegated to `Creature.evolveDir(...)`.
 
 > ⚠️ **Teaching example only — not investment advice.**
 >
@@ -29,8 +37,9 @@ flowchart LR
     DL["📥 fetchDataset()<br/>S&P 500 CSV (pinned)"]
     SLIDE["🪟 Sliding window<br/>last N returns"]
     SPLIT["✂️ Train / val / test<br/>chronological split"]
+    NORM["🧮 Robust standardise<br/>median/IQR frozen on train"]
     BIN["📦 Binary .bin training set<br/>(window, target) records"]
-    SEED["🌱 new Creature(10, 1)<br/>minimal seed — no hidden hint"]
+    SEED["🌱 Creature.forDataset(records, &#123;cost&#125;)<br/>linear output, target-mean bias,<br/>data-derived capacity"]
     EVOLVE["🧪 Creature.evolveDir(dataDir, ...)<br/>forward-only, targetError=0.01,<br/>timeoutMinutes=5"]
     SUMMARY["📈 Multi-run milestone<br/>(error + complexity charts)"]
     CHAMP["💾 champion.json"]
@@ -38,8 +47,8 @@ flowchart LR
     SIG["📝 signals.json"]
     CHART["🖼️ Animated chart<br/>sweep + ▲ ▼ markers"]
 
-    DL --> SLIDE --> SPLIT --> BIN --> EVOLVE
-    SEED --> EVOLVE
+    DL --> SLIDE --> SPLIT --> NORM --> BIN --> EVOLVE
+    BIN --> SEED --> EVOLVE
     EVOLVE --> SUMMARY
     EVOLVE --> CHAMP
     CHAMP --> REPLAY --> SIG
@@ -87,14 +96,47 @@ sliding-window logic is identical.
 
 ## 🎯 Inputs and Outputs
 
-| Channel    | Type      | Meaning                                                   |
-| ---------- | --------- | --------------------------------------------------------- |
-| Input 0..N | feature   | The last `WINDOW_SIZE` (default 10) simple period returns |
-| Output 0   | direction | LOGISTIC, `>= 0.5` predicts up, otherwise predicts down   |
+| Channel    | Type      | Meaning                                                                                              |
+| ---------- | --------- | ---------------------------------------------------------------------------------------------------- |
+| Input 0..N | feature   | The last `WINDOW_SIZE` (default 10) returns, **robustly standardised** (median/IQR, frozen on train) |
+| Output 0   | direction | Linear (IDENTITY) regression score; `>= 0.5` predicts up, otherwise predicts down                    |
 
-The fitness used by `evolveDir` is `1 - MSE` against the binary `{0, 1}` direction labels — a
-constant `0.5` predictor scores `1 - 0.25 = 0.75`, so anything above `0.75` reflects the network
-correlating its output with realised direction.
+The factory picks a **linear (IDENTITY)** output from the regression cost (`MSE`) and warm-starts
+the output bias to the mean of the `{0, 1}` direction labels (≈ 0.63 on the up-skewed S&P 500), so
+the seed predicts the base rate before any training. The network then regresses toward the `{0, 1}`
+targets, and the `>= 0.5` threshold maps the score back to an up/down call. The fitness used by
+`evolveDir` is `1 - MSE` against the direction labels.
+
+## 🧮 Frozen input normalisation
+
+Return windows carry heterogeneous, fat-tailed scales, and markets are **non-stationary** — the
+distribution drifts from regime to regime. To stop the seed (and the model) being dominated by a few
+outlier months, inputs are **robustly standardised** before they reach the network:
+
+1. **Compute on train only.** `computeNormalizationStats(split.train)` records a per-feature
+   **median** and **inter-quartile range (IQR = Q3 − Q1)** over the training window.
+2. **Freeze.** Those statistics are never recomputed. Validation, test, and any live inference reuse
+   the frozen training stats via `normalizeSamples(...)`, so no future information leaks backwards
+   and the model always sees the exact transform it was trained against.
+3. **Apply.** Each feature is mapped `(x − median) / max(IQR, ε)`. Median/IQR (rather than
+   mean/standard-deviation) keep the scale resistant to the fat-tailed outliers typical of financial
+   returns; the `ε` floor maps a constant feature to `0` rather than `NaN`.
+
+The frozen stats are written to `.synthetic-stock/creatures/normalization.json` and embedded in
+`signals.json`, so the normalisation **travels with the model into inference** — the same JSON that
+documents a run is enough to reproduce its input transform.
+
+```mermaid
+flowchart LR
+    TRAIN["📚 Train window"] -->|median / IQR| STATS["🧊 Frozen stats<br/>normalization.json"]
+    STATS --> NT["Train (normalised)"]
+    STATS --> NV["Validation (normalised)"]
+    STATS --> NE["Test / live (normalised)"]
+    NT --> FACT["🌱 Creature.forDataset()"]
+    NT --> EV["🧪 evolveDir"]
+    NV --> INF["🔮 Inference"]
+    NE --> INF
+```
 
 ## 🛑 Stop conditions
 
@@ -280,7 +322,7 @@ sequenceDiagram
     alt prior champion exists
         State-->>Stock: Creature.fromJSON(creatureExport)
     else first run
-        State-->>Stock: buildRandomSeedCreature() — uniform-random noise
+        State-->>Stock: buildSeedCreature() — Creature.forDataset() factory seed
     end
     Stock->>Stock: Creature.evolveDir(dataDir)
     Stock->>State: appendMultiRunRun({champion, milestones})
@@ -320,10 +362,16 @@ The dashed purple play-head sweeps left-to-right, letting viewers walk the test 
 
 A few things that are not obvious from the code alone:
 
-- **Minimal seed only.** `stock_market.ts` passes only `input` and `output` integers to NEAT-AI's
-  `new Creature(input, output)` constructor. There are no `hiddenLayers`, no `nodes`, and no
-  pre-built `network.json` seed — the library random-initialises the rest, with hidden structure
-  emerging purely from `evolveDir`'s mutation operators.
+- **Data-derived factory seed.** `stock_market.ts` builds its fresh-run seed via
+  `Creature.forDataset(records, { cost: "MSE" })` (issue #519). The factory scans the training file
+  and derives the output activation (linear/IDENTITY for a regression cost), the output bias
+  (warm-started to the target mean), a conservative hidden-capacity budget, and constant-feature
+  pruning — all from problem-intrinsic facts, never a dataset-specific architecture lookup. **This
+  is a deliberate, milestone-sanctioned departure** from the project-wide
+  [no-warm-starts](../AGENTS.md#-no-warm-starts--evolution-must-start-from-random-noise) policy,
+  made under the factory-adoption tracker (issue #517): the data-derived seed _is_ the
+  demonstration. Structural growth beyond the seed still comes purely from `evolveDir`'s mutation
+  operators, and the `evolveDir` configuration is unchanged.
 - **Balanced accuracy, not raw accuracy.** The S&P 500 has a strong upward bias (~63% of months
   close above the previous month). Raw directional accuracy would credit a network that always
   predicts "up" with the base rate (~63%) even though it has learnt nothing. Balanced accuracy (mean
@@ -349,8 +397,14 @@ A few things that are not obvious from the code alone:
 
 `stock_market_test.ts` verifies:
 
-- The minimal seed has zero hidden neurons and a LOGISTIC output, and is deterministic for a given
-  seed.
+- The factory seed (`buildSeedCreature`) picks a linear (IDENTITY) output, warm-starts the output
+  bias to the target mean, sizes a data-derived hidden layer, and is deterministic (weights/biases)
+  for a given seed; `readTrainingRecords` round-trips a written `.bin` back into factory records.
+- The robust normalisation helpers (`computeNormalizationStats`, `applyNormalization`,
+  `normalizeSamples`) freeze median/IQR stats on the training window and reuse them unchanged on
+  unseen samples, guarding constant features and resisting outliers.
+- The bare `new Creature(...)` baseline seed (`buildRandomSeedCreature`, retained for fixtures) has
+  zero hidden neurons and a LOGISTIC output, and is deterministic for a given seed.
 - `writeStockTrainingDataset` emits the expected number of records with one float per feature plus
   one float per label, and rejects malformed input.
 - `evolveStockController` returns finite numeric fields built from `Creature.evolveDir`'s return
@@ -366,11 +420,13 @@ A few things that are not obvious from the code alone:
 
 ## 🧰 NEAT-AI Features Used
 
-Stock Market is a supervised noise → competent demo, so the demonstrated capability is NEAT-AI's
-evolutionary topology search against a price-prediction fitness signal driven by `evolveDir`.
+Stock Market is a supervised seed → competent demo: the data-derived factory seed (issue #519)
+replaces the historical random-noise seed, and the demonstrated capability is NEAT-AI's evolutionary
+topology search against a price-prediction fitness signal driven by `evolveDir`.
 
-- **Minimal NEAT seed** — `new Creature(input, output)` with no hidden hint, no pre-built
-  `network.json` seed; NEAT-AI random-initialises the rest.
+- **Dataset-aware factory seed** — `Creature.forDataset(records, { cost })` derives the output
+  activation, output bias, hidden-capacity budget, and constant-feature pruning from a scan of the
+  training data (issue #519); no hand-coded hidden-layer sizes or pre-built `network.json` seed.
 - **`Creature.evolveDir`** over the binary `.bin` training stream (per
   [`docs/binary_training_stream.md`](../docs/binary_training_stream.md)) — orders of magnitude
   faster than per-call `activate()`.

--- a/stock_market/data.ts
+++ b/stock_market/data.ts
@@ -140,6 +140,112 @@ export function buildSamples(
   return samples;
 }
 
+/**
+ * Frozen, per-feature robust-standardisation statistics.
+ *
+ * Computed **once** on the training window and then reused unchanged for
+ * validation, test, and live inference (see {@link normalizeSamples}).
+ * Freezing the stats is the non-stationarity safeguard: markets drift
+ * regime to regime, so re-estimating the scale on each window would let
+ * future information leak backwards and would move the goalposts the
+ * model was trained against. Median / IQR (rather than mean / standard
+ * deviation) keep the scale resistant to the fat-tailed outliers typical
+ * of financial returns.
+ */
+export interface NormalizationStats {
+  /** Per-feature median over the training window. */
+  medians: number[];
+  /** Per-feature inter-quartile range (Q3 − Q1) over the training window. */
+  iqrs: number[];
+}
+
+/**
+ * Floor applied to a feature's IQR before dividing, so a constant
+ * (zero-IQR) feature normalises to `0` rather than producing `NaN`/`±∞`.
+ */
+export const NORMALIZATION_EPS = 1e-8;
+
+/**
+ * Linear-interpolated quantile of an already-sorted ascending array.
+ * `q` is in `[0, 1]`. Matches the common "type 7" definition used by
+ * NumPy's default `percentile`.
+ */
+function quantileSorted(sorted: readonly number[], q: number): number {
+  if (sorted.length === 1) return sorted[0];
+  const pos = (sorted.length - 1) * q;
+  const lo = Math.floor(pos);
+  const hi = Math.ceil(pos);
+  if (lo === hi) return sorted[lo];
+  return sorted[lo] * (hi - pos) + sorted[hi] * (pos - lo);
+}
+
+/**
+ * Compute frozen robust-standardisation stats (per-feature median and
+ * IQR) over a set of samples. Intended to be called on the **training**
+ * window only; the returned {@link NormalizationStats} then travels with
+ * the model into inference via {@link normalizeSamples}.
+ */
+export function computeNormalizationStats(samples: readonly Sample[]): NormalizationStats {
+  if (samples.length === 0) {
+    throw new Error("computeNormalizationStats: samples must not be empty");
+  }
+  const width = samples[0].features.length;
+  const medians = new Array<number>(width);
+  const iqrs = new Array<number>(width);
+  for (let j = 0; j < width; j++) {
+    const column = new Array<number>(samples.length);
+    for (let i = 0; i < samples.length; i++) {
+      const f = samples[i].features;
+      if (f.length !== width) {
+        throw new Error(
+          `computeNormalizationStats: sample ${i} has ${f.length} features, expected ${width}`,
+        );
+      }
+      column[i] = f[j];
+    }
+    column.sort((a, b) => a - b);
+    medians[j] = quantileSorted(column, 0.5);
+    iqrs[j] = quantileSorted(column, 0.75) - quantileSorted(column, 0.25);
+  }
+  return { medians, iqrs };
+}
+
+/**
+ * Robustly standardise a single feature vector with frozen stats:
+ * `(x − median) / max(IQR, eps)`. A constant feature (IQR ≈ 0) maps to
+ * `0` via the {@link NORMALIZATION_EPS} floor.
+ */
+export function applyNormalization(
+  features: readonly number[],
+  stats: NormalizationStats,
+): number[] {
+  if (features.length !== stats.medians.length) {
+    throw new Error(
+      `applyNormalization: feature width ${features.length} does not match ` +
+        `stats width ${stats.medians.length}`,
+    );
+  }
+  const out = new Array<number>(features.length);
+  for (let j = 0; j < features.length; j++) {
+    out[j] = (features[j] - stats.medians[j]) / Math.max(stats.iqrs[j], NORMALIZATION_EPS);
+  }
+  return out;
+}
+
+/**
+ * Apply frozen {@link NormalizationStats} to every sample, returning
+ * fresh {@link Sample} objects with normalised features. Non-feature
+ * fields (date, label, return, close, index) are preserved unchanged so
+ * downstream charts and metrics still see the real outcomes. The input
+ * samples are never mutated.
+ */
+export function normalizeSamples(
+  samples: readonly Sample[],
+  stats: NormalizationStats,
+): Sample[] {
+  return samples.map((s) => ({ ...s, features: applyNormalization(s.features, stats) }));
+}
+
 /** Configuration for {@link splitChronologically}. */
 export interface SplitOptions {
   /** Fraction of samples to allocate to training (0–1). */

--- a/stock_market/data_test.ts
+++ b/stock_market/data_test.ts
@@ -5,7 +5,21 @@
  */
 import { assert, assertAlmostEquals, assertEquals, assertThrows } from "@std/assert";
 
-import { buildSamples, computeReturns, parsePriceCSV, splitChronologically } from "./data.ts";
+import {
+  applyNormalization,
+  buildSamples,
+  computeNormalizationStats,
+  computeReturns,
+  normalizeSamples,
+  parsePriceCSV,
+  type Sample,
+  splitChronologically,
+} from "./data.ts";
+
+/** Build a minimal {@link Sample} with the given feature vector. */
+function sampleWith(features: number[], label: 0 | 1 = 0): Sample {
+  return { index: 0, date: "d", features, label, return: 0, close: 1 };
+}
 
 Deno.test("parsePriceCSV reads dated SP500 rows", () => {
   const csv = [
@@ -160,4 +174,82 @@ Deno.test("splitChronologically rejects fractions that leave no test slice", () 
     Error,
     "leave a test slice",
   );
+});
+
+/* ------------------------------------------------------------------ */
+/*  Robust input normalisation (issue #519)                            */
+/* ------------------------------------------------------------------ */
+
+Deno.test("computeNormalizationStats returns per-feature median and IQR", () => {
+  // Two features. Column 0 = 1..7 (median 4, Q1 2.5, Q3 5.5 → IQR 3).
+  // Column 1 = constant 10 (median 10, IQR 0).
+  const samples = [1, 2, 3, 4, 5, 6, 7].map((v) => sampleWith([v, 10]));
+  const stats = computeNormalizationStats(samples);
+  assertEquals(stats.medians.length, 2);
+  assertEquals(stats.iqrs.length, 2);
+  assertAlmostEquals(stats.medians[0], 4, 1e-9);
+  assertAlmostEquals(stats.iqrs[0], 3, 1e-9);
+  assertAlmostEquals(stats.medians[1], 10, 1e-9);
+  assertAlmostEquals(stats.iqrs[1], 0, 1e-9);
+});
+
+Deno.test("computeNormalizationStats throws on empty sample list", () => {
+  assertThrows(() => computeNormalizationStats([]), Error, "must not be empty");
+});
+
+Deno.test("applyNormalization robustly standardises a feature vector", () => {
+  const stats = { medians: [4], iqrs: [2] };
+  // (x - median) / IQR.
+  assertAlmostEquals(applyNormalization([4], stats)[0], 0, 1e-9);
+  assertAlmostEquals(applyNormalization([6], stats)[0], 1, 1e-9);
+  assertAlmostEquals(applyNormalization([2], stats)[0], -1, 1e-9);
+});
+
+Deno.test("applyNormalization is robust to outliers via median/IQR", () => {
+  // A single huge outlier must not blow up the frozen median/IQR scale.
+  const samples = [0, 0, 0, 0, 0, 0, 0, 0, 0, 1_000_000].map((v) => sampleWith([v]));
+  const stats = computeNormalizationStats(samples);
+  // Median is 0 and IQR is 0 (most values identical) → constant column,
+  // so a normal in-range value maps to a finite, small number.
+  const normal = applyNormalization([0], stats)[0];
+  assert(Number.isFinite(normal));
+  assertAlmostEquals(normal, 0, 1e-6);
+});
+
+Deno.test("applyNormalization guards a constant (zero-IQR) feature", () => {
+  const stats = { medians: [10], iqrs: [0] };
+  const out = applyNormalization([10], stats);
+  assert(Number.isFinite(out[0]));
+  assertAlmostEquals(out[0], 0, 1e-6);
+});
+
+Deno.test("applyNormalization rejects a width mismatch", () => {
+  assertThrows(
+    () => applyNormalization([1, 2], { medians: [0], iqrs: [1] }),
+    Error,
+    "feature width",
+  );
+});
+
+Deno.test("normalizeSamples freezes train stats and reuses them on unseen samples", () => {
+  const train = [1, 2, 3, 4, 5, 6, 7].map((v) => sampleWith([v], 1));
+  const stats = computeNormalizationStats(train);
+  // A later-regime ("non-stationary") sample is normalised with the
+  // FROZEN training stats, not its own — this is the inference path.
+  const future = [sampleWith([100], 0)];
+  const out = normalizeSamples(future, stats);
+  // (100 - 4) / 3 == 32.
+  assertAlmostEquals(out[0].features[0], 32, 1e-9);
+  // Non-feature fields are preserved untouched.
+  assertEquals(out[0].label, 0);
+  assertEquals(out[0].close, 1);
+});
+
+Deno.test("normalizeSamples does not mutate the input samples", () => {
+  const samples = [sampleWith([2, 4])];
+  const stats = { medians: [0, 0], iqrs: [1, 1] };
+  const out = normalizeSamples(samples, stats);
+  assertEquals(samples[0].features, [2, 4], "source features must be untouched");
+  assertEquals(out[0].features, [2, 4]);
+  assert(out[0] !== samples[0], "a fresh sample object is returned");
 });

--- a/stock_market/stock_market.ts
+++ b/stock_market/stock_market.ts
@@ -10,15 +10,21 @@
  * library — exercising back-propagation, structural mutation, and the
  * library's full evolution pipeline.
  *
- * 🌱 **Generation 1 starts from random noise.** A fresh run (no prior
- * persisted champion, or `--fresh` on the command line) builds the seed
- * via {@link buildRandomSeedCreature} — the NEAT-AI library's
- * uniform-random `new Creature(WINDOW_SIZE, 1)` constructor — direct
- * input → output connections, random weights, and a random output bias
- * drawn from the seeded global PRNG. **No topology, weights, or biases
- * are hand-specified by this example.** Hidden neurons are not
- * pre-built — they emerge purely from NEAT-AI's own structural mutation
- * operators while `evolveDir` runs.
+ * 🌱 **Generation 1 starts from a data-derived factory seed (issue
+ * #519).** A fresh run (no prior persisted champion, or `--fresh` on the
+ * command line) builds the seed via {@link buildSeedCreature} — the
+ * NEAT-AI `Creature.forDataset(records, { cost })` factory — instead of a
+ * bare `new Creature(WINDOW_SIZE, 1)`. The factory scans the training
+ * data and seeds problem-intrinsic defaults: a **linear (IDENTITY)
+ * regression output**, an **output bias warm-started to the target
+ * mean**, a **conservative hidden-capacity budget**, and
+ * **constant-feature pruning**. **No dataset-specific architecture is
+ * hand-coded** — every default is derived from the observation count,
+ * output count, cost, and a scan of the training file, so the same
+ * approach transfers to private/unknown problems. Only the seed changes;
+ * the `evolveDir` configuration (population, mutation, stop conditions)
+ * is identical to the historical run, and structural growth still comes
+ * from NEAT-AI's own mutation operators.
  *
  * Under #301 the per-generation `onTrainingEvent` hook and multi-panel
  * checkpoint strip were removed in favour of NEAT-AI's supported
@@ -55,6 +61,7 @@ import {
   createSeededRng,
   Creature,
   type CreatureExport,
+  type DatasetFactoryOptions,
   type NeatOptions,
   safeWriteJson,
   setRandomNumberGenerator,
@@ -73,7 +80,10 @@ import { renderMultiRunErrorChartSVG } from "../common/multi_run_error_chart.ts"
 import { setupWorkingDirs } from "../common/working_dirs.ts";
 import {
   buildSamples,
+  computeNormalizationStats,
   type DataSplit,
+  type NormalizationStats,
+  normalizeSamples,
   parsePriceCSV,
   type PricePoint,
   type Sample,
@@ -87,8 +97,19 @@ export const WINDOW_SIZE = 10;
 /** Number of network inputs. */
 export const INPUT_COUNT = WINDOW_SIZE;
 
-/** Number of network outputs (a single direction probability). */
+/** Number of network outputs (a single regression score for next-period return). */
 export const OUTPUT_COUNT = 1;
+
+/** Filename of the binary training stream consumed by `evolveDir`. */
+export const TRAIN_BIN_FILENAME = "stock_market.bin";
+
+/**
+ * Cost / task name handed to the NEAT-AI factory ({@link Creature.forDataset})
+ * and `evolveDir`. A regression cost makes the factory pick a **linear
+ * (IDENTITY) output** and warm-start the output bias to the target mean
+ * — the data-derived seed this example demonstrates (issue #519).
+ */
+export const REGRESSION_COST = "MSE";
 
 /** Working-directory root for this example. */
 export const STOCK_ROOT = ".synthetic-stock";
@@ -242,10 +263,14 @@ export const DEFAULT_EVOLVE_OPTIONS: Omit<EvolveOptions, "dataDir"> = {
 };
 
 /**
- * Build a uniform-random NEAT seed creature. Seeds the library's global
- * PRNG with {@link createSeededRng} and then defers to
- * `new Creature(windowSize, OUTPUT_COUNT)` — the library's
- * uniform-random constructor. **No topology, weight, or bias is
+ * Build a uniform-random NEAT seed creature via the library's bare
+ * `new Creature(windowSize, OUTPUT_COUNT)` constructor.
+ *
+ * Retained as the historical baseline and for synthetic test/resume
+ * fixtures — the production fresh-run seed now comes from the
+ * data-derived factory ({@link buildSeedCreature}, issue #519). Seeds the
+ * library's global PRNG with {@link createSeededRng} so output is
+ * deterministic for a given seed. **No topology, weight, or bias is
  * hand-specified by this example.**
  *
  * The single output neuron's activation is pinned to LOGISTIC because
@@ -263,6 +288,73 @@ export function buildRandomSeedCreature(
     if (neuron.type === "output") neuron.squash = "LOGISTIC";
   }
   return json;
+}
+
+/** A single factory training record: a feature window plus its target. */
+type FactoryRecords = Parameters<typeof Creature.forDataset>[0];
+
+/**
+ * Build the **data-derived seed creature** via the NEAT-AI factory
+ * ({@link Creature.forDataset}) instead of a bare `new Creature(...)`
+ * (issue #519). The factory scans `records` and:
+ *
+ * - picks a **linear (IDENTITY) output** activation from the regression
+ *   cost ({@link REGRESSION_COST});
+ * - **warm-starts the output bias to the target mean**, so the seed can
+ *   predict the unconditional mean return before any training;
+ * - sizes a **conservative hidden-capacity budget** from the problem
+ *   shape (markets offer limited, non-stationary samples, so overfitting
+ *   is the main risk);
+ * - **prunes truly-constant features** — synapses originating from a
+ *   feature with no variance are zeroed so their noise is not propagated.
+ *
+ * The library's global PRNG is reseeded via {@link createSeededRng} so a
+ * given `seed` produces a deterministic seed creature. Inputs are
+ * expected to be **already robustly standardised** (see
+ * {@link computeNormalizationStats}); the frozen stats travel with the
+ * model into inference, so the factory trusts the incoming scale.
+ */
+export function buildSeedCreature(
+  records: FactoryRecords,
+  seed: number,
+  _windowSize: number = WINDOW_SIZE,
+): CreatureExport {
+  if (records.length === 0) {
+    throw new Error("buildSeedCreature: records must not be empty");
+  }
+  setRandomNumberGenerator(createSeededRng(seed));
+  const options: DatasetFactoryOptions = { cost: REGRESSION_COST };
+  return Creature.forDataset(records, options).exportJSON();
+}
+
+/**
+ * Read a written `.bin` training stream back into factory records
+ * (`{ input, output }` pairs). Each record is `windowSize + OUTPUT_COUNT`
+ * Float32 values: the feature window followed by the regression target.
+ * Used by {@link evolveStockController} to feed the factory the exact
+ * data `evolveDir` will train on.
+ */
+export function readTrainingRecords(
+  dataDir: string,
+  windowSize: number = WINDOW_SIZE,
+): FactoryRecords {
+  const path = join(dataDir, TRAIN_BIN_FILENAME);
+  const bytes = Deno.readFileSync(path);
+  const stride = windowSize + OUTPUT_COUNT;
+  const floats = new Float32Array(bytes.buffer, bytes.byteOffset, bytes.byteLength / 4);
+  const count = Math.floor(floats.length / stride);
+  if (count === 0) {
+    throw new Error(`readTrainingRecords: no records found in ${path}`);
+  }
+  const records: { input: Float32Array; output: Float32Array }[] = new Array(count);
+  for (let i = 0; i < count; i++) {
+    const base = i * stride;
+    records[i] = {
+      input: floats.slice(base, base + windowSize),
+      output: floats.slice(base + windowSize, base + stride),
+    };
+  }
+  return records;
 }
 
 /**
@@ -297,7 +389,7 @@ export function writeStockTrainingDataset(
     }
     buffer[i * stride + windowSize] = sample.label;
   }
-  const path = join(dataDir, "stock_market.bin");
+  const path = join(dataDir, TRAIN_BIN_FILENAME);
   Deno.writeFileSync(path, new Uint8Array(buffer.buffer));
   return path;
 }
@@ -305,10 +397,13 @@ export function writeStockTrainingDataset(
 /**
  * Run NEAT structural evolution to learn next-period direction.
  *
- * The runner builds the **uniform-random seed creature** via
- * {@link buildRandomSeedCreature} (no hidden neurons, random weights and
- * output bias from the seeded PRNG) and delegates structural mutation
- * to the library via `creature.evolveDir(dataDir, ...)`. One call
+ * The runner builds the **data-derived factory seed** via
+ * {@link buildSeedCreature} (linear output, target-mean bias warm-start,
+ * conservative hidden-capacity budget, constant-feature pruning) and
+ * delegates structural mutation to the library via
+ * `creature.evolveDir(dataDir, ...)`. Only the seed differs from the
+ * historical `new Creature(...)` path — the `evolveDir` configuration is
+ * unchanged. One call
  * covers the whole budget; the return value's
  * `{ error, score, time, generation }` fields plus the seed and final
  * topology counts feed an {@link EvolveDirSummary} for the milestone
@@ -325,10 +420,17 @@ export async function evolveStockController(options: EvolveOptions): Promise<Evo
   }
 
   // Resume from the prior champion when supplied, otherwise build the
-  // uniform-random minimal seed via the seeded global PRNG.
+  // data-derived factory seed by scanning the training `.bin` the
+  // factory will (via evolveDir) actually train on (issue #519).
   const creature = options.seedCreatureExport !== undefined
     ? Creature.fromJSON(options.seedCreatureExport)
-    : Creature.fromJSON(buildRandomSeedCreature(options.seed, options.windowSize));
+    : Creature.fromJSON(
+      buildSeedCreature(
+        readTrainingRecords(options.dataDir, options.windowSize),
+        options.seed,
+        options.windowSize,
+      ),
+    );
   const seedNeurons = creature.neurons.length;
   const seedSynapses = creature.synapses.length;
 
@@ -685,9 +787,24 @@ if (import.meta.main) {
     `   Train=${split.train.length}  Val=${split.validation.length}  Test=${split.test.length}`,
   );
 
-  // Pre-generate the binary `.bin` training set for `evolveDir`.
-  const trainBin = writeStockTrainingDataset(split.train, dataDir);
-  console.log(`📦 Wrote training set to ${trainBin}`);
+  // Robustly standardise inputs with frozen (median / IQR) stats derived
+  // from the TRAIN window only. The same frozen stats are reused for
+  // validation, test, and live inference so the normalisation "travels
+  // with the model" and never re-estimates the scale on a later regime
+  // (issue #519). Non-feature fields (date, close, return) are preserved.
+  const normStats: NormalizationStats = computeNormalizationStats(split.train);
+  const normTrain = normalizeSamples(split.train, normStats);
+  const normValidation = normalizeSamples(split.validation, normStats);
+  const normTest = normalizeSamples(split.test, normStats);
+  const normalizationPath = join(creaturesDir, "normalization.json");
+  await safeWriteJson(normalizationPath, normStats);
+  console.log(`🧮 Froze robust input-normalisation stats → ${normalizationPath}`);
+
+  // Pre-generate the binary `.bin` training set for `evolveDir` from the
+  // normalised features. `evolveStockController` scans this same file to
+  // build the data-derived factory seed.
+  const trainBin = writeStockTrainingDataset(normTrain, dataDir);
+  console.log(`📦 Wrote normalised training set to ${trainBin}`);
 
   // Multi-run flag parsing (logged here for the operator; the runner
   // also re-parses inside `runMultiRunStock`).
@@ -715,7 +832,9 @@ if (import.meta.main) {
   if (multi.resumed) {
     console.log(`🔁 Resumed from prior champion (run ${multi.runIndex}).`);
   } else {
-    console.log(`🌱 Fresh start — run ${multi.runIndex} begins from random noise.`);
+    console.log(
+      `🌱 Fresh start — run ${multi.runIndex} begins from the data-derived factory seed.`,
+    );
   }
 
   console.log(
@@ -733,20 +852,23 @@ if (import.meta.main) {
   await safeWriteJson(championPath, championExport);
   console.log(`💾 Saved champion to ${championPath}`);
 
-  // Replay champion on validation + test windows.
-  const valAccuracy = directionalAccuracy(result.champion, split.validation);
-  const valBalanced = balancedDirectionalAccuracy(result.champion, split.validation);
-  const records = replayController(result.champion, split.test);
+  // Replay champion on validation + test windows. Inference uses the
+  // SAME frozen normalisation stats as training, so the standardisation
+  // travels with the model (issue #519).
+  const valAccuracy = directionalAccuracy(result.champion, normValidation);
+  const valBalanced = balancedDirectionalAccuracy(result.champion, normValidation);
+  const records = replayController(result.champion, normTest);
   const testAccuracy = records.length === 0
     ? 0
     : records.filter((r) => r.correct).length / records.length;
-  const testBalanced = balancedDirectionalAccuracy(result.champion, split.test);
+  const testBalanced = balancedDirectionalAccuracy(result.champion, normTest);
   const cumulativeReturn = cumulativeStrategyReturn(records);
 
   // Save per-day signals.
   const signalsPath = join(outputDir, "signals.json");
   await safeWriteJson(signalsPath, {
     windowSize: WINDOW_SIZE,
+    normalization: normStats,
     validationAccuracy: valAccuracy,
     validationBalancedAccuracy: valBalanced,
     testAccuracy,

--- a/stock_market/stock_market_test.ts
+++ b/stock_market/stock_market_test.ts
@@ -19,10 +19,16 @@ import { Creature } from "@stsoftware/neat-ai";
 
 import { createDeterministicRandom } from "../common/deterministic_random.ts";
 import { appendMultiRunRun, loadMultiRunState } from "../common/multi_run_state.ts";
-import { buildSamples, splitChronologically } from "./data.ts";
+import {
+  buildSamples,
+  computeNormalizationStats,
+  normalizeSamples,
+  splitChronologically,
+} from "./data.ts";
 import {
   balancedDirectionalAccuracy,
   buildRandomSeedCreature,
+  buildSeedCreature,
   classifyGlyph,
   cumulativeStrategyReturn,
   DEFAULT_EVOLVE_OPTIONS,
@@ -33,6 +39,7 @@ import {
   INPUT_COUNT,
   OUTPUT_COUNT,
   predictionFromOutput,
+  readTrainingRecords,
   replayController,
   runMultiRunStock,
   WINDOW_SIZE,
@@ -94,6 +101,148 @@ Deno.test("buildRandomSeedCreature produces a valid creature with finite outputs
   const out = creature.activate(Float32Array.from(new Array(WINDOW_SIZE).fill(0)));
   assertEquals(out.length, OUTPUT_COUNT);
   assert(Number.isFinite(out[0]));
+});
+
+/* ------------------------------------------------------------------ */
+/*  Factory seed (issue #519)                                          */
+/* ------------------------------------------------------------------ */
+
+/** Synthetic factory records: `windowSize` features + one regression target. */
+function syntheticRecords(
+  count: number,
+  windowSize: number,
+): { input: Float32Array; output: Float32Array }[] {
+  const recs: { input: Float32Array; output: Float32Array }[] = [];
+  for (let i = 0; i < count; i++) {
+    const input = new Float32Array(windowSize);
+    for (let j = 0; j < windowSize; j++) input[j] = Math.sin(i * 0.2 + j) * 0.02;
+    // Up-skewed target mean (~0.66) so the bias warm-start is observable.
+    recs.push({ input, output: Float32Array.from([i % 3 === 0 ? 0 : 1]) });
+  }
+  return recs;
+}
+
+Deno.test("buildSeedCreature builds a factory seed with the right arity", () => {
+  const json = buildSeedCreature(syntheticRecords(140, WINDOW_SIZE), 12345, WINDOW_SIZE);
+  assertEquals(json.input, INPUT_COUNT);
+  assertEquals(json.output, OUTPUT_COUNT);
+});
+
+Deno.test("buildSeedCreature sizes a data-derived hidden capacity budget", () => {
+  // Unlike the bare `new Creature(...)` seed (zero hidden), the factory
+  // derives a conservative hidden-layer budget from the problem shape.
+  const json = buildSeedCreature(syntheticRecords(140, WINDOW_SIZE), 7, WINDOW_SIZE);
+  const hidden = json.neurons.filter((n) => n.type === "hidden");
+  assertGreater(hidden.length, 0, "factory seed must pre-size a hidden layer");
+});
+
+Deno.test("buildSeedCreature picks a linear (regression) output activation", () => {
+  const json = buildSeedCreature(syntheticRecords(140, WINDOW_SIZE), 5, WINDOW_SIZE);
+  const outputs = json.neurons.filter((n) => n.type === "output");
+  assertEquals(outputs.length, OUTPUT_COUNT);
+  for (const out of outputs) {
+    assertEquals(out.squash, "IDENTITY", "regression cost ⇒ linear output");
+  }
+});
+
+Deno.test("buildSeedCreature warm-starts the output bias to the target mean", () => {
+  const records = syntheticRecords(150, WINDOW_SIZE);
+  let sum = 0;
+  for (const r of records) sum += r.output[0];
+  const mean = sum / records.length;
+  const json = buildSeedCreature(records, 3, WINDOW_SIZE);
+  const out = json.neurons.find((n) => n.type === "output");
+  assert(out !== undefined);
+  assertAlmostEquals(out!.bias ?? 0, mean, 1e-3, "output bias should equal the target mean");
+});
+
+Deno.test("buildSeedCreature is deterministic (weights/biases) for a given seed", () => {
+  // The factory mints fresh random UUIDs for hidden neurons, so full
+  // JSON equality is too strict. The meaningful invariant is that the
+  // learnable parameters (topology shape, biases, squashes, weights) are
+  // identical for a fixed seed.
+  const records = syntheticRecords(120, WINDOW_SIZE);
+  const fingerprint = (json: ReturnType<typeof buildSeedCreature>) => ({
+    neurons: json.neurons.map((n) => `${n.type}:${n.squash}:${n.bias}`),
+    weights: json.synapses.map((s) => s.weight),
+  });
+  const a = fingerprint(buildSeedCreature(records, 4242, WINDOW_SIZE));
+  const b = fingerprint(buildSeedCreature(records, 4242, WINDOW_SIZE));
+  assertEquals(a, b);
+});
+
+Deno.test("buildSeedCreature produces a valid creature with finite outputs", () => {
+  const creature = Creature.fromJSON(
+    buildSeedCreature(syntheticRecords(120, WINDOW_SIZE), 7, WINDOW_SIZE),
+  );
+  creature.validate();
+  creature.clearState();
+  const out = creature.activate(Float32Array.from(new Array(WINDOW_SIZE).fill(0)));
+  assertEquals(out.length, OUTPUT_COUNT);
+  assert(Number.isFinite(out[0]));
+});
+
+Deno.test("buildSeedCreature throws on an empty record set", () => {
+  let threw = false;
+  try {
+    buildSeedCreature([], 1, WINDOW_SIZE);
+  } catch (_err) {
+    threw = true;
+  }
+  assert(threw, "expected an error for empty records");
+});
+
+Deno.test("readTrainingRecords round-trips a written .bin into factory records", () => {
+  const tmp = Deno.makeTempDirSync({ prefix: "stock_records_" });
+  try {
+    const prices = syntheticPrices(80, 7);
+    const samples = buildSamples(prices, { windowSize: 5 });
+    const stats = computeNormalizationStats(samples);
+    const normalized = normalizeSamples(samples, stats);
+    writeStockTrainingDataset(normalized, tmp, 5);
+    const records = readTrainingRecords(tmp, 5);
+    assertEquals(records.length, normalized.length);
+    for (let i = 0; i < records.length; i++) {
+      assertEquals(records[i].input.length, 5);
+      assertEquals(records[i].output.length, OUTPUT_COUNT);
+      for (let j = 0; j < 5; j++) {
+        assertAlmostEquals(records[i].input[j], normalized[i].features[j], 1e-6);
+      }
+      assertAlmostEquals(records[i].output[0], normalized[i].label, 1e-6);
+    }
+  } finally {
+    Deno.removeSync(tmp, { recursive: true });
+  }
+});
+
+Deno.test("evolveStockController seeds via the factory when not resuming", async () => {
+  const tmp = Deno.makeTempDirSync({ prefix: "stock_factory_seed_" });
+  try {
+    const prices = syntheticPrices(200, 5);
+    const samples = buildSamples(prices, { windowSize: 5 });
+    const split = splitChronologically(samples, {
+      trainFraction: 0.7,
+      validationFraction: 0.15,
+    });
+    const stats = computeNormalizationStats(split.train);
+    writeStockTrainingDataset(normalizeSamples(split.train, stats), tmp, 5);
+    const result = await evolveStockController({
+      ...DEFAULT_EVOLVE_OPTIONS,
+      windowSize: 5,
+      seed: 1,
+      populationSize: 4,
+      maxGenerations: 2,
+      errorThreshold: 0,
+      timeoutMinutes: 0,
+      dataDir: tmp,
+    });
+    // The factory seed carries a pre-sized hidden layer, so it has more
+    // than the single output neuron a bare `new Creature(5, 1)` would.
+    assertGreater(result.seedNeurons, OUTPUT_COUNT);
+    assertGreater(result.seedSynapses, 0);
+  } finally {
+    Deno.removeSync(tmp, { recursive: true });
+  }
 });
 
 Deno.test("writeStockTrainingDataset writes one record per sample", () => {


### PR DESCRIPTION
## Summary

Build the Stock-Market example's fresh-run seed via the NEAT-AI **dataset-aware factory**
(`Creature.forDataset(records, { cost: "MSE" })`) instead of a bare `new Creature(WINDOW_SIZE, 1)`,
and add **robust, frozen input normalisation** that travels with the model into inference. This is
the closest example to the private GRQ market-prediction use case, so it is the most valuable
demonstration of data-derived initialisation on a regression / time-series problem (part of the
factory-adoption tracker #517). **Only the seed and the input transform change — the `evolveDir`
configuration (population, mutation, stop conditions, seed) is untouched.**

Closes #519.

### What changed

- **Factory seed (`buildSeedCreature`).** The fresh-run seed is now built by scanning the training
  data. The factory derives, from problem-intrinsic facts only:
  - a **linear (IDENTITY) regression output** (picked from the `MSE` cost);
  - an **output bias warm-started to the target mean** (≈ 0.63 on the up-skewed S&P 500), so the
    seed predicts the base rate before any training;
  - a **conservative, data-derived hidden-capacity budget** (markets = limited, non-stationary
    samples → overfitting is the main risk);
  - **constant-feature pruning** (synapses from zero-variance inputs are zeroed).
- **Frozen robust normalisation (`computeNormalizationStats` / `applyNormalization` /
  `normalizeSamples`).** Per-feature **median / IQR** statistics are computed on the **training
  window only**, then frozen and reused unchanged for validation, test, and live inference. Median /
  IQR resist the fat-tailed outliers typical of returns; freezing the stats is the
  **non-stationarity safeguard** — the model always sees the exact transform it was trained against,
  and no future information leaks backwards. The stats are persisted to
  `.synthetic-stock/creatures/normalization.json` and embedded in `signals.json`, so the
  normalisation **travels with the model into inference**.
- **`readTrainingRecords`** reconstructs factory records from the written `.bin`, so the factory
  scans exactly the data `evolveDir` trains on.
- The bare-constructor seed (`buildRandomSeedCreature`) is **retained** as the historical baseline
  and for synthetic test/resume fixtures.

### Deliberate departure from the no-warm-start policy

`stock_market` is listed as an in-scope "noise → competent" example in `AGENTS.md`. Adopting the
data-derived factory seed is a **deliberate, milestone-sanctioned exception** under the
factory-adoption tracker (#517): the data-derived seed _is_ the demonstration. `AGENTS.md` and the
example README are updated to record the exception. Structural growth beyond the seed still comes
purely from `evolveDir`'s mutation operators.

## Evidence

This is a backend / CLI change — no web UI to screenshot. Verified via unit tests and an end-to-end
quick-mode run (`STOCK_QUICK=1 ... --fresh`).

### Baseline comparison (seed topology)

| Seed (fresh run)        | Output activation | Output bias        | Hidden neurons | Neurons / synapses\* |
| ----------------------- | ----------------- | ------------------ | -------------- | -------------------- |
| Prior `new Creature`    | LOGISTIC          | random             | 0              | 11 / 10              |
| **Factory (this PR)**   | IDENTITY (linear) | target mean (≈0.63)| 8              | **19 / 88**          |

\* Neurons counted on the live `Creature` (10 inputs + hidden + 1 output). End-to-end quick run
reported `seed=19/88` for `WINDOW_SIZE=10`, confirming the data-derived hidden layer.

Inputs are now robustly standardised with frozen train-window median/IQR stats, persisted to
`normalization.json` and `signals.json` so the transform is reproducible from the run artefacts.

### Seed + normalisation data flow

```mermaid
flowchart LR
    TRAIN["Train window"] -->|median / IQR| STATS["Frozen stats<br/>normalization.json"]
    STATS --> NT["Train (normalised)"]
    STATS --> NV["Val / Test / live (normalised)"]
    NT --> BIN["Binary .bin"]
    BIN --> FACT["Creature.forDataset()<br/>linear output, target-mean bias,<br/>data-derived capacity"]
    BIN --> EV["evolveDir (unchanged)"]
    FACT --> EV
    NV --> INF["Inference (same frozen stats)"]
```

## Test Plan

New "what" tests (all call real functions and assert on observable outputs):

- `stock_market/data_test.ts`
  - `computeNormalizationStats` returns per-feature median and IQR; throws on empty input.
  - `applyNormalization` robustly standardises, is robust to a large outlier, guards a constant
    (zero-IQR) feature, and rejects a width mismatch.
  - `normalizeSamples` freezes train stats and reuses them on unseen samples, and does not mutate the
    input.
- `stock_market/stock_market_test.ts`
  - `buildSeedCreature` builds the right arity, sizes a data-derived hidden layer, picks a linear
    (IDENTITY) output, warm-starts the output bias to the target mean, is deterministic
    (weights/biases) for a given seed, produces a valid creature with finite outputs, and throws on
    empty records.
  - `readTrainingRecords` round-trips a written `.bin` into factory records.
  - `evolveStockController` seeds via the factory when not resuming (`seedNeurons > OUTPUT_COUNT`).

Existing tests are unchanged and still pass (the bare-constructor baseline and all multi-run wiring
remain green). Full `./quality.sh` run (fmt, lint, type-check, unit tests, every example in quick
mode) passes.



## Milestone
This PR is part of the **Factory** milestone and targets the `milestone/factory` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mpqmu98q-2e2e8e`<!-- vibe-worker-issue-519 -->