### PR TITLE
Auto-thin run-boundary labels/ticks in shared multi-run SVG renderers (Issue #521)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -264,6 +264,8 @@ common/
   multi_run_error_chart_test.ts    — Unit tests for the multi-run error chart renderer
   multi_run_complexity_chart.ts    — SVG renderer: neurons + synapses vs cumulative generations across runs
   multi_run_complexity_chart_test.ts — Unit tests for the multi-run complexity chart renderer
+  multi_run_boundary_thinning.ts   — Shared run-boundary label/tick thinning policy for both renderers
+  multi_run_boundary_thinning_test.ts — Unit tests for the boundary thinning policy
 
 crossover/
   crossover_example.ts             — Example: breed two creatures (crossover)

--- a/common/multi_run_boundary_thinning.ts
+++ b/common/multi_run_boundary_thinning.ts
@@ -1,0 +1,114 @@
+/**
+ * Shared run-boundary label thinning policy for the multi-run SVG renderers.
+ *
+ * Multi-run examples can accumulate dozens or hundreds of run boundaries
+ * (see issue #514 — 115 runs across ~5650 generations on a log-x axis).
+ * Drawing one tick + `run N` label per boundary collapses into an
+ * unreadable smear, so both `multi_run_error_chart.ts` and
+ * `multi_run_complexity_chart.ts` route their boundary rendering through
+ * {@link selectBoundaryIndices}: it picks the indices of the boundaries
+ * that should actually receive a visible tick + label.
+ *
+ * Policy (from issue #521):
+ *
+ *   1. **Auto-fit.** Estimate label width from the longest `"run N"`
+ *      string at font-size 10 (≈6.5 px per character is a safe
+ *      deno-side estimate) and pick the largest stride `k` such that
+ *      `ceil(totalBoundaries / k) * estimatedLabelWidth <= plotW * 0.9`.
+ *   2. **Cap.** Never show more than 10 boundary labels.
+ *   3. **Anchors.** The first and last run-boundary transition must
+ *      always be in the selected set; intermediate picks are evenly
+ *      spaced.
+ *   4. **Ticks follow labels.** Callers only render a boundary tick
+ *      where a label is drawn — bare ticks are never emitted.
+ *   5. **≤10 boundaries.** Every boundary keeps its label/tick
+ *      regardless of plot width — guarantees byte-identical output
+ *      for low-run-count campaigns (acceptance criterion).
+ */
+
+/**
+ * Maximum boundary labels the policy will ever emit, even when more
+ * would technically fit at the default 800 px width.
+ */
+export const MAX_BOUNDARY_LABELS = 10;
+
+/**
+ * Estimated width in pixels of a single character at font-size 10
+ * sans-serif. Empirically a safe upper-bound on a Deno-side render
+ * (no DOM is available to measure exactly).
+ */
+export const ESTIMATED_CHAR_WIDTH_PX = 6.5;
+
+/**
+ * Fraction of the plot width that label text is allowed to occupy.
+ * The remaining 10 % gives the leftmost and rightmost labels room to
+ * extend past the boundary tick they sit above.
+ */
+export const PLOT_WIDTH_USABLE_FRACTION = 0.9;
+
+/**
+ * Select the indices of the run boundaries that should receive a
+ * visible tick + label.
+ *
+ * @param boundaryCount Number of run-boundary transitions detected in
+ *   the milestone series. Boundary `i` corresponds to the i-th
+ *   transition in cumulative order.
+ * @param plotWidth Width of the plot area in user units.
+ * @param longestLabelChars Length of the longest `"run N"` label that
+ *   would be emitted. Used to estimate label width.
+ * @returns Sorted, deduplicated array of boundary indices to render.
+ *   Empty when `boundaryCount === 0`. Always includes the first (`0`)
+ *   and last (`boundaryCount - 1`) indices when `boundaryCount >= 1`.
+ */
+export function selectBoundaryIndices(
+  boundaryCount: number,
+  plotWidth: number,
+  longestLabelChars: number,
+): number[] {
+  if (boundaryCount <= 0) return [];
+  if (boundaryCount === 1) return [0];
+
+  // Low-run-count short-circuit: ≤10 boundaries keeps every label, so
+  // a 1–10 run campaign renders byte-identically to the pre-#521
+  // implementation. The width check is intentionally skipped here —
+  // the cap itself comfortably fits at the default 800 px plot width
+  // (10 × "run 10" ≈ 390 px <= 720 px).
+  if (boundaryCount <= MAX_BOUNDARY_LABELS) {
+    return rangeIndices(boundaryCount);
+  }
+
+  // Auto-fit: how many labels can sit side-by-side without overlap?
+  const labelWidth = Math.max(1, longestLabelChars) * ESTIMATED_CHAR_WIDTH_PX;
+  const usableWidth = Math.max(0, plotWidth) * PLOT_WIDTH_USABLE_FRACTION;
+  const maxByWidth = Math.max(1, Math.floor(usableWidth / labelWidth));
+
+  // Apply the cap and clamp to the available boundary count.
+  const numLabels = Math.min(boundaryCount, MAX_BOUNDARY_LABELS, maxByWidth);
+
+  if (numLabels >= boundaryCount) {
+    return rangeIndices(boundaryCount);
+  }
+  if (numLabels <= 1) {
+    // Degenerate width — still anchor on the last boundary so the
+    // viewer can read "run N" for whatever the final run was.
+    return [boundaryCount - 1];
+  }
+
+  // Evenly distribute `numLabels` indices across `[0, boundaryCount - 1]`,
+  // anchored at both ends. `Math.round` of the linear interpolation
+  // gives an integer position for each label; deduplication via Set
+  // guards against rounding collisions when `numLabels` is close to
+  // `boundaryCount`.
+  const indices = new Set<number>();
+  for (let j = 0; j < numLabels; j++) {
+    const idx = Math.round((j * (boundaryCount - 1)) / (numLabels - 1));
+    indices.add(idx);
+  }
+  return [...indices].sort((a, b) => a - b);
+}
+
+function rangeIndices(n: number): number[] {
+  const out: number[] = new Array(n);
+  for (let i = 0; i < n; i++) out[i] = i;
+  return out;
+}

--- a/common/multi_run_boundary_thinning_test.ts
+++ b/common/multi_run_boundary_thinning_test.ts
@@ -1,0 +1,126 @@
+/**
+ * Unit tests for the shared run-boundary thinning policy.
+ *
+ * These are "what" tests — they verify the indices returned by
+ * `selectBoundaryIndices` for a range of boundary counts, without
+ * inspecting how the helper computes them.
+ */
+
+import { assert, assertEquals } from "@std/assert";
+
+import {
+  ESTIMATED_CHAR_WIDTH_PX,
+  MAX_BOUNDARY_LABELS,
+  PLOT_WIDTH_USABLE_FRACTION,
+  selectBoundaryIndices,
+} from "./multi_run_boundary_thinning.ts";
+
+const DEFAULT_PLOT_W = 690; // matches 800 px chart minus 70 + 40 margins.
+const DEFAULT_LONGEST = "run 115".length;
+
+Deno.test("selectBoundaryIndices: zero boundaries returns empty", () => {
+  assertEquals(selectBoundaryIndices(0, DEFAULT_PLOT_W, DEFAULT_LONGEST), []);
+});
+
+Deno.test("selectBoundaryIndices: single boundary returns [0]", () => {
+  assertEquals(selectBoundaryIndices(1, DEFAULT_PLOT_W, DEFAULT_LONGEST), [0]);
+});
+
+Deno.test("selectBoundaryIndices: ≤10 boundaries selects every index (no thinning)", () => {
+  for (let n = 1; n <= MAX_BOUNDARY_LABELS; n++) {
+    const indices = selectBoundaryIndices(n, DEFAULT_PLOT_W, DEFAULT_LONGEST);
+    assertEquals(indices.length, n, `n=${n}: expected ${n} indices`);
+    assertEquals(indices[0], 0);
+    assertEquals(indices[n - 1], n - 1);
+  }
+});
+
+Deno.test(
+  "selectBoundaryIndices: 49 boundaries (50 runs) caps at 10 labels and anchors first + last",
+  () => {
+    const indices = selectBoundaryIndices(49, DEFAULT_PLOT_W, "run 50".length);
+    assert(
+      indices.length <= MAX_BOUNDARY_LABELS,
+      `expected ≤${MAX_BOUNDARY_LABELS} labels, got ${indices.length}`,
+    );
+    assertEquals(indices[0], 0, "first boundary must be selected");
+    assertEquals(
+      indices[indices.length - 1],
+      48,
+      "last boundary must be selected",
+    );
+  },
+);
+
+Deno.test(
+  "selectBoundaryIndices: 114 boundaries (115 runs) caps at 10 labels and labels do not overlap at 800 px",
+  () => {
+    const longest = "run 115".length;
+    const indices = selectBoundaryIndices(114, DEFAULT_PLOT_W, longest);
+    assert(
+      indices.length <= MAX_BOUNDARY_LABELS,
+      `expected ≤${MAX_BOUNDARY_LABELS} labels, got ${indices.length}`,
+    );
+    assertEquals(indices[0], 0);
+    assertEquals(indices[indices.length - 1], 113);
+
+    // Verify the selected labels comfortably fit the usable width.
+    const labelWidth = longest * ESTIMATED_CHAR_WIDTH_PX;
+    const usableWidth = DEFAULT_PLOT_W * PLOT_WIDTH_USABLE_FRACTION;
+    assert(
+      indices.length * labelWidth <= usableWidth + 1e-6,
+      `labels (${indices.length}*${labelWidth}=${indices.length * labelWidth}) ` +
+        `exceed usable width ${usableWidth}`,
+    );
+  },
+);
+
+Deno.test("selectBoundaryIndices: deterministic for identical input", () => {
+  const a = selectBoundaryIndices(114, DEFAULT_PLOT_W, "run 115".length);
+  const b = selectBoundaryIndices(114, DEFAULT_PLOT_W, "run 115".length);
+  assertEquals(a, b);
+});
+
+Deno.test("selectBoundaryIndices: large counts produce evenly-spaced indices", () => {
+  const indices = selectBoundaryIndices(100, DEFAULT_PLOT_W, "run 100".length);
+  // Confirm strictly increasing.
+  for (let i = 1; i < indices.length; i++) {
+    assert(
+      indices[i] > indices[i - 1],
+      `indices must be strictly increasing: ${indices.join(",")}`,
+    );
+  }
+  // Evenly spaced — every gap is within 1 of the average gap.
+  const avgGap = (indices[indices.length - 1] - indices[0]) /
+    (indices.length - 1);
+  for (let i = 1; i < indices.length; i++) {
+    const gap = indices[i] - indices[i - 1];
+    assert(
+      Math.abs(gap - avgGap) <= 1,
+      `gap ${gap} differs from average ${avgGap} by more than 1`,
+    );
+  }
+});
+
+Deno.test(
+  "selectBoundaryIndices: narrow plot width still anchors last boundary",
+  () => {
+    // 30 px plot with a 6-char label → labelWidth ≈ 39, usable ≈ 27.
+    // Only one label fits, so the helper should return just the last.
+    const indices = selectBoundaryIndices(50, 30, "run 50".length);
+    assert(indices.length >= 1);
+    assertEquals(indices[indices.length - 1], 49);
+  },
+);
+
+Deno.test(
+  "selectBoundaryIndices: longer labels shrink the selected count at fixed width",
+  () => {
+    const wide = selectBoundaryIndices(200, DEFAULT_PLOT_W, "run 9".length);
+    const narrow = selectBoundaryIndices(200, DEFAULT_PLOT_W, "run 9999".length);
+    assert(
+      wide.length >= narrow.length,
+      `shorter labels should fit at least as many: wide=${wide.length} narrow=${narrow.length}`,
+    );
+  },
+);

--- a/common/multi_run_complexity_chart.ts
+++ b/common/multi_run_complexity_chart.ts
@@ -17,6 +17,7 @@
  */
 
 import type { MultiRunMilestone } from "./multi_run_state.ts";
+import { selectBoundaryIndices } from "./multi_run_boundary_thinning.ts";
 
 /** Options controlling {@link renderMultiRunComplexityChartSVG}. */
 export interface RenderMultiRunComplexityChartOptions {
@@ -124,7 +125,7 @@ export function renderMultiRunComplexityChartSVG(
 
   // Run-boundary markers — render under the polylines so the data stays
   // visually on top. Detect each runIndex transition in cumulative order.
-  lines.push(renderRunBoundaries(ordered, xScale, plotY, plotH));
+  lines.push(renderRunBoundaries(ordered, xScale, plotY, plotH, plotW));
 
   // Series — neurons on left axis, synapses on right axis.
   lines.push(
@@ -317,16 +318,37 @@ function renderRunBoundaries(
   xScale: (v: number) => number,
   plotTop: number,
   plotH: number,
+  plotW: number,
 ): string {
-  const out: string[] = [];
-  out.push(
-    `  <g class="run-boundaries" font-family="sans-serif" font-size="10" fill="#666666">`,
-  );
+  // Detect every runIndex transition in cumulative order before
+  // applying the thinning policy — boundaries are de-duplicated to
+  // (runIndex, cumulativeGen) pairs at this stage.
+  const boundaries: Array<{ runIndex: number; cumulativeGen: number }> = [];
   for (let i = 1; i < samples.length; i++) {
     const prev = samples[i - 1];
     const curr = samples[i];
     if (curr.runIndex === prev.runIndex) continue;
-    const x = xScale(curr.cumulativeGen);
+    boundaries.push({
+      runIndex: curr.runIndex,
+      cumulativeGen: curr.cumulativeGen,
+    });
+  }
+
+  const longestLabel = boundaries.length === 0 ? 0 : Math.max(
+    ...boundaries.map((b) => `run ${b.runIndex}`.length),
+  );
+  const selected = new Set(
+    selectBoundaryIndices(boundaries.length, plotW, longestLabel),
+  );
+
+  const out: string[] = [];
+  out.push(
+    `  <g class="run-boundaries" font-family="sans-serif" font-size="10" fill="#666666">`,
+  );
+  for (let i = 0; i < boundaries.length; i++) {
+    if (!selected.has(i)) continue;
+    const b = boundaries[i];
+    const x = xScale(b.cumulativeGen);
     out.push(
       `    <line class="run-boundary" x1="${fmt(x)}" y1="${fmt(plotTop)}" ` +
         `x2="${fmt(x)}" y2="${fmt(plotTop + plotH)}" ` +
@@ -334,7 +356,7 @@ function renderRunBoundaries(
     );
     out.push(
       `    <text x="${fmt(x)}" y="${fmt(plotTop - 4)}" text-anchor="middle">` +
-        `run ${curr.runIndex}</text>`,
+        `run ${b.runIndex}</text>`,
     );
   }
   out.push(`  </g>`);

--- a/common/multi_run_complexity_chart_test.ts
+++ b/common/multi_run_complexity_chart_test.ts
@@ -253,3 +253,125 @@ Deno.test("renderMultiRunComplexityChartSVG: default title mentions creature com
   const svg = renderMultiRunComplexityChartSVG(samples);
   assertStringIncludes(svg, "complexity");
 });
+
+// ---------------------------------------------------------------------------
+// Boundary thinning (issue #521)
+// ---------------------------------------------------------------------------
+
+/** Synthesise an N-run milestone series with one sample per run. */
+function makeNRunSeries(runCount: number): MultiRunMilestone[] {
+  const samples: MultiRunMilestone[] = [];
+  for (let r = 1; r <= runCount; r++) {
+    samples.push({
+      runIndex: r,
+      runGen: 10,
+      cumulativeGen: r * 10,
+      error: 0.5,
+      bestScore: 0.5,
+      neurons: 4 + r,
+      synapses: 6 + r * 2,
+      generationWallClockMs: 100,
+    });
+  }
+  return samples;
+}
+
+function countBoundaryLabels(svg: string): number {
+  const block = svg.match(
+    /<g class="run-boundaries"[\s\S]*?<\/g>/,
+  );
+  if (!block) return 0;
+  return (block[0].match(/<text[^>]*>run \d+<\/text>/g) ?? []).length;
+}
+
+function countBoundaryTicks(svg: string): number {
+  return (svg.match(/<line class="run-boundary"/g) ?? []).length;
+}
+
+Deno.test(
+  "renderMultiRunComplexityChartSVG: ≤10 runs renders every boundary (issue #521)",
+  () => {
+    for (const runCount of [1, 2, 5, 10]) {
+      const svg = renderMultiRunComplexityChartSVG(makeNRunSeries(runCount));
+      const expectedBoundaries = runCount - 1;
+      assertEquals(
+        countBoundaryLabels(svg),
+        expectedBoundaries,
+        `runCount=${runCount}: expected ${expectedBoundaries} labels`,
+      );
+      assertEquals(
+        countBoundaryTicks(svg),
+        expectedBoundaries,
+        `runCount=${runCount}: tick count must match label count`,
+      );
+    }
+  },
+);
+
+Deno.test(
+  "renderMultiRunComplexityChartSVG: 50 runs caps boundary labels at 10 (issue #521)",
+  () => {
+    const svg = renderMultiRunComplexityChartSVG(makeNRunSeries(50));
+    const labels = countBoundaryLabels(svg);
+    assert(labels <= 10, `expected ≤10 labels, got ${labels}`);
+    assertEquals(countBoundaryTicks(svg), labels);
+    assertStringIncludes(svg, ">run 2<");
+    assertStringIncludes(svg, ">run 50<");
+  },
+);
+
+Deno.test(
+  "renderMultiRunComplexityChartSVG: 115 runs caps labels at 10 and includes first + last (issue #521 / #514)",
+  () => {
+    const svg = renderMultiRunComplexityChartSVG(makeNRunSeries(115));
+    const labels = countBoundaryLabels(svg);
+    assert(labels <= 10, `expected ≤10 labels, got ${labels}`);
+    assertEquals(countBoundaryTicks(svg), labels);
+    assertStringIncludes(svg, ">run 2<");
+    assertStringIncludes(svg, ">run 115<");
+  },
+);
+
+Deno.test(
+  "renderMultiRunComplexityChartSVG: boundary selection is deterministic across runs (issue #521)",
+  () => {
+    const samples = makeNRunSeries(60);
+    const a = renderMultiRunComplexityChartSVG(samples);
+    const b = renderMultiRunComplexityChartSVG(samples);
+    assertEquals(a, b);
+  },
+);
+
+/** Build the snapshot's 10-run fixture deterministically. */
+function makeBaselineSnapshotSeries(): MultiRunMilestone[] {
+  const samples: MultiRunMilestone[] = [];
+  for (let r = 1; r <= 10; r++) {
+    for (let i = 0; i < 3; i++) {
+      const g = (r - 1) * 100 + Math.pow(10, i);
+      samples.push({
+        runIndex: r,
+        runGen: Math.pow(10, i),
+        cumulativeGen: g,
+        error: 0.9 / r - 0.01 * i,
+        bestScore: 0.1 * r,
+        neurons: 4 + r,
+        synapses: 6 + r * 2,
+        generationWallClockMs: 100,
+      });
+    }
+  }
+  return samples;
+}
+
+Deno.test(
+  "renderMultiRunComplexityChartSVG: 10-run snapshot is byte-identical to pre-#521 baseline",
+  async () => {
+    const expected = await Deno.readTextFile(
+      new URL("./testdata/baseline_cx_10runs.svg", import.meta.url),
+    );
+    const actual = renderMultiRunComplexityChartSVG(
+      makeBaselineSnapshotSeries(),
+    );
+    assertEquals(actual, expected);
+  },
+);

--- a/common/multi_run_error_chart.ts
+++ b/common/multi_run_error_chart.ts
@@ -15,6 +15,7 @@
  */
 
 import type { MultiRunMilestone } from "./multi_run_state.ts";
+import { selectBoundaryIndices } from "./multi_run_boundary_thinning.ts";
 
 /** Options controlling {@link renderMultiRunErrorChartSVG}. */
 export interface RenderMultiRunErrorChartOptions {
@@ -127,7 +128,7 @@ export function renderMultiRunErrorChartSVG(
 
   // Run-boundary markers — render under the polylines so the data stays
   // visually on top. Detect each runIndex transition in cumulative order.
-  lines.push(renderRunBoundaries(ordered, xScale, plotY, plotH));
+  lines.push(renderRunBoundaries(ordered, xScale, plotY, plotH, plotW));
 
   // Issue #431: plot the best-error-so-far envelope as a single
   // continuous polyline. The envelope is monotonically non-increasing,
@@ -272,16 +273,37 @@ function renderRunBoundaries(
   xScale: (v: number) => number,
   plotTop: number,
   plotH: number,
+  plotW: number,
 ): string {
-  const out: string[] = [];
-  out.push(
-    `  <g class="run-boundaries" font-family="sans-serif" font-size="10" fill="#666666">`,
-  );
+  // Detect every runIndex transition in cumulative order before
+  // applying the thinning policy — boundaries are de-duplicated to
+  // (runIndex, cumulativeGen) pairs at this stage.
+  const boundaries: Array<{ runIndex: number; cumulativeGen: number }> = [];
   for (let i = 1; i < samples.length; i++) {
     const prev = samples[i - 1];
     const curr = samples[i];
     if (curr.runIndex === prev.runIndex) continue;
-    const x = xScale(curr.cumulativeGen);
+    boundaries.push({
+      runIndex: curr.runIndex,
+      cumulativeGen: curr.cumulativeGen,
+    });
+  }
+
+  const longestLabel = boundaries.length === 0 ? 0 : Math.max(
+    ...boundaries.map((b) => `run ${b.runIndex}`.length),
+  );
+  const selected = new Set(
+    selectBoundaryIndices(boundaries.length, plotW, longestLabel),
+  );
+
+  const out: string[] = [];
+  out.push(
+    `  <g class="run-boundaries" font-family="sans-serif" font-size="10" fill="#666666">`,
+  );
+  for (let i = 0; i < boundaries.length; i++) {
+    if (!selected.has(i)) continue;
+    const b = boundaries[i];
+    const x = xScale(b.cumulativeGen);
     out.push(
       `    <line class="run-boundary" x1="${fmt(x)}" y1="${fmt(plotTop)}" ` +
         `x2="${fmt(x)}" y2="${fmt(plotTop + plotH)}" ` +
@@ -289,7 +311,7 @@ function renderRunBoundaries(
     );
     out.push(
       `    <text x="${fmt(x)}" y="${fmt(plotTop - 4)}" text-anchor="middle">` +
-        `run ${curr.runIndex}</text>`,
+        `run ${b.runIndex}</text>`,
     );
   }
   out.push(`  </g>`);

--- a/common/multi_run_error_chart_test.ts
+++ b/common/multi_run_error_chart_test.ts
@@ -399,3 +399,128 @@ Deno.test("renderMultiRunErrorChartSVG: unsorted input is sorted by cumulativeGe
   const shuffled = renderMultiRunErrorChartSVG(reversed);
   assertEquals(ordered, shuffled);
 });
+
+// ---------------------------------------------------------------------------
+// Boundary thinning (issue #521)
+// ---------------------------------------------------------------------------
+
+/** Synthesise an N-run milestone series with one sample per run. */
+function makeNRunSeries(runCount: number): MultiRunMilestone[] {
+  const samples: MultiRunMilestone[] = [];
+  for (let r = 1; r <= runCount; r++) {
+    samples.push({
+      runIndex: r,
+      runGen: 10,
+      cumulativeGen: r * 10,
+      error: 0.5,
+      bestScore: 0.5,
+      neurons: 4,
+      synapses: 6,
+      generationWallClockMs: 100,
+    });
+  }
+  return samples;
+}
+
+function countBoundaryLabels(svg: string): number {
+  const block = svg.match(
+    /<g class="run-boundaries"[\s\S]*?<\/g>/,
+  );
+  if (!block) return 0;
+  return (block[0].match(/<text[^>]*>run \d+<\/text>/g) ?? []).length;
+}
+
+function countBoundaryTicks(svg: string): number {
+  return (svg.match(/<line class="run-boundary"/g) ?? []).length;
+}
+
+Deno.test(
+  "renderMultiRunErrorChartSVG: ≤10 runs renders every boundary (issue #521)",
+  () => {
+    for (const runCount of [1, 2, 5, 10]) {
+      const svg = renderMultiRunErrorChartSVG(makeNRunSeries(runCount));
+      const expectedBoundaries = runCount - 1; // first run has no boundary.
+      assertEquals(
+        countBoundaryLabels(svg),
+        expectedBoundaries,
+        `runCount=${runCount}: expected ${expectedBoundaries} labels`,
+      );
+      assertEquals(
+        countBoundaryTicks(svg),
+        expectedBoundaries,
+        `runCount=${runCount}: tick count must match label count`,
+      );
+    }
+  },
+);
+
+Deno.test(
+  "renderMultiRunErrorChartSVG: 50 runs caps boundary labels at 10 (issue #521)",
+  () => {
+    const svg = renderMultiRunErrorChartSVG(makeNRunSeries(50));
+    const labels = countBoundaryLabels(svg);
+    assert(labels <= 10, `expected ≤10 labels, got ${labels}`);
+    assertEquals(
+      countBoundaryTicks(svg),
+      labels,
+      "tick count must match label count (ticks follow labels)",
+    );
+    // First boundary (run 2) and last boundary (run 50) must be labelled.
+    assertStringIncludes(svg, ">run 2<");
+    assertStringIncludes(svg, ">run 50<");
+  },
+);
+
+Deno.test(
+  "renderMultiRunErrorChartSVG: 115 runs caps labels at 10 and includes first + last (issue #521 / #514)",
+  () => {
+    const svg = renderMultiRunErrorChartSVG(makeNRunSeries(115));
+    const labels = countBoundaryLabels(svg);
+    assert(labels <= 10, `expected ≤10 labels, got ${labels}`);
+    assertEquals(countBoundaryTicks(svg), labels);
+    assertStringIncludes(svg, ">run 2<");
+    assertStringIncludes(svg, ">run 115<");
+  },
+);
+
+Deno.test(
+  "renderMultiRunErrorChartSVG: boundary selection is deterministic across runs (issue #521)",
+  () => {
+    const samples = makeNRunSeries(60);
+    const a = renderMultiRunErrorChartSVG(samples);
+    const b = renderMultiRunErrorChartSVG(samples);
+    assertEquals(a, b);
+  },
+);
+
+/** Build the snapshot's 10-run fixture deterministically. */
+function makeBaselineSnapshotSeries(): MultiRunMilestone[] {
+  const samples: MultiRunMilestone[] = [];
+  for (let r = 1; r <= 10; r++) {
+    for (let i = 0; i < 3; i++) {
+      const g = (r - 1) * 100 + Math.pow(10, i);
+      samples.push({
+        runIndex: r,
+        runGen: Math.pow(10, i),
+        cumulativeGen: g,
+        error: 0.9 / r - 0.01 * i,
+        bestScore: 0.1 * r,
+        neurons: 4 + r,
+        synapses: 6 + r * 2,
+        generationWallClockMs: 100,
+      });
+    }
+  }
+  return samples;
+}
+
+Deno.test(
+  "renderMultiRunErrorChartSVG: 10-run snapshot is byte-identical to pre-#521 baseline",
+  async () => {
+    const expected = await Deno.readTextFile(
+      new URL("./testdata/baseline_err_10runs.svg", import.meta.url),
+    );
+    const actual = renderMultiRunErrorChartSVG(makeBaselineSnapshotSeries());
+    assertEquals(actual, expected);
+  },
+);

--- a/common/testdata/baseline_cx_10runs.svg
+++ b/common/testdata/baseline_cx_10runs.svg
@@ -1,0 +1,160 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" width="800" height="400" role="img" aria-label="Multi-run evolution — creature complexity vs cumulative generations dual-axis chart">
+  <title>Multi-run evolution — creature complexity vs cumulative generations</title>
+  <rect width="800" height="400" fill="#fafafa"/>
+  <text x="400" y="24" text-anchor="middle" font-family="sans-serif" font-size="16" font-weight="bold" fill="#222">Multi-run evolution — creature complexity vs cumulative generations</text>
+  <rect x="70" y="50" width="660" height="290" fill="#ffffff" stroke="#333333" stroke-width="1"/>
+  <g class="x-axis" font-family="sans-serif" font-size="11" fill="#333333">
+    <line x1="70" y1="340" x2="70" y2="344" stroke="#333333" stroke-width="1"/>
+    <text x="70" y="358" text-anchor="middle">1</text>
+    <line x1="290" y1="340" x2="290" y2="344" stroke="#333333" stroke-width="1"/>
+    <text x="290" y="358" text-anchor="middle">10</text>
+    <line x1="510" y1="340" x2="510" y2="344" stroke="#333333" stroke-width="1"/>
+    <text x="510" y="358" text-anchor="middle">100</text>
+    <line x1="730" y1="340" x2="730" y2="344" stroke="#333333" stroke-width="1"/>
+    <text x="730" y="358" text-anchor="middle">1000</text>
+    <text x="400" y="376" text-anchor="middle" font-weight="bold">cumulative generation (log scale)</text>
+  </g>
+  <g class="left-axis" font-family="sans-serif" font-size="11" fill="#333333">
+    <line x1="66" y1="340" x2="70" y2="340" stroke="#333333" stroke-width="1"/>
+    <text x="62" y="340" text-anchor="end" dominant-baseline="middle">0</text>
+    <line x1="66" y1="277.86" x2="70" y2="277.86" stroke="#333333" stroke-width="1"/>
+    <text x="62" y="277.86" text-anchor="end" dominant-baseline="middle">3</text>
+    <line x1="66" y1="215.71" x2="70" y2="215.71" stroke="#333333" stroke-width="1"/>
+    <text x="62" y="215.71" text-anchor="end" dominant-baseline="middle">6</text>
+    <line x1="66" y1="153.57" x2="70" y2="153.57" stroke="#333333" stroke-width="1"/>
+    <text x="62" y="153.57" text-anchor="end" dominant-baseline="middle">9</text>
+    <line x1="66" y1="91.43" x2="70" y2="91.43" stroke="#333333" stroke-width="1"/>
+    <text x="62" y="91.43" text-anchor="end" dominant-baseline="middle">12</text>
+    <line x1="66" y1="50" x2="70" y2="50" stroke="#333333" stroke-width="1"/>
+    <text x="62" y="50" text-anchor="end" dominant-baseline="middle">14</text>
+    <text x="22" y="195" text-anchor="middle" dominant-baseline="middle" font-weight="bold" transform="rotate(-90 22 195)">neurons</text>
+  </g>
+  <g class="right-axis" font-family="sans-serif" font-size="11" fill="#333333">
+    <line x1="730" y1="340" x2="734" y2="340" stroke="#333333" stroke-width="1"/>
+    <text x="738" y="340" text-anchor="start" dominant-baseline="middle">0</text>
+    <line x1="730" y1="284.23" x2="734" y2="284.23" stroke="#333333" stroke-width="1"/>
+    <text x="738" y="284.23" text-anchor="start" dominant-baseline="middle">5</text>
+    <line x1="730" y1="228.46" x2="734" y2="228.46" stroke="#333333" stroke-width="1"/>
+    <text x="738" y="228.46" text-anchor="start" dominant-baseline="middle">10</text>
+    <line x1="730" y1="172.69" x2="734" y2="172.69" stroke="#333333" stroke-width="1"/>
+    <text x="738" y="172.69" text-anchor="start" dominant-baseline="middle">15</text>
+    <line x1="730" y1="116.92" x2="734" y2="116.92" stroke="#333333" stroke-width="1"/>
+    <text x="738" y="116.92" text-anchor="start" dominant-baseline="middle">20</text>
+    <line x1="730" y1="61.15" x2="734" y2="61.15" stroke="#333333" stroke-width="1"/>
+    <text x="738" y="61.15" text-anchor="start" dominant-baseline="middle">25</text>
+    <line x1="730" y1="50" x2="734" y2="50" stroke="#333333" stroke-width="1"/>
+    <text x="738" y="50" text-anchor="start" dominant-baseline="middle">26</text>
+    <text x="778" y="195" text-anchor="middle" dominant-baseline="middle" font-weight="bold" transform="rotate(90 778 195)">synapses</text>
+  </g>
+  <g class="run-boundaries" font-family="sans-serif" font-size="10" fill="#666666">
+    <line class="run-boundary" x1="510.95" y1="50" x2="510.95" y2="340" stroke="#cccccc" stroke-width="0.5"/>
+    <text x="510.95" y="46" text-anchor="middle">run 2</text>
+    <line class="run-boundary" x1="576.7" y1="50" x2="576.7" y2="340" stroke="#cccccc" stroke-width="0.5"/>
+    <text x="576.7" y="46" text-anchor="middle">run 3</text>
+    <line class="run-boundary" x1="615.28" y1="50" x2="615.28" y2="340" stroke="#cccccc" stroke-width="0.5"/>
+    <text x="615.28" y="46" text-anchor="middle">run 4</text>
+    <line class="run-boundary" x1="642.69" y1="50" x2="642.69" y2="340" stroke="#cccccc" stroke-width="0.5"/>
+    <text x="642.69" y="46" text-anchor="middle">run 5</text>
+    <line class="run-boundary" x1="663.96" y1="50" x2="663.96" y2="340" stroke="#cccccc" stroke-width="0.5"/>
+    <text x="663.96" y="46" text-anchor="middle">run 6</text>
+    <line class="run-boundary" x1="681.35" y1="50" x2="681.35" y2="340" stroke="#cccccc" stroke-width="0.5"/>
+    <text x="681.35" y="46" text-anchor="middle">run 7</text>
+    <line class="run-boundary" x1="696.06" y1="50" x2="696.06" y2="340" stroke="#cccccc" stroke-width="0.5"/>
+    <text x="696.06" y="46" text-anchor="middle">run 8</text>
+    <line class="run-boundary" x1="708.8" y1="50" x2="708.8" y2="340" stroke="#cccccc" stroke-width="0.5"/>
+    <text x="708.8" y="46" text-anchor="middle">run 9</text>
+    <line class="run-boundary" x1="720.04" y1="50" x2="720.04" y2="340" stroke="#cccccc" stroke-width="0.5"/>
+    <text x="720.04" y="46" text-anchor="middle">run 10</text>
+  </g>
+  <g class="neurons-line">
+    <polyline fill="none" stroke="#2ca02c" stroke-width="1.5" points="70,236.43 290,236.43 510,236.43"/>
+    <polyline fill="none" stroke="#2ca02c" stroke-width="1.5" points="510.95,215.71 519.11,215.71 576.23,215.71"/>
+    <polyline fill="none" stroke="#2ca02c" stroke-width="1.5" points="576.7,195 580.89,195 614.97,195"/>
+    <polyline fill="none" stroke="#2ca02c" stroke-width="1.5" points="615.28,174.29 618.1,174.29 642.45,174.29"/>
+    <polyline fill="none" stroke="#2ca02c" stroke-width="1.5" points="642.69,153.57 644.81,153.57 663.77,153.57"/>
+    <polyline fill="none" stroke="#2ca02c" stroke-width="1.5" points="663.96,132.86 665.67,132.86 681.19,132.86"/>
+    <polyline fill="none" stroke="#2ca02c" stroke-width="1.5" points="681.35,112.14 682.77,112.14 695.92,112.14"/>
+    <polyline fill="none" stroke="#2ca02c" stroke-width="1.5" points="696.06,91.43 697.28,91.43 708.68,91.43"/>
+    <polyline fill="none" stroke="#2ca02c" stroke-width="1.5" points="708.8,70.71 709.87,70.71 719.93,70.71"/>
+    <polyline fill="none" stroke="#2ca02c" stroke-width="1.5" points="720.04,50 720.99,50 730,50"/>
+    <circle class="neurons-point" cx="70" cy="236.43" r="2.4" fill="#2ca02c"/>
+    <circle class="neurons-point" cx="290" cy="236.43" r="2.4" fill="#2ca02c"/>
+    <circle class="neurons-point" cx="510" cy="236.43" r="2.4" fill="#2ca02c"/>
+    <circle class="neurons-point" cx="510.95" cy="215.71" r="2.4" fill="#2ca02c"/>
+    <circle class="neurons-point" cx="519.11" cy="215.71" r="2.4" fill="#2ca02c"/>
+    <circle class="neurons-point" cx="576.23" cy="215.71" r="2.4" fill="#2ca02c"/>
+    <circle class="neurons-point" cx="576.7" cy="195" r="2.4" fill="#2ca02c"/>
+    <circle class="neurons-point" cx="580.89" cy="195" r="2.4" fill="#2ca02c"/>
+    <circle class="neurons-point" cx="614.97" cy="195" r="2.4" fill="#2ca02c"/>
+    <circle class="neurons-point" cx="615.28" cy="174.29" r="2.4" fill="#2ca02c"/>
+    <circle class="neurons-point" cx="618.1" cy="174.29" r="2.4" fill="#2ca02c"/>
+    <circle class="neurons-point" cx="642.45" cy="174.29" r="2.4" fill="#2ca02c"/>
+    <circle class="neurons-point" cx="642.69" cy="153.57" r="2.4" fill="#2ca02c"/>
+    <circle class="neurons-point" cx="644.81" cy="153.57" r="2.4" fill="#2ca02c"/>
+    <circle class="neurons-point" cx="663.77" cy="153.57" r="2.4" fill="#2ca02c"/>
+    <circle class="neurons-point" cx="663.96" cy="132.86" r="2.4" fill="#2ca02c"/>
+    <circle class="neurons-point" cx="665.67" cy="132.86" r="2.4" fill="#2ca02c"/>
+    <circle class="neurons-point" cx="681.19" cy="132.86" r="2.4" fill="#2ca02c"/>
+    <circle class="neurons-point" cx="681.35" cy="112.14" r="2.4" fill="#2ca02c"/>
+    <circle class="neurons-point" cx="682.77" cy="112.14" r="2.4" fill="#2ca02c"/>
+    <circle class="neurons-point" cx="695.92" cy="112.14" r="2.4" fill="#2ca02c"/>
+    <circle class="neurons-point" cx="696.06" cy="91.43" r="2.4" fill="#2ca02c"/>
+    <circle class="neurons-point" cx="697.28" cy="91.43" r="2.4" fill="#2ca02c"/>
+    <circle class="neurons-point" cx="708.68" cy="91.43" r="2.4" fill="#2ca02c"/>
+    <circle class="neurons-point" cx="708.8" cy="70.71" r="2.4" fill="#2ca02c"/>
+    <circle class="neurons-point" cx="709.87" cy="70.71" r="2.4" fill="#2ca02c"/>
+    <circle class="neurons-point" cx="719.93" cy="70.71" r="2.4" fill="#2ca02c"/>
+    <circle class="neurons-point" cx="720.04" cy="50" r="2.4" fill="#2ca02c"/>
+    <circle class="neurons-point" cx="720.99" cy="50" r="2.4" fill="#2ca02c"/>
+    <circle class="neurons-point" cx="730" cy="50" r="2.4" fill="#2ca02c"/>
+  </g>
+  <g class="synapses-line">
+    <polyline fill="none" stroke="#d62728" stroke-width="1.5" points="70,250.77 290,250.77 510,250.77"/>
+    <polyline fill="none" stroke="#d62728" stroke-width="1.5" points="510.95,228.46 519.11,228.46 576.23,228.46"/>
+    <polyline fill="none" stroke="#d62728" stroke-width="1.5" points="576.7,206.15 580.89,206.15 614.97,206.15"/>
+    <polyline fill="none" stroke="#d62728" stroke-width="1.5" points="615.28,183.85 618.1,183.85 642.45,183.85"/>
+    <polyline fill="none" stroke="#d62728" stroke-width="1.5" points="642.69,161.54 644.81,161.54 663.77,161.54"/>
+    <polyline fill="none" stroke="#d62728" stroke-width="1.5" points="663.96,139.23 665.67,139.23 681.19,139.23"/>
+    <polyline fill="none" stroke="#d62728" stroke-width="1.5" points="681.35,116.92 682.77,116.92 695.92,116.92"/>
+    <polyline fill="none" stroke="#d62728" stroke-width="1.5" points="696.06,94.62 697.28,94.62 708.68,94.62"/>
+    <polyline fill="none" stroke="#d62728" stroke-width="1.5" points="708.8,72.31 709.87,72.31 719.93,72.31"/>
+    <polyline fill="none" stroke="#d62728" stroke-width="1.5" points="720.04,50 720.99,50 730,50"/>
+    <circle class="synapses-point" cx="70" cy="250.77" r="2.4" fill="#d62728"/>
+    <circle class="synapses-point" cx="290" cy="250.77" r="2.4" fill="#d62728"/>
+    <circle class="synapses-point" cx="510" cy="250.77" r="2.4" fill="#d62728"/>
+    <circle class="synapses-point" cx="510.95" cy="228.46" r="2.4" fill="#d62728"/>
+    <circle class="synapses-point" cx="519.11" cy="228.46" r="2.4" fill="#d62728"/>
+    <circle class="synapses-point" cx="576.23" cy="228.46" r="2.4" fill="#d62728"/>
+    <circle class="synapses-point" cx="576.7" cy="206.15" r="2.4" fill="#d62728"/>
+    <circle class="synapses-point" cx="580.89" cy="206.15" r="2.4" fill="#d62728"/>
+    <circle class="synapses-point" cx="614.97" cy="206.15" r="2.4" fill="#d62728"/>
+    <circle class="synapses-point" cx="615.28" cy="183.85" r="2.4" fill="#d62728"/>
+    <circle class="synapses-point" cx="618.1" cy="183.85" r="2.4" fill="#d62728"/>
+    <circle class="synapses-point" cx="642.45" cy="183.85" r="2.4" fill="#d62728"/>
+    <circle class="synapses-point" cx="642.69" cy="161.54" r="2.4" fill="#d62728"/>
+    <circle class="synapses-point" cx="644.81" cy="161.54" r="2.4" fill="#d62728"/>
+    <circle class="synapses-point" cx="663.77" cy="161.54" r="2.4" fill="#d62728"/>
+    <circle class="synapses-point" cx="663.96" cy="139.23" r="2.4" fill="#d62728"/>
+    <circle class="synapses-point" cx="665.67" cy="139.23" r="2.4" fill="#d62728"/>
+    <circle class="synapses-point" cx="681.19" cy="139.23" r="2.4" fill="#d62728"/>
+    <circle class="synapses-point" cx="681.35" cy="116.92" r="2.4" fill="#d62728"/>
+    <circle class="synapses-point" cx="682.77" cy="116.92" r="2.4" fill="#d62728"/>
+    <circle class="synapses-point" cx="695.92" cy="116.92" r="2.4" fill="#d62728"/>
+    <circle class="synapses-point" cx="696.06" cy="94.62" r="2.4" fill="#d62728"/>
+    <circle class="synapses-point" cx="697.28" cy="94.62" r="2.4" fill="#d62728"/>
+    <circle class="synapses-point" cx="708.68" cy="94.62" r="2.4" fill="#d62728"/>
+    <circle class="synapses-point" cx="708.8" cy="72.31" r="2.4" fill="#d62728"/>
+    <circle class="synapses-point" cx="709.87" cy="72.31" r="2.4" fill="#d62728"/>
+    <circle class="synapses-point" cx="719.93" cy="72.31" r="2.4" fill="#d62728"/>
+    <circle class="synapses-point" cx="720.04" cy="50" r="2.4" fill="#d62728"/>
+    <circle class="synapses-point" cx="720.99" cy="50" r="2.4" fill="#d62728"/>
+    <circle class="synapses-point" cx="730" cy="50" r="2.4" fill="#d62728"/>
+  </g>
+  <g class="legend" font-family="sans-serif" font-size="11" fill="#222222">
+    <rect x="76" y="52" width="120" height="40" fill="#ffffff" fill-opacity="0.85" stroke="#cccccc" stroke-width="0.5"/>
+    <line x1="82" y1="62" x2="100" y2="62" stroke="#2ca02c" stroke-width="2"/>
+    <text x="106" y="66">neurons</text>
+    <line x1="82" y1="78" x2="100" y2="78" stroke="#d62728" stroke-width="2"/>
+    <text x="106" y="82">synapses</text>
+  </g>
+</svg>

--- a/common/testdata/baseline_err_10runs.svg
+++ b/common/testdata/baseline_err_10runs.svg
@@ -1,0 +1,88 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" width="800" height="400" role="img" aria-label="Multi-run evolution — error vs cumulative generations chart">
+  <title>Multi-run evolution — error vs cumulative generations</title>
+  <rect width="800" height="400" fill="#fafafa"/>
+  <text x="400" y="24" text-anchor="middle" font-family="sans-serif" font-size="16" font-weight="bold" fill="#222">Multi-run evolution — error vs cumulative generations</text>
+  <rect x="70" y="50" width="690" height="290" fill="#ffffff" stroke="#333333" stroke-width="1"/>
+  <g class="x-axis" font-family="sans-serif" font-size="11" fill="#333333">
+    <line x1="70" y1="340" x2="70" y2="344" stroke="#333333" stroke-width="1"/>
+    <text x="70" y="358" text-anchor="middle">1</text>
+    <line x1="300" y1="340" x2="300" y2="344" stroke="#333333" stroke-width="1"/>
+    <text x="300" y="358" text-anchor="middle">10</text>
+    <line x1="530" y1="340" x2="530" y2="344" stroke="#333333" stroke-width="1"/>
+    <text x="530" y="358" text-anchor="middle">100</text>
+    <line x1="760" y1="340" x2="760" y2="344" stroke="#333333" stroke-width="1"/>
+    <text x="760" y="358" text-anchor="middle">1000</text>
+    <text x="415" y="376" text-anchor="middle" font-weight="bold">cumulative generation (log scale)</text>
+  </g>
+  <g class="y-axis" font-family="sans-serif" font-size="11" fill="#333333">
+    <line x1="66" y1="340" x2="70" y2="340" stroke="#333333" stroke-width="1"/>
+    <text x="62" y="340" text-anchor="end" dominant-baseline="middle">0</text>
+    <line x1="66" y1="275.56" x2="70" y2="275.56" stroke="#333333" stroke-width="1"/>
+    <text x="62" y="275.56" text-anchor="end" dominant-baseline="middle">0.2</text>
+    <line x1="66" y1="211.11" x2="70" y2="211.11" stroke="#333333" stroke-width="1"/>
+    <text x="62" y="211.11" text-anchor="end" dominant-baseline="middle">0.4</text>
+    <line x1="66" y1="146.67" x2="70" y2="146.67" stroke="#333333" stroke-width="1"/>
+    <text x="62" y="146.67" text-anchor="end" dominant-baseline="middle">0.6</text>
+    <line x1="66" y1="82.22" x2="70" y2="82.22" stroke="#333333" stroke-width="1"/>
+    <text x="62" y="82.22" text-anchor="end" dominant-baseline="middle">0.8</text>
+    <line x1="66" y1="50" x2="70" y2="50" stroke="#333333" stroke-width="1"/>
+    <text x="62" y="50" text-anchor="end" dominant-baseline="middle">0.9</text>
+    <text x="22" y="195" text-anchor="middle" dominant-baseline="middle" font-weight="bold" transform="rotate(-90 22 195)">error</text>
+  </g>
+  <g class="axis-footnote" font-family="sans-serif" font-size="10" fill="#666666">
+    <text x="415" y="386" text-anchor="middle">Linear error on Y · log₁₀ generations on X · line is best error so far · dots are raw milestone measurements.</text>
+  </g>
+  <g class="run-boundaries" font-family="sans-serif" font-size="10" fill="#666666">
+    <line class="run-boundary" x1="530.99" y1="50" x2="530.99" y2="340" stroke="#cccccc" stroke-width="0.5"/>
+    <text x="530.99" y="46" text-anchor="middle">run 2</text>
+    <line class="run-boundary" x1="599.74" y1="50" x2="599.74" y2="340" stroke="#cccccc" stroke-width="0.5"/>
+    <text x="599.74" y="46" text-anchor="middle">run 3</text>
+    <line class="run-boundary" x1="640.07" y1="50" x2="640.07" y2="340" stroke="#cccccc" stroke-width="0.5"/>
+    <text x="640.07" y="46" text-anchor="middle">run 4</text>
+    <line class="run-boundary" x1="668.72" y1="50" x2="668.72" y2="340" stroke="#cccccc" stroke-width="0.5"/>
+    <text x="668.72" y="46" text-anchor="middle">run 5</text>
+    <line class="run-boundary" x1="690.96" y1="50" x2="690.96" y2="340" stroke="#cccccc" stroke-width="0.5"/>
+    <text x="690.96" y="46" text-anchor="middle">run 6</text>
+    <line class="run-boundary" x1="709.14" y1="50" x2="709.14" y2="340" stroke="#cccccc" stroke-width="0.5"/>
+    <text x="709.14" y="46" text-anchor="middle">run 7</text>
+    <line class="run-boundary" x1="724.52" y1="50" x2="724.52" y2="340" stroke="#cccccc" stroke-width="0.5"/>
+    <text x="724.52" y="46" text-anchor="middle">run 8</text>
+    <line class="run-boundary" x1="737.84" y1="50" x2="737.84" y2="340" stroke="#cccccc" stroke-width="0.5"/>
+    <text x="737.84" y="46" text-anchor="middle">run 9</text>
+    <line class="run-boundary" x1="749.59" y1="50" x2="749.59" y2="340" stroke="#cccccc" stroke-width="0.5"/>
+    <text x="749.59" y="46" text-anchor="middle">run 10</text>
+  </g>
+  <g class="error-line">
+    <polyline fill="none" stroke="#d62728" stroke-width="1.5" points="70,50 300,53.22 530,56.44 530.99,195 539.52,198.22 599.24,201.44 599.74,243.33 604.11,246.56 639.74,249.78 640.07,267.5 643.01,270.72 668.47,273.94 668.72,282 670.94,285.22 690.76,288.44 690.96,291.67 692.74,294.89 708.97,298.11 709.14,298.57 710.63,301.79 724.37,305.02 724.52,305.02 725.79,306.97 737.71,310.19 737.84,310.19 738.95,311 749.48,314.22 749.59,314.22 750.58,314.22 760,317.44"/>
+    <circle class="error-point" cx="70" cy="50" r="2.4" fill="#d62728"/>
+    <circle class="error-point" cx="300" cy="53.22" r="2.4" fill="#d62728"/>
+    <circle class="error-point" cx="530" cy="56.44" r="2.4" fill="#d62728"/>
+    <circle class="error-point" cx="530.99" cy="195" r="2.4" fill="#d62728"/>
+    <circle class="error-point" cx="539.52" cy="198.22" r="2.4" fill="#d62728"/>
+    <circle class="error-point" cx="599.24" cy="201.44" r="2.4" fill="#d62728"/>
+    <circle class="error-point" cx="599.74" cy="243.33" r="2.4" fill="#d62728"/>
+    <circle class="error-point" cx="604.11" cy="246.56" r="2.4" fill="#d62728"/>
+    <circle class="error-point" cx="639.74" cy="249.78" r="2.4" fill="#d62728"/>
+    <circle class="error-point" cx="640.07" cy="267.5" r="2.4" fill="#d62728"/>
+    <circle class="error-point" cx="643.01" cy="270.72" r="2.4" fill="#d62728"/>
+    <circle class="error-point" cx="668.47" cy="273.94" r="2.4" fill="#d62728"/>
+    <circle class="error-point" cx="668.72" cy="282" r="2.4" fill="#d62728"/>
+    <circle class="error-point" cx="670.94" cy="285.22" r="2.4" fill="#d62728"/>
+    <circle class="error-point" cx="690.76" cy="288.44" r="2.4" fill="#d62728"/>
+    <circle class="error-point" cx="690.96" cy="291.67" r="2.4" fill="#d62728"/>
+    <circle class="error-point" cx="692.74" cy="294.89" r="2.4" fill="#d62728"/>
+    <circle class="error-point" cx="708.97" cy="298.11" r="2.4" fill="#d62728"/>
+    <circle class="error-point" cx="709.14" cy="298.57" r="2.4" fill="#d62728"/>
+    <circle class="error-point" cx="710.63" cy="301.79" r="2.4" fill="#d62728"/>
+    <circle class="error-point" cx="724.37" cy="305.02" r="2.4" fill="#d62728"/>
+    <circle class="error-point" cx="724.52" cy="303.75" r="2.4" fill="#d62728"/>
+    <circle class="error-point" cx="725.79" cy="306.97" r="2.4" fill="#d62728"/>
+    <circle class="error-point" cx="737.71" cy="310.19" r="2.4" fill="#d62728"/>
+    <circle class="error-point" cx="737.84" cy="307.78" r="2.4" fill="#d62728"/>
+    <circle class="error-point" cx="738.95" cy="311" r="2.4" fill="#d62728"/>
+    <circle class="error-point" cx="749.48" cy="314.22" r="2.4" fill="#d62728"/>
+    <circle class="error-point" cx="749.59" cy="311" r="2.4" fill="#d62728"/>
+    <circle class="error-point" cx="750.58" cy="314.22" r="2.4" fill="#d62728"/>
+    <circle class="error-point" cx="760" cy="317.44" r="2.4" fill="#d62728"/>
+  </g>
+</svg>

--- a/docs/archive/pr-summaries/pr-summary-521.md
+++ b/docs/archive/pr-summaries/pr-summary-521.md
@@ -1,0 +1,63 @@
+## Summary
+
+Adds auto-thinning to the run-boundary labels and ticks rendered by the two
+shared multi-run SVG renderers so that high-run-count campaigns (50, 115, …)
+no longer collapse into an unreadable smear at the top of the chart.
+
+Both `multi_run_error_chart.ts` and `multi_run_complexity_chart.ts` now route
+their boundary rendering through a single new helper,
+`common/multi_run_boundary_thinning.ts`, which encodes the agreed policy in
+one place. For ≤ 10 boundaries the output is byte-identical to the previous
+implementation; above that the helper auto-fits the largest number of labels
+that fit in 90 % of the plot width (capped at 10), always anchoring the first
+and last boundary and spacing the intermediate picks evenly.
+
+Closes #521.
+
+## Evidence
+
+This is a backend / SVG-string change with no UI to screenshot — verified via
+automated tests:
+
+- A new snapshot regression test
+  (`renderMultiRun{Error,Complexity}ChartSVG: 10-run snapshot is
+  byte-identical to pre-#521 baseline`) asserts the rendered SVG for a fixed
+  10-run input matches a captured baseline byte-for-byte. The baseline was
+  recorded before any code change, so a regression in the ≤ 10-run path would
+  fail this test.
+- New high-run-count tests assert that 50- and 115-run inputs produce at most
+  10 boundary `<text>` labels and the same number of `<line class="run-boundary">`
+  ticks, and that the first and last boundary are always present.
+
+```mermaid
+flowchart LR
+    A[milestones array] --> B[multi_run_boundary_thinning.ts<br/>selectBoundaryIndices]
+    B --> C[multi_run_error_chart.ts<br/>renderRunBoundaries]
+    B --> D[multi_run_complexity_chart.ts<br/>renderRunBoundaries]
+    C --> E[SVG output - up to 10 labels]
+    D --> E
+```
+
+## Test Plan
+
+- [x] `common/multi_run_boundary_thinning_test.ts` (new, 9 tests):
+  - zero / single boundary edge cases,
+  - 1 … 10 boundaries → every index selected,
+  - 49 / 114 boundary inputs cap at 10 with first + last anchored,
+  - selection is deterministic,
+  - selection is strictly increasing and roughly evenly spaced,
+  - narrow plot width still anchors the last boundary,
+  - longer labels shrink the selected count at fixed width.
+- [x] `common/multi_run_error_chart_test.ts` (5 new tests):
+  - ≤ 10 runs (1, 2, 5, 10) → every boundary labelled, ticks == labels,
+  - 50 runs → at most 10 labels, first + last present,
+  - 115 runs → at most 10 labels, first + last present,
+  - boundary selection is deterministic,
+  - 10-run snapshot byte-identical to pre-#521 baseline.
+- [x] `common/multi_run_complexity_chart_test.ts` (5 new tests, mirror set).
+- [x] All 194 existing tests under `common/` continue to pass.
+
+### Deno regression avoided
+
+Implemented entirely with `deno test`, `deno lint`, `deno fmt`, and
+`deno check` — no Node tooling, package.json, or npm/yarn introduced.


### PR DESCRIPTION
## Summary

Adds auto-thinning to the run-boundary labels and ticks rendered by the two
shared multi-run SVG renderers so that high-run-count campaigns (50, 115, …)
no longer collapse into an unreadable smear at the top of the chart.

Both `multi_run_error_chart.ts` and `multi_run_complexity_chart.ts` now route
their boundary rendering through a single new helper,
`common/multi_run_boundary_thinning.ts`, which encodes the agreed policy in
one place. For ≤ 10 boundaries the output is byte-identical to the previous
implementation; above that the helper auto-fits the largest number of labels
that fit in 90 % of the plot width (capped at 10), always anchoring the first
and last boundary and spacing the intermediate picks evenly.

Closes #521.

## Evidence

This is a backend / SVG-string change with no UI to screenshot — verified via
automated tests:

- A new snapshot regression test
  (`renderMultiRun{Error,Complexity}ChartSVG: 10-run snapshot is
  byte-identical to pre-#521 baseline`) asserts the rendered SVG for a fixed
  10-run input matches a captured baseline byte-for-byte. The baseline was
  recorded before any code change, so a regression in the ≤ 10-run path would
  fail this test.
- New high-run-count tests assert that 50- and 115-run inputs produce at most
  10 boundary `<text>` labels and the same number of `<line class="run-boundary">`
  ticks, and that the first and last boundary are always present.

```mermaid
flowchart LR
    A[milestones array] --> B[multi_run_boundary_thinning.ts<br/>selectBoundaryIndices]
    B --> C[multi_run_error_chart.ts<br/>renderRunBoundaries]
    B --> D[multi_run_complexity_chart.ts<br/>renderRunBoundaries]
    C --> E[SVG output - up to 10 labels]
    D --> E
```

## Test Plan

- [x] `common/multi_run_boundary_thinning_test.ts` (new, 9 tests):
  - zero / single boundary edge cases,
  - 1 … 10 boundaries → every index selected,
  - 49 / 114 boundary inputs cap at 10 with first + last anchored,
  - selection is deterministic,
  - selection is strictly increasing and roughly evenly spaced,
  - narrow plot width still anchors the last boundary,
  - longer labels shrink the selected count at fixed width.
- [x] `common/multi_run_error_chart_test.ts` (5 new tests):
  - ≤ 10 runs (1, 2, 5, 10) → every boundary labelled, ticks == labels,
  - 50 runs → at most 10 labels, first + last present,
  - 115 runs → at most 10 labels, first + last present,
  - boundary selection is deterministic,
  - 10-run snapshot byte-identical to pre-#521 baseline.
- [x] `common/multi_run_complexity_chart_test.ts` (5 new tests, mirror set).
- [x] All 194 existing tests under `common/` continue to pass.

### Deno regression avoided

Implemented entirely with `deno test`, `deno lint`, `deno fmt`, and
`deno check` — no Node tooling, package.json, or npm/yarn introduced.



## Milestone
This PR is part of the **Factory** milestone and targets the `milestone/factory` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mpqr7e87-c96d41`<!-- vibe-worker-issue-521 -->