### PR TITLE
adaptive_mutation: build the initial creature via the NEAT-AI factory (#533)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,8 +78,15 @@ These examples exist to demonstrate evolution from noise → competent and must 
 - `lunar_lander`
 - `mountain_car`
 - `maze_navigation`
-- `adaptive_mutation` — evolves a 4-bit even-parity classifier from a minimal `new Creature(4, 1)`
-  seed; the noise → competent classification arc is the demo (rewired under #263 / #264).
+- `adaptive_mutation` — **exception (issue #533, factory-adoption tracker #517):** the fresh-run
+  seed is built via the data-derived
+  `Creature.forDataset(records, { cost: "BINARY_CROSS_ENTROPY" })` factory (LOGISTIC output coupled
+  to the cost, a conservative factory-sized hidden layer, He/Xavier weight-init scaling) rather than
+  the legacy bare `new Creature(4, 1)`. Adopting the factory _is_ the demonstration; seed weights
+  and biases stay random and structural growth beyond the seed still comes purely from `evolveDir`'s
+  unchanged mutation operators. The bare constructor baseline is retained as
+  `buildRandomSeedCreature` for test / resume fixtures. The noise → competent classification arc is
+  still the demo (rewired under #263 / #264).
 
 ### Exempt examples (hand-crafted state IS the demo)
 

--- a/adaptive_mutation/README.md
+++ b/adaptive_mutation/README.md
@@ -1,67 +1,85 @@
-# 🧬 Adaptive Mutation Rate — Classifying 4-bit Parity from Random Noise
+# 🧬 Adaptive Mutation Rate — Classifying 4-bit Parity from a Factory Seed
 
-> 🌱 **Generation 1 starts from random noise** — `new Creature(4, 1)` with direct input→output
-> synapses only. No hidden hint, no pretrained champion, no hand-crafted weights. NEAT-AI must
-> **find** the parity classifier on its own; it is not given the answer.
+> 🏭 **Generation 1 is built by the NEAT-AI factory (issue #533).** Instead of a bare
+> `new Creature(4, 1)`, the seed is minted by
+> `Creature.forDataset(records, { cost: "BINARY_CROSS_ENTROPY" })`, which couples the output to a
+> LOGISTIC activation and pre-sizes a conservative hidden layer. **Only the seed changes — evolution
+> is untouched.** Seed weights and biases stay random; NEAT-AI must still **find** the parity
+> classifier on its own. This is a milestone-sanctioned departure from the no-warm-start policy (see
+> below).
 
 **Acronyms.** _NEAT_ = NeuroEvolution of Augmenting Topologies — the algorithm that grows neural
 network topology and weights together with an evolutionary search. _MSE_ = mean squared error.
 _WASM_ = WebAssembly. _RL_ = reinforcement learning. _XOR_ = exclusive OR.
 
 `adaptive_mutation.ts` evolves a NEAT-AI network that solves a **4-bit even-parity classification**
-task — the textbook XOR generalisation. The minimal direct-only seed cannot represent parity at all
-(parity is not linearly separable), so NEAT-AI **must** invent hidden neurons and inter-layer
-synapses before the network can score above chance. That structural growth is exactly the signal the
-demo is built around: the same NEAT-AI **adaptive mutation policy** that drives the growth naturally
-tapers topology mutations as size rises and lets weight tuning take over.
+task — the textbook XOR generalisation. Parity is not linearly separable, so it needs hidden
+capacity; the factory seed starts with a small conservative hidden layer whose **random** weights
+still score around chance, so NEAT-AI **must** grow and tune the network before accuracy can climb.
+That structural growth is exactly the signal the demo is built around: the same NEAT-AI **adaptive
+mutation policy** that drives the growth naturally tapers topology mutations as size rises and lets
+weight tuning take over.
 
-Per the noise → competent policy in [`AGENTS.md`](../AGENTS.md), the example seeds NEAT-AI with
-**only** `new Creature(4, 1)` (no warm start, no `network.json`, no hand-tuned shape), runs
-`Creature.evolveDir(...)` over a binary `.bin` training set built from the 4-bit even-parity truth
-table, and quotes real measured numbers from the latest local run.
+The example seeds NEAT-AI via the data-derived factory
+`Creature.forDataset(records, { cost: "BINARY_CROSS_ENTROPY" })`, runs `Creature.evolveDir(...)`
+over a binary `.bin` training set built from the 4-bit even-parity truth table, and quotes real
+measured numbers from the latest local run. The factory chooses **only** the seed's topology and
+weight-init scaling from problem-intrinsic facts; the weights and biases stay random and `evolveDir`
+keeps its default scoring, so evolution behaves exactly as before.
 
 ![Adaptive mutation classification — topology grows, the analytic p(topology) decays, and
 classification accuracy climbs from chance to the final solution](../docs/screenshots/adaptive_mutation.svg)
 
-## 🌱 No warm start — gen 1 is uniform-random noise
+## 🏭 Factory seed — a milestone-sanctioned departure
 
-The first generation is the bare `new Creature(4, 1)` constructor: four input neurons, one logistic
-output neuron, four direct input→output synapses with uniform-random weights, a uniform-random
-output bias, and **zero hidden neurons**. Per AGENTS.md every disqualifying form of warm start is
-absent:
+Generation 1 is minted by the NEAT-AI factory
+`Creature.forDataset(records, { cost: "BINARY_CROSS_ENTROPY" })`. From problem-intrinsic facts only,
+the factory:
 
-- ❌ No pretrained champion is loaded from disk.
-- ❌ No hidden-layer hint or hand-crafted topology is set on the seed.
-- ❌ No hand-crafted weights or biases — every initial parameter comes from NEAT-AI's seeded PRNG.
-- ❌ No resumed population or checkpoint restore.
+- couples the output activation to the cost — `BINARY_CROSS_ENTROPY` ⇒ a **LOGISTIC** output
+  ([NEAT-AI #2793](https://github.com/stSoftwareAU/NEAT-AI/issues/2793)), the exact activation this
+  example's `>= 0.5` threshold and `{0, 1}` MSE both assume;
+- sizes a **conservative hidden-capacity budget** from the problem shape (Heaton's rule → a small
+  RELU hidden layer);
+- scales the random weight init per activation (He / Xavier).
 
-Gen 1's accuracy is little better than chance (around 0.5 on the balanced 16-row parity truth
-table); from there NEAT-AI grows the topology and tunes the weights until the network classifies the
-table to the configured target.
+**Only the seed's topology and scaling are factory-derived** — seed weights and biases remain
+random, drawn from NEAT-AI's seeded PRNG, and `evolveDir` keeps its default MSE scoring. All
+structural growth beyond the seed still comes from the unchanged mutation operators, so the example
+converges as before (or faster).
+
+This is a **deliberate, milestone-sanctioned departure** from the
+[no-warm-start policy](../AGENTS.md#-no-warm-starts--evolution-must-start-from-random-noise) in
+`AGENTS.md`, made under the factory-adoption tracker
+([#517](https://github.com/stSoftwareAU/NEAT-AI-Examples/issues/517); see
+[`docs/factory_adoption.md`](../docs/factory_adoption.md)). The bare `new Creature(4, 1)` baseline
+is retained in code as `buildRandomSeedCreature(seed)` for test / resume fixtures.
 
 ## 📈 Latest Measured Run
 
 The numbers below come directly from the latest local run of `./adaptive_mutation/run.sh` — no
 estimates, no qualifiers.
 
-| Metric                    | Value                                  |
-| ------------------------- | -------------------------------------- |
-| Task                      | 4-bit even parity (16-row truth table) |
-| Generations               | 1440 (solved — `targetError` reached)  |
-| Wall-clock                | 1 m 26 s                               |
-| Final training accuracy   | 1.0000 (16 of 16 rows correct)         |
-| Held-out accuracy         | 1.0000                                 |
-| Final best fitness        | 1.0000                                 |
-| Held-out score (-MSE)     | -0.0000234                             |
-| Seed neurons / synapses   | 5 / 4                                  |
-| Final neurons / synapses  | 19 / 44                                |
-| `targetError`             | 0.05                                   |
-| `timeoutMinutes` (safety) | 5                                      |
+| Metric                    | Value                                                            |
+| ------------------------- | ---------------------------------------------------------------- |
+| Task                      | 4-bit even parity (16-row truth table)                           |
+| Seed                      | `Creature.forDataset(records, { cost: "BINARY_CROSS_ENTROPY" })` |
+| Generations               | 955 (solved — `targetError` reached)                             |
+| Wall-clock                | 1 m 1 s                                                          |
+| Final training accuracy   | 1.0000 (16 of 16 rows correct)                                   |
+| Held-out accuracy         | 1.0000                                                           |
+| Final best fitness        | 1.0000                                                           |
+| Held-out score (-MSE)     | ≈ 0.0000 (essentially perfect)                                   |
+| Seed neurons / synapses   | 9 / 20 (4 factory-sized hidden)                                  |
+| Final neurons / synapses  | 11 / 27                                                          |
+| `targetError`             | 0.05                                                             |
+| `timeoutMinutes` (safety) | 5                                                                |
 
-Topology genuinely changed: NEAT added 14 hidden neurons (5 → 19) and grew the synapse count from 4
-to 44 across 1440 generations, starting from a minimal direct-only seed that cannot represent parity
-at all. Classification accuracy climbed from about chance at gen 1 to **1.0000 at the final
-generation** — the captured noise → competent arc.
+Topology genuinely changed: NEAT grew the network from the factory seed (9 neurons / 20 synapses,
+including a 4-neuron factory-sized hidden layer) to 11 neurons / 27 synapses across 955 generations.
+The factory hidden layer ships with **random** weights, so gen-1 accuracy still sits around chance;
+classification accuracy then climbs to **1.0000 at the final generation** — the captured "noise →
+competent" arc, now starting from a factory-derived topology instead of a bare seed.
 
 - Single-call summary chart:
   [`docs/screenshots/adaptive_mutation/evolution_summary.svg`](../docs/screenshots/adaptive_mutation/evolution_summary.svg)
@@ -79,7 +97,8 @@ The runner:
 1. Generates the full 4-bit even-parity truth table (16 records, 4 binary inputs → 1 binary output)
    from `classification_task.ts`. Class balance is exact (8 even, 8 odd) by construction.
 2. Writes the dataset as a Float32 `.bin` file under `.adaptive-mutation/data/`.
-3. Seeds NEAT-AI with `new Creature(4, 1)` — minimal direct-only topology, no warm start.
+3. Seeds NEAT-AI via the factory `Creature.forDataset(records, { cost: "BINARY_CROSS_ENTROPY" })` —
+   LOGISTIC output, a factory-sized hidden layer, He/Xavier-scaled random weights.
 4. Runs `Creature.evolveDir(dataDir, neatOptions)` with `targetError = 0.05` and
    `timeoutMinutes = 5` as a **single call** — no per-generation chunking, no `onTrainingEvent`
    hook. NEAT-AI's milestone-only telemetry surface is the supported way to chart progress (see
@@ -117,7 +136,7 @@ rises across the run, `p(topology)` collapses toward zero, exactly as the policy
 flowchart LR
     DATA["📊 4-bit even-parity truth table<br/>4 binary inputs → 1 binary label<br/>(16 rows, balanced 8/8)"]
     BIN["💾 training.bin<br/>(Float32 little-endian)"]
-    SEED["🌱 Minimal NEAT seed<br/>new Creature(4, 1)<br/>direct edges only<br/>(uniform-random noise)"]
+    SEED["🏭 Factory NEAT seed<br/>Creature.forDataset(records,<br/>{ cost: BINARY_CROSS_ENTROPY })<br/>LOGISTIC output + hidden layer"]
     EVOLVE["🧬 evolveDir<br/>single call<br/>targetError + timeoutMinutes:5"]
     POLICY["⚖️ Adaptive policy<br/>p(topology) tapers as size grows"]
     SUMMARY["📦 EvolveDirSummary<br/>(error, score, time, generation<br/>+ seed/final topology)"]
@@ -135,9 +154,11 @@ flowchart LR
 
 The classification target is the textbook **even-parity detector**: given four bits, return `1` if
 the number of `1` bits is even (count ∈ {0, 2, 4}), else `0`. This is the standard XOR
-generalisation — a single direct input→output synapse layer cannot fit the truth table, so NEAT-AI
-**must** invent hidden neurons before accuracy can move off chance. The captured noise → competent
-arc — gen 1 ≈ chance, final ≥ target accuracy — is exactly what the demo is built to show.
+generalisation — parity is not linearly separable, so it needs hidden capacity. The factory seed
+ships a small conservative hidden layer, but with **random** weights it still scores around chance,
+so NEAT-AI **must** grow and tune the network before accuracy can move off chance. The captured
+noise → competent arc — gen 1 ≈ chance, final ≥ target accuracy — is exactly what the demo is built
+to show.
 
 ### Why `evolveDir` rather than per-step `activate()`?
 
@@ -164,6 +185,12 @@ action.
 
 `adaptive_mutation_test.ts` verifies (with "what" tests — no source-level grepping):
 
+- `buildSeedCreature` mints a factory seed with the right arity, a LOGISTIC output coupled to
+  `BINARY_CROSS_ENTROPY`, a data-derived hidden layer, deterministic weights/biases per seed, and
+  valid finite `[0, 1]` outputs; it rejects an empty record set. `datasetToFactoryRecords` mirrors
+  the dataset's inputs and targets.
+- `buildRandomSeedCreature` (the retained bare-constructor baseline) has zero hidden neurons, a
+  pinned LOGISTIC output, and is deterministic per seed.
 - `topologyProbability` decreases monotonically with size, matches the documented closed form, and
   rejects invalid policies / negative sizes.
 - `runAdaptiveMutationDemo` rejects invalid configs, returns a summary whose `finalNeurons` /
@@ -180,7 +207,7 @@ action.
 
 ## 🧰 NEAT-AI Features Used
 
-This example exercises NEAT-AI's adaptive-mutation policy through real evolution from a minimal seed
+This example exercises NEAT-AI's adaptive-mutation policy through real evolution from a factory seed
 on a concrete classification problem.
 
 Features exercised (links go to upstream
@@ -188,10 +215,14 @@ Features exercised (links go to upstream
 
 - **[Hyperparameter Self-Adaptation](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/COMPARISON.md#what-weve-implemented)**
   — captures the operator-distribution shift indirectly via the measured topology trajectory: the
-  network grows aggressively from the minimal seed while the analytic policy curve collapses toward
-  zero, exactly as the adaptive policy intends.
+  network grows from the factory seed while the analytic policy curve collapses toward zero, exactly
+  as the adaptive policy intends.
 - **Binary `.bin` training set + `evolveDir`** — canonical fast supervised path; the parity truth
   table is pre-generated once and consumed by NEAT-AI's optimised evolution pipeline.
 - **`targetError + timeoutMinutes` stop conditions** — the audit policy from issue #203.
-- **Structural mutation from a minimal seed** — `ADD_NODE` and `ADD_CONN` operators invent the
-  hidden topology that direct-only input→output edges cannot represent.
+- **Cost-coupled factory seed** — `Creature.forDataset(records, { cost: "BINARY_CROSS_ENTROPY" })`
+  derives a LOGISTIC output, a conservative hidden layer, and He/Xavier weight-init scaling from the
+  problem shape; the bare `new Creature(4, 1)` baseline is retained as `buildRandomSeedCreature` for
+  fixtures.
+- **Structural mutation beyond the factory seed** — `ADD_NODE` and `ADD_CONN` operators grow the
+  hidden topology further as evolution tunes the parity classifier.

--- a/adaptive_mutation/adaptive_mutation.ts
+++ b/adaptive_mutation/adaptive_mutation.ts
@@ -18,16 +18,25 @@
  * {@link topologyProbability}) and the seed-vs-final topology bars
  * rendered by the shared {@link renderEvolveDirSummarySvg} helper.
  *
- * Policy compliance:
+ * Seed policy (factory adoption — issue #533, tracker #517):
  *
- * 1. The creature passed to NEAT-AI is built **only** from
- *    `new Creature(INPUT_COUNT, OUTPUT_COUNT)` — no hidden-layer hint,
- *    no pre-built `network.json` seed, no hand-tuned shape, no warm
- *    start. NEAT-AI random-initialises the rest.
+ * 1. The creature passed to NEAT-AI is minted by the NEAT-AI **factory**
+ *    `Creature.forDataset(records, { cost: "BINARY_CROSS_ENTROPY" })`
+ *    ({@link buildSeedCreature}) instead of a bare
+ *    `new Creature(INPUT_COUNT, OUTPUT_COUNT)`. The factory couples the
+ *    output activation to the cost (LOGISTIC), sizes a conservative
+ *    hidden-capacity budget (Heaton's rule), and scales the random
+ *    weight init per activation (He / Xavier). Seed weights and biases
+ *    stay random — only topology and scaling are factory-derived. This
+ *    is a **milestone-sanctioned departure** from the no-warm-start
+ *    policy in `AGENTS.md` / `docs/factory_adoption.md`. The bare
+ *    constructor baseline is retained as {@link buildRandomSeedCreature}
+ *    for test / resume fixtures.
  * 2. Evolution runs through a single `Creature.evolveDir(dataDir, neatOptions)`
  *    call over a pre-generated binary `.bin` classification training
- *    set — the topology is learned by NEAT, not bolted on by the
- *    example.
+ *    set — **evolution is untouched**; all structural growth beyond the
+ *    seed still comes from the unchanged mutation operators, and
+ *    `evolveDir` keeps its default MSE scoring.
  * 3. Stop conditions are a per-example `targetError` plus a
  *    `timeoutMinutes: 5` safety backstop.
  */
@@ -36,10 +45,13 @@ import { ensureDirSync } from "@std/fs";
 import { join } from "@std/path";
 
 import {
+  createSeededRng,
   Creature,
   type CreatureExport,
+  type DatasetFactoryOptions,
   type NeatOptions,
   safeWriteJson,
+  setRandomNumberGenerator,
 } from "@stsoftware/neat-ai";
 
 import { type EvolveDirSummary, renderEvolveDirSummarySvg } from "../common/evolve_dir_summary.ts";
@@ -81,6 +93,88 @@ export const INPUT_COUNT = TASK_INPUT_COUNT;
 
 /** Number of output neurons fed to the NEAT-AI seed. */
 export const OUTPUT_COUNT = TASK_OUTPUT_COUNT;
+
+/**
+ * Cost handed to the NEAT-AI factory ({@link Creature.forDataset}) when
+ * building the seed creature (issue #533). The 4-bit even-parity task is
+ * a binary classification with `{0, 1}` targets, so `BINARY_CROSS_ENTROPY`
+ * couples the output activation to a **LOGISTIC** sigmoid (NEAT-AI #2793)
+ * — the exact activation this example's `>= 0.5` threshold interface and
+ * `{0, 1}` MSE both assume. Same cost / activation pairing as the XOR
+ * adoption (#520).
+ *
+ * The cost shapes only the *seed*; `evolveDir` itself is left on its
+ * default MSE scoring, so evolution behaves exactly as it did before the
+ * factory was adopted.
+ */
+export const CLASSIFICATION_COST = "BINARY_CROSS_ENTROPY";
+
+/** The record shape (`{ input, output }`) the NEAT-AI factory scans. */
+export type FactoryRecords = Parameters<typeof Creature.forDataset>[0];
+
+/**
+ * Convert the classification dataset ({@link DataPoint}[]) into the
+ * `{ input, output }` record shape the NEAT-AI factory scans. The factory
+ * derives its seed from the same records `evolveDir` trains on.
+ */
+export function datasetToFactoryRecords(dataset: readonly DataPoint[]): FactoryRecords {
+  return dataset.map(({ inputs, targets }) => ({
+    input: Float32Array.from(inputs),
+    output: Float32Array.from(targets),
+  }));
+}
+
+/**
+ * Build the bare uniform-random NEAT seed — `new Creature(INPUT_COUNT,
+ * OUTPUT_COUNT)` with direct input → output synapses and zero hidden
+ * neurons. **Retained as the historical baseline** for test / resume
+ * fixtures after the fresh-run seed moved to the factory
+ * ({@link buildSeedCreature}, issue #533). The library's global PRNG is
+ * reseeded via {@link createSeededRng} so a given `seed` is deterministic;
+ * every weight and bias is drawn from that PRNG — nothing is hand-crafted.
+ *
+ * The single output neuron is pinned to LOGISTIC to match the `>= 0.5`
+ * threshold interface and `{0, 1}` MSE the example uses.
+ */
+export function buildRandomSeedCreature(seed: number): CreatureExport {
+  setRandomNumberGenerator(createSeededRng(seed));
+  const json = new Creature(INPUT_COUNT, OUTPUT_COUNT).exportJSON();
+  for (const neuron of json.neurons) {
+    if (neuron.type === "output") neuron.squash = "LOGISTIC";
+  }
+  return json;
+}
+
+/**
+ * Build the **factory seed creature** via the NEAT-AI factory
+ * ({@link Creature.forDataset}) instead of a bare `new Creature(...)`
+ * (issue #533). From problem-intrinsic facts only, the factory:
+ *
+ * - picks a **LOGISTIC output** activation from the classification cost
+ *   ({@link CLASSIFICATION_COST}) — the activation the `>= 0.5` threshold
+ *   interface and `{0, 1}` MSE both assume;
+ * - sizes a **conservative hidden-capacity budget** from the problem
+ *   shape (Heaton's rule → a small RELU hidden layer);
+ * - scales the random weights to the **per-activation init stddev**
+ *   (He / Xavier), so the forward pass neither saturates nor vanishes.
+ *
+ * The global PRNG is reseeded via {@link createSeededRng} so a given
+ * `seed` produces a deterministic seed creature. Every weight and bias is
+ * still drawn from that PRNG — the factory chooses the topology and
+ * scaling, never hand-crafted parameters. The cost shapes only the seed;
+ * `evolveDir` keeps its default MSE scoring so evolution is untouched.
+ *
+ * Milestone-sanctioned departure from the project-wide no-warm-start
+ * policy, made under the factory-adoption tracker (issue #517).
+ */
+export function buildSeedCreature(records: FactoryRecords, seed: number): CreatureExport {
+  if (records.length === 0) {
+    throw new Error("buildSeedCreature: records must not be empty");
+  }
+  setRandomNumberGenerator(createSeededRng(seed));
+  const options: DatasetFactoryOptions = { cost: CLASSIFICATION_COST };
+  return Creature.forDataset(records, options).exportJSON();
+}
 
 /** Configuration for {@link runAdaptiveMutationDemo}. */
 export interface AdaptiveMutationConfig {
@@ -247,8 +341,11 @@ export function creatureHeldOutScore(
  *
  *   1. Pre-generate a binary `.bin` classification training set from
  *      the 4-bit parity truth table.
- *   2. Seed `new Creature(INPUT_COUNT, OUTPUT_COUNT)` (minimal, no
- *      hidden hint, uniform-random weights — NO warm start).
+ *   2. Build the seed via the NEAT-AI factory
+ *      `Creature.forDataset(records, { cost: "BINARY_CROSS_ENTROPY" })`
+ *      ({@link buildSeedCreature}) — LOGISTIC output, a factory-sized
+ *      hidden layer, He/Xavier-scaled random weights. Only the seed is
+ *      factory-derived; weights and biases stay random.
  *   3. Make a **single** `creature.evolveDir(...)` call and chart the
  *      run from its return value plus the final creature's topology.
  *
@@ -292,11 +389,15 @@ export async function runAdaptiveMutationDemo(
 
     if (ownDataDir) writeBinaryClassificationDataset(trainingSet, dataDir);
 
-    // Seed = minimal direct-only creature. NEAT-AI random-initialises
-    // weights and bias for direct input → output edges; no hidden
-    // neurons exist yet. This is a uniform-random noise seed — NO
-    // warm start, no hand-crafted topology, no pretrained champion.
-    const creature = new Creature(INPUT_COUNT, OUTPUT_COUNT);
+    // Seed = NEAT-AI factory creature (issue #533). The factory couples
+    // the LOGISTIC output to the cost, sizes a conservative hidden layer
+    // (Heaton's rule), and scales the random weight init per activation
+    // (He / Xavier). Weights and biases stay random — only topology and
+    // scaling are factory-derived. Milestone-sanctioned departure from
+    // the no-warm-start policy (tracker #517).
+    const creature = Creature.fromJSON(
+      buildSeedCreature(datasetToFactoryRecords(trainingSet), config.seed),
+    );
 
     // Capture seed topology before evolution so the summary can show
     // genuine before-vs-after growth.
@@ -380,8 +481,9 @@ if (import.meta.main) {
   const { dataDir, creaturesDir } = setupWorkingDirs(WORKING_ROOT);
 
   console.log(
-    "🌱 Building minimal NEAT-AI seed: " +
-      `new Creature(${INPUT_COUNT}, ${OUTPUT_COUNT}) — no hidden hint, no warm start.`,
+    "🏭 Building NEAT-AI factory seed: " +
+      `Creature.forDataset(records, { cost: "${CLASSIFICATION_COST}" }) ` +
+      `(${INPUT_COUNT} → ${OUTPUT_COUNT}, LOGISTIC output, factory-sized hidden layer).`,
   );
   console.log("📊 Generating classification dataset and writing binary .bin training set...");
 

--- a/adaptive_mutation/adaptive_mutation_test.ts
+++ b/adaptive_mutation/adaptive_mutation_test.ts
@@ -28,7 +28,11 @@ import { Creature } from "@stsoftware/neat-ai";
 
 import {
   type AdaptiveMutationConfig,
+  buildRandomSeedCreature,
+  buildSeedCreature,
+  CLASSIFICATION_COST,
   creatureHeldOutScore,
+  datasetToFactoryRecords,
   DEFAULT_ADAPTIVE_MUTATION_CONFIG,
   DEFAULT_POLICY_CONFIG,
   INPUT_COUNT,
@@ -73,6 +77,132 @@ Deno.test("module exports the rewired classification task metadata", () => {
   assertEquals(OUTPUT_COUNT, 1);
   assertEquals(typeof TASK_NAME, "string");
   assert(TASK_NAME.length > 0);
+});
+
+/* ------------------------------------------------------------------ */
+/*  Bare-constructor baseline seed (retained for fixtures — issue #533) */
+/* ------------------------------------------------------------------ */
+
+Deno.test("buildRandomSeedCreature has 4 inputs, 0 hidden, 1 output", () => {
+  const json = buildRandomSeedCreature(86);
+  assertEquals(json.input, INPUT_COUNT);
+  assertEquals(json.output, OUTPUT_COUNT);
+  const hidden = json.neurons.filter((n) => n.type === "hidden");
+  assertEquals(
+    hidden.length,
+    0,
+    "bare baseline must have zero hidden neurons — NEAT must invent them",
+  );
+});
+
+Deno.test("buildRandomSeedCreature pins a LOGISTIC output and is deterministic", () => {
+  const a = buildRandomSeedCreature(4242);
+  const b = buildRandomSeedCreature(4242);
+  const c = buildRandomSeedCreature(9999);
+  for (const out of a.neurons.filter((n) => n.type === "output")) {
+    assertEquals(out.squash, "LOGISTIC");
+  }
+  assertEquals(JSON.stringify(a), JSON.stringify(b));
+  assert(
+    JSON.stringify(a) !== JSON.stringify(c),
+    "different seeds must produce different baseline creatures",
+  );
+});
+
+Deno.test("buildRandomSeedCreature produces a valid creature with finite outputs", () => {
+  const creature = Creature.fromJSON(buildRandomSeedCreature(86));
+  creature.validate();
+  assertEquals(creature.input, INPUT_COUNT);
+  assertEquals(creature.output, OUTPUT_COUNT);
+  const out = creature.activate(Float32Array.from([1, 0, 1, 0]));
+  assert(Number.isFinite(out[0]), `output must be finite, got ${out[0]}`);
+});
+
+/* ------------------------------------------------------------------ */
+/*  Factory seed (issue #533)                                          */
+/* ------------------------------------------------------------------ */
+
+Deno.test("CLASSIFICATION_COST couples the output to a sigmoid", () => {
+  // BINARY_CROSS_ENTROPY ⇒ LOGISTIC output — same pairing as XOR (#520).
+  assertEquals(CLASSIFICATION_COST, "BINARY_CROSS_ENTROPY");
+});
+
+Deno.test("datasetToFactoryRecords mirrors the dataset's inputs and targets", () => {
+  const ds = generateClassificationDataset(86, TRUTH_TABLE_SIZE);
+  const records = datasetToFactoryRecords(ds);
+  assertEquals(records.length, ds.length);
+  for (let i = 0; i < ds.length; i++) {
+    assertEquals(records[i].input.length, INPUT_COUNT);
+    assertEquals(records[i].output.length, OUTPUT_COUNT);
+    for (let k = 0; k < INPUT_COUNT; k++) {
+      assertEquals(records[i].input[k], ds[i].inputs[k]);
+    }
+    assertEquals(records[i].output[0], ds[i].targets[0]);
+  }
+});
+
+Deno.test("buildSeedCreature builds a factory seed with the right arity", () => {
+  const records = datasetToFactoryRecords(generateClassificationDataset(86));
+  const json = buildSeedCreature(records, 86);
+  assertEquals(json.input, INPUT_COUNT);
+  assertEquals(json.output, OUTPUT_COUNT);
+});
+
+Deno.test("buildSeedCreature picks a LOGISTIC output from the classification cost", () => {
+  const records = datasetToFactoryRecords(generateClassificationDataset(5));
+  const json = buildSeedCreature(records, 5);
+  const outputs = json.neurons.filter((n) => n.type === "output");
+  assertEquals(outputs.length, OUTPUT_COUNT);
+  for (const out of outputs) {
+    assertEquals(out.squash, "LOGISTIC", "classification cost ⇒ LOGISTIC output");
+  }
+});
+
+Deno.test("buildSeedCreature sizes a data-derived hidden capacity budget", () => {
+  // Unlike the bare `new Creature(...)` baseline (zero hidden), the
+  // factory derives a conservative hidden layer from the problem shape.
+  const records = datasetToFactoryRecords(generateClassificationDataset(7));
+  const json = buildSeedCreature(records, 7);
+  const hidden = json.neurons.filter((n) => n.type === "hidden");
+  assertGreater(hidden.length, 0, "factory seed must pre-size a hidden layer");
+});
+
+Deno.test("buildSeedCreature is deterministic (weights/biases) for a given seed", () => {
+  // The factory mints fresh UUIDs for hidden neurons, so full JSON
+  // equality is too strict — the learnable parameters must match.
+  const records = datasetToFactoryRecords(generateClassificationDataset(86));
+  const fingerprint = (json: ReturnType<typeof buildSeedCreature>) => ({
+    neurons: json.neurons.map((n) => `${n.type}:${n.squash}:${n.bias}`),
+    weights: json.synapses.map((s) => s.weight),
+  });
+  const a = fingerprint(buildSeedCreature(records, 4242));
+  const b = fingerprint(buildSeedCreature(records, 4242));
+  const c = fingerprint(buildSeedCreature(records, 9999));
+  assertEquals(a, b);
+  assert(
+    JSON.stringify(a) !== JSON.stringify(c),
+    "different seeds must produce different factory seeds",
+  );
+});
+
+Deno.test("buildSeedCreature produces a valid creature with finite [0,1] outputs", () => {
+  const records = datasetToFactoryRecords(generateClassificationDataset(86));
+  const creature = Creature.fromJSON(buildSeedCreature(records, 86));
+  creature.validate();
+  assertEquals(creature.input, INPUT_COUNT);
+  assertEquals(creature.output, OUTPUT_COUNT);
+  const out = creature.activate(Float32Array.from([1, 0, 1, 0]));
+  assert(Number.isFinite(out[0]), `output must be finite, got ${out[0]}`);
+  assertGreaterOrEqual(out[0], 0);
+  assertLessOrEqual(out[0], 1);
+});
+
+Deno.test("buildSeedCreature rejects an empty record set", () => {
+  assertThrows(
+    () => buildSeedCreature([], 1),
+    Error,
+    "records must not be empty",
+  );
 });
 
 Deno.test("topologyProbability decreases monotonically as size grows", () => {

--- a/docs/archive/pr-summaries/pr-summary-533.md
+++ b/docs/archive/pr-summaries/pr-summary-533.md
@@ -1,0 +1,97 @@
+# PR Summary — adaptive_mutation: build the initial creature via the NEAT-AI factory (#533)
+
+## Summary
+
+Migrated the `adaptive_mutation` example to seed its fresh run via the NEAT-AI **factory**
+`Creature.forDataset(records, { cost: "BINARY_CROSS_ENTROPY" })` instead of a bare
+`new Creature(4, 1)`. **Only the seed changes — evolution is untouched:** `evolveDir` keeps its
+default MSE scoring and the example still converges (faster, in fact — 955 generations / 1 m 1 s vs
+the prior 1440 / 1 m 26 s). This is a deliberate, milestone-sanctioned departure from the
+no-warm-start policy, made under the factory-adoption tracker (#517) and matching the merged MNIST
+(#518), Stock Market (#519), and XOR (#520) adoptions. Closes #533.
+
+### Cost / activation coupling chosen
+
+The `classification_task` driver is a 4-bit even-parity classifier (4 → 1, binary) with `{0, 1}`
+targets, classified via a `>= 0.5` threshold on a single output. So the cost is
+**`BINARY_CROSS_ENTROPY`**, which couples the output activation to a **LOGISTIC** sigmoid
+([NEAT-AI #2793](https://github.com/stSoftwareAU/NEAT-AI/issues/2793)) — the exact activation the
+threshold interface and `{0, 1}` MSE both assume. This is the same cost / activation pairing as the
+XOR adoption (#520).
+
+The factory derives, from problem-intrinsic facts only:
+
+- output activation coupled to the cost (LOGISTIC);
+- a conservative hidden-capacity budget (Heaton's rule → a small RELU hidden layer);
+- per-activation weight-init scaling (He / Xavier).
+
+Seed weights and biases remain **random** — only topology and scaling are factory-derived, and all
+structural growth beyond the seed still comes from the unchanged mutation operators.
+
+## Changes
+
+- `adaptive_mutation/adaptive_mutation.ts`
+  - Added `CLASSIFICATION_COST = "BINARY_CROSS_ENTROPY"`, `FactoryRecords`,
+    `datasetToFactoryRecords()`, `buildSeedCreature()` (factory), and `buildRandomSeedCreature()`
+    (the bare-constructor baseline, **retained for test / resume fixtures**).
+  - `runAdaptiveMutationDemo` now builds the seed via
+    `Creature.fromJSON(buildSeedCreature(datasetToFactoryRecords(trainingSet), config.seed))`. No
+    hardcoded hidden-layer sizes remain.
+- `adaptive_mutation/README.md` — documents the factory call and the deliberate departure; refreshed
+  the "Latest Measured Run" table with the new factory-seeded numbers.
+- `AGENTS.md` — added the `adaptive_mutation` factory exception alongside MNIST / Stock Market.
+- `docs/factory_adoption.md` — moved `adaptive_mutation` to ✅ Migrated and updated the adoption
+  flow diagram.
+- Regenerated `docs/screenshots/adaptive_mutation.svg` and
+  `.../adaptive_mutation/evolution_summary.svg`.
+
+## Seed change at a glance
+
+```mermaid
+flowchart LR
+    OLD["🌱 Old seed<br/>new Creature(4, 1)<br/>0 hidden, direct edges"]
+    FAC["🏭 Creature.forDataset(records,<br/>{ cost: BINARY_CROSS_ENTROPY })"]
+    NEW["🆕 Factory seed<br/>LOGISTIC output<br/>4 hidden, He/Xavier init"]
+    EVO["🧬 evolveDir — UNCHANGED<br/>default MSE scoring"]
+    OLD -. retained as<br/>buildRandomSeedCreature .-> FIX["test / resume fixtures"]
+    FAC --> NEW --> EVO
+```
+
+## Evidence
+
+CLI / library change — no web UI to screenshot. Verified by the unit-test suite and a full
+end-to-end run of `./adaptive_mutation/run.sh`:
+
+| Metric                   | Value (factory seed)            |
+| ------------------------ | ------------------------------- |
+| Generations              | 955 (solved — targetError 0.05) |
+| Wall-clock               | 1 m 1 s                         |
+| Final training accuracy  | 1.0000 (16/16)                  |
+| Held-out accuracy        | 1.0000                          |
+| Seed neurons / synapses  | 9 / 20 (4 factory hidden)       |
+| Final neurons / synapses | 11 / 27                         |
+
+The factory hidden layer ships with random weights, so gen-1 accuracy still sits around chance; the
+network grows and tunes from there to 1.0000 — the captured "noise → competent" arc preserved.
+
+## Test Plan
+
+`deno test adaptive_mutation/` — 46 passed, 0 failed. New "what" tests in
+`adaptive_mutation/adaptive_mutation_test.ts`:
+
+- `buildSeedCreature` — right arity; LOGISTIC output coupled to `BINARY_CROSS_ENTROPY`; data-derived
+  hidden layer (> 0 hidden); deterministic weights/biases per seed; valid finite `[0, 1]` outputs;
+  rejects an empty record set.
+- `datasetToFactoryRecords` — mirrors the dataset's inputs and targets.
+- `buildRandomSeedCreature` (retained baseline) — zero hidden neurons, pinned LOGISTIC output,
+  deterministic per seed, valid finite output.
+- `CLASSIFICATION_COST` equals `BINARY_CROSS_ENTROPY`.
+
+No existing tests were removed or commented out. Repo-wide `deno lint`, `deno check **/*.ts`, and
+`deno fmt --check` (for the changed files) pass.
+
+## Security self-check
+
+- No new external input surface; the factory reads the in-memory deterministic truth-table dataset.
+- No secrets, credentials, or hidden files staged.
+- No new SQL / shell / HTTP / filesystem injection surface.

--- a/docs/factory_adoption.md
+++ b/docs/factory_adoption.md
@@ -46,16 +46,16 @@ from the unchanged mutation operators.
 These examples train on a labelled dataset (CSV, `.bin`, or in-memory truth table) and can use the
 full data-scanning factory.
 
-| Example                | Status      | Issue                                                               | Notes                                                                                                  |
-| ---------------------- | ----------- | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| `mnist_classification` | ✅ Migrated | [#518](https://github.com/stSoftwareAU/NEAT-AI-Examples/issues/518) | `Creature.forDataset(records, { cost: "CROSS_ENTROPY" })` — dropped hardcoded `[128, 64]` hidden seed. |
-| `stock_market`         | ✅ Migrated | [#519](https://github.com/stSoftwareAU/NEAT-AI-Examples/issues/519) | Regression seed — `IDENTITY` output activation, target-mean bias warm-start.                           |
-| `xor_classification`   | ✅ Migrated | [#520](https://github.com/stSoftwareAU/NEAT-AI-Examples/issues/520) | Smoke-test — `BINARY_CROSS_ENTROPY` → `LOGISTIC` output + small RELU hidden layer.                     |
-| `adaptive_mutation`    | 🟡 Planned  | [#533](https://github.com/stSoftwareAU/NEAT-AI-Examples/issues/533) | `classification_task` is a 4-bit even-parity classifier (4 → 1, binary).                               |
-| `evolution_showcase`   | 🟡 Planned  | [#534](https://github.com/stSoftwareAU/NEAT-AI-Examples/issues/534) | Long-form flagship run; needs a deliberate departure write-up given its "noise → competent" framing.   |
-| `discovery_at_scale`   | 🟡 Planned  | [#535](https://github.com/stSoftwareAU/NEAT-AI-Examples/issues/535) | `evolveDir` over a binary `.bin` set built from a `buildLargeCreature(...)` reference.                 |
-| `memetic_evolution`    | 🟡 Planned  | [#536](https://github.com/stSoftwareAU/NEAT-AI-Examples/issues/536) | Two `evolveDir` runs (memetic + control); both seeds eligible for `forDataset`.                        |
-| `crossover`            | 🟡 Planned  | [#537](https://github.com/stSoftwareAU/NEAT-AI-Examples/issues/537) | NEAT seed for the second stage of the crossover demo is a minimal `new Creature(...)`.                 |
+| Example                | Status      | Issue                                                               | Notes                                                                                                             |
+| ---------------------- | ----------- | ------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `mnist_classification` | ✅ Migrated | [#518](https://github.com/stSoftwareAU/NEAT-AI-Examples/issues/518) | `Creature.forDataset(records, { cost: "CROSS_ENTROPY" })` — dropped hardcoded `[128, 64]` hidden seed.            |
+| `stock_market`         | ✅ Migrated | [#519](https://github.com/stSoftwareAU/NEAT-AI-Examples/issues/519) | Regression seed — `IDENTITY` output activation, target-mean bias warm-start.                                      |
+| `xor_classification`   | ✅ Migrated | [#520](https://github.com/stSoftwareAU/NEAT-AI-Examples/issues/520) | Smoke-test — `BINARY_CROSS_ENTROPY` → `LOGISTIC` output + small RELU hidden layer.                                |
+| `adaptive_mutation`    | ✅ Migrated | [#533](https://github.com/stSoftwareAU/NEAT-AI-Examples/issues/533) | 4-bit even-parity classifier (4 → 1, binary) — `BINARY_CROSS_ENTROPY` → `LOGISTIC` output + factory hidden layer. |
+| `evolution_showcase`   | 🟡 Planned  | [#534](https://github.com/stSoftwareAU/NEAT-AI-Examples/issues/534) | Long-form flagship run; needs a deliberate departure write-up given its "noise → competent" framing.              |
+| `discovery_at_scale`   | 🟡 Planned  | [#535](https://github.com/stSoftwareAU/NEAT-AI-Examples/issues/535) | `evolveDir` over a binary `.bin` set built from a `buildLargeCreature(...)` reference.                            |
+| `memetic_evolution`    | 🟡 Planned  | [#536](https://github.com/stSoftwareAU/NEAT-AI-Examples/issues/536) | Two `evolveDir` runs (memetic + control); both seeds eligible for `forDataset`.                                   |
+| `crossover`            | 🟡 Planned  | [#537](https://github.com/stSoftwareAU/NEAT-AI-Examples/issues/537) | NEAT seed for the second stage of the crossover demo is a minimal `new Creature(...)`.                            |
 
 ### Group B — RL / control (Tier-0 `forProblem` only, no data scan)
 
@@ -111,8 +111,8 @@ flowchart LR
     SHIP --> B["🅱️ Group B<br/>RL/control — forProblem (Tier-0)"]
     SHIP --> C["🅲 Group C<br/>Mechanic demos — forDataset (post-A)"]
 
-    A --> A_DONE["MNIST · Stock · XOR<br/>(merged into milestone/factory)"]
-    A --> A_TODO["adaptive_mutation<br/>evolution_showcase<br/>discovery_at_scale<br/>memetic_evolution<br/>crossover"]
+    A --> A_DONE["MNIST · Stock · XOR · adaptive_mutation<br/>(merged into milestone/factory)"]
+    A --> A_TODO["evolution_showcase<br/>discovery_at_scale<br/>memetic_evolution<br/>crossover"]
 
     B --> B_TIER0["6 × Tier-0 swap<br/>(cart_pole, lunar_lander,<br/>mountain_car, snake_game,<br/>maze_navigation, tsp_constructive)"]
     B --> B_DEFER["tsp_two_opt<br/>(hand-tuned 16/12 layers —<br/>revisit)"]

--- a/docs/screenshots/adaptive_mutation.svg
+++ b/docs/screenshots/adaptive_mutation.svg
@@ -26,33 +26,33 @@
   <text x="20.00" y="191.00" text-anchor="middle" dominant-baseline="middle" transform="rotate(-90 20.00 191.00)" font-family="sans-serif" font-size="11" fill="#e67e22">p(topology mutation)</text>
   <text x="475.00" y="346.00" text-anchor="middle" font-family="sans-serif" font-size="11" fill="#555">size (neurons + synapses)</text>
   <polyline class="topology-rate" fill="none" stroke="#e67e22" stroke-width="2" stroke-dasharray="6 3" points="70.00,70.00 80.13,81.52 90.25,92.00 100.38,101.57 110.50,110.33 120.63,118.40 130.75,125.85 140.88,132.74 151.00,139.14 161.13,145.10 171.25,150.67 181.38,155.87 191.50,160.75 201.63,165.33 211.75,169.65 221.88,173.71 232.00,177.56 242.13,181.19 252.25,184.63 262.38,187.90 272.50,191.00 282.63,193.95 292.75,196.76 302.88,199.44 313.00,202.00 323.13,204.44 333.25,206.78 343.38,209.02 353.50,211.17 363.63,213.22 373.75,215.20 383.88,217.10 394.00,218.92 404.13,220.68 414.25,222.37 424.38,224.00 434.50,225.57 444.63,227.09 454.75,228.55 464.88,229.97 475.00,231.33 485.12,232.66 495.25,233.94 505.38,235.17 515.50,236.38 525.63,237.54 535.75,238.67 545.88,239.76 556.00,240.82 566.13,241.86 576.25,242.86 586.38,243.83 596.50,244.78 606.63,245.70 616.75,246.59 626.88,247.47 637.00,248.32 647.13,249.14 657.25,249.95 667.38,250.73 677.50,251.50 687.63,252.25 697.75,252.98 707.88,253.69 718.00,254.38 728.13,255.06 738.25,255.72 748.38,256.37 758.50,257.00 768.63,257.62 778.75,258.22 788.88,258.81 799.00,259.39 809.13,259.96 819.25,260.51 829.38,261.05 839.50,261.58 849.63,262.10 859.75,262.61 869.88,263.11 880.00,263.60"/>
-  <circle class="seed-mark" cx="92.78" cy="94.47" r="5" fill="#9ecae1" stroke="#333" stroke-width="1"/>
-  <text x="100.78" y="88.47" font-family="sans-serif" font-size="10" fill="#333">seed (size 9)</text>
-  <circle class="final-mark" cx="140.88" cy="132.74" r="5" fill="#1f77b4" stroke="#333" stroke-width="1"/>
-  <text x="148.88" y="146.74" font-family="sans-serif" font-size="10" fill="#333">final (size 28)</text>
+  <circle class="seed-mark" cx="143.41" cy="134.39" r="5" fill="#9ecae1" stroke="#333" stroke-width="1"/>
+  <text x="151.41" y="128.39" font-family="sans-serif" font-size="10" fill="#333">seed (size 29)</text>
+  <circle class="final-mark" cx="166.19" cy="147.93" r="5" fill="#1f77b4" stroke="#333" stroke-width="1"/>
+  <text x="174.19" y="161.93" font-family="sans-serif" font-size="10" fill="#333">final (size 38)</text>
   <text x="70.00" y="64.00" font-family="sans-serif" font-size="11" font-weight="bold" fill="#333">Analytic topology-mutation policy curve</text>
   <text x="70.00" y="356.00" font-family="sans-serif" font-size="11" font-weight="bold" fill="#333">Seed → final topology (neurons and synapses)</text>
   <g class="seed-vs-final">
-    <rect class="topo-bar topo-bar-seed-neurons" x="125.69" y="449.87" width="91.13" height="82.13" fill="#9ecae1"/>
-    <text x="171.25" y="445.87" text-anchor="middle" font-family="sans-serif" font-size="11" font-weight="bold" fill="#222">5</text>
+    <rect class="topo-bar topo-bar-seed-neurons" x="125.69" y="411.05" width="91.13" height="120.95" fill="#9ecae1"/>
+    <text x="171.25" y="407.05" text-anchor="middle" font-family="sans-serif" font-size="11" font-weight="bold" fill="#222">9</text>
     <text x="171.25" y="546.00" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#555">seed</text>
     <rect class="topo-bar topo-bar-final-neurons" x="328.19" y="384.17" width="91.13" height="147.83" fill="#1f77b4"/>
-    <text x="373.75" y="380.17" text-anchor="middle" font-family="sans-serif" font-size="11" font-weight="bold" fill="#222">9</text>
+    <text x="373.75" y="380.17" text-anchor="middle" font-family="sans-serif" font-size="11" font-weight="bold" fill="#222">11</text>
     <text x="373.75" y="546.00" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#555">final</text>
     <text x="272.50" y="560.00" text-anchor="middle" font-family="sans-serif" font-size="11" font-weight="bold" fill="#333">neurons</text>
-    <rect class="topo-bar topo-bar-seed-synapses" x="530.69" y="500.88" width="91.13" height="31.12" fill="#9ecae1"/>
-    <text x="576.25" y="496.88" text-anchor="middle" font-family="sans-serif" font-size="11" font-weight="bold" fill="#222">4</text>
+    <rect class="topo-bar topo-bar-seed-synapses" x="530.69" y="422.50" width="91.13" height="109.50" fill="#9ecae1"/>
+    <text x="576.25" y="418.50" text-anchor="middle" font-family="sans-serif" font-size="11" font-weight="bold" fill="#222">20</text>
     <text x="576.25" y="546.00" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#555">seed</text>
     <rect class="topo-bar topo-bar-final-synapses" x="733.19" y="384.17" width="91.13" height="147.83" fill="#1f77b4"/>
-    <text x="778.75" y="380.17" text-anchor="middle" font-family="sans-serif" font-size="11" font-weight="bold" fill="#222">19</text>
+    <text x="778.75" y="380.17" text-anchor="middle" font-family="sans-serif" font-size="11" font-weight="bold" fill="#222">27</text>
     <text x="778.75" y="546.00" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#555">final</text>
     <text x="677.50" y="560.00" text-anchor="middle" font-family="sans-serif" font-size="11" font-weight="bold" fill="#333">synapses</text>
   </g>
   <rect x="82.00" y="82.00" width="220" height="74" fill="#ffffff" fill-opacity="0.92" stroke="#cccccc"/>
-  <text x="90.00" y="98.00" font-family="sans-serif" font-size="11" fill="#222">Generations: 2002</text>
-  <text x="90.00" y="112.00" font-family="sans-serif" font-size="11" fill="#222">Wall-clock: 216.3s</text>
-  <text x="90.00" y="126.00" font-family="sans-serif" font-size="11" fill="#222">Final error: 0.0575</text>
-  <text x="90.00" y="140.00" font-family="sans-serif" font-size="11" fill="#222">Held-out -MSE: -0.0624</text>
+  <text x="90.00" y="98.00" font-family="sans-serif" font-size="11" fill="#222">Generations: 955 (solved)</text>
+  <text x="90.00" y="112.00" font-family="sans-serif" font-size="11" fill="#222">Wall-clock: 61.0s</text>
+  <text x="90.00" y="126.00" font-family="sans-serif" font-size="11" fill="#222">Final error: 0.0000</text>
+  <text x="90.00" y="140.00" font-family="sans-serif" font-size="11" fill="#222">Held-out -MSE: 0.0000</text>
   <g class="legend" font-family="sans-serif" font-size="11" fill="#333">
     <line x1="260" y1="610" x2="282" y2="610" stroke="#e67e22" stroke-width="2" stroke-dasharray="6 3"/>
     <text x="288" y="614">analytic p(topology)</text>

--- a/docs/screenshots/adaptive_mutation/evolution_summary.svg
+++ b/docs/screenshots/adaptive_mutation/evolution_summary.svg
@@ -5,18 +5,18 @@
   <g class="topology" font-family="sans-serif" font-size="11" fill="#333">
     <rect x="24" y="48" width="369" height="256" fill="#ffffff" stroke="#333" stroke-width="1"/>
     <text x="34" y="64" font-weight="bold">topology</text>
-    <rect class="topo-bar topo-bar-seed-neurons" x="47.06" y="170" width="46.13" height="100" fill="#9ecae1"/>
-    <text x="70.13" y="166" text-anchor="middle" font-weight="bold">5</text>
+    <rect class="topo-bar topo-bar-seed-neurons" x="47.06" y="122.73" width="46.13" height="147.27" fill="#9ecae1"/>
+    <text x="70.13" y="118.73" text-anchor="middle" font-weight="bold">9</text>
     <text x="70.13" y="282" text-anchor="middle">seed</text>
     <rect class="topo-bar topo-bar-final-neurons" x="139.31" y="90" width="46.13" height="180" fill="#1f77b4"/>
-    <text x="162.38" y="86" text-anchor="middle" font-weight="bold">9</text>
+    <text x="162.38" y="86" text-anchor="middle" font-weight="bold">11</text>
     <text x="162.38" y="282" text-anchor="middle">final</text>
     <text x="116.25" y="292" text-anchor="middle" font-weight="bold">neurons</text>
-    <rect class="topo-bar topo-bar-seed-synapses" x="231.56" y="232.11" width="46.13" height="37.89" fill="#9ecae1"/>
-    <text x="254.63" y="228.11" text-anchor="middle" font-weight="bold">4</text>
+    <rect class="topo-bar topo-bar-seed-synapses" x="231.56" y="136.67" width="46.13" height="133.33" fill="#9ecae1"/>
+    <text x="254.63" y="132.67" text-anchor="middle" font-weight="bold">20</text>
     <text x="254.63" y="282" text-anchor="middle">seed</text>
     <rect class="topo-bar topo-bar-final-synapses" x="323.81" y="90" width="46.13" height="180" fill="#1f77b4"/>
-    <text x="346.88" y="86" text-anchor="middle" font-weight="bold">19</text>
+    <text x="346.88" y="86" text-anchor="middle" font-weight="bold">27</text>
     <text x="346.88" y="282" text-anchor="middle">final</text>
     <text x="300.75" y="292" text-anchor="middle" font-weight="bold">synapses</text>
   </g>
@@ -24,13 +24,13 @@
     <rect x="409" y="48" width="287" height="256" fill="#ffffff" stroke="#333" stroke-width="1"/>
     <text x="419" y="64" font-weight="bold">summary</text>
     <text class="callout-label" x="421" y="103.5" dominant-baseline="middle">final error</text>
-    <text class="callout-value" x="684" y="103.5" text-anchor="end" dominant-baseline="middle" font-weight="bold" fill="#2ca02c">0.058</text>
+    <text class="callout-value" x="684" y="103.5" text-anchor="end" dominant-baseline="middle" font-weight="bold" fill="#2ca02c">0</text>
     <text class="callout-label" x="421" y="158.5" dominant-baseline="middle">final score</text>
-    <text class="callout-value" x="684" y="158.5" text-anchor="end" dominant-baseline="middle" font-weight="bold" fill="#2ca02c">0.942</text>
+    <text class="callout-value" x="684" y="158.5" text-anchor="end" dominant-baseline="middle" font-weight="bold" fill="#2ca02c">1</text>
     <text class="callout-label" x="421" y="213.5" dominant-baseline="middle">generations</text>
-    <text class="callout-value" x="684" y="213.5" text-anchor="end" dominant-baseline="middle" font-weight="bold" fill="#2ca02c">2002</text>
+    <text class="callout-value" x="684" y="213.5" text-anchor="end" dominant-baseline="middle" font-weight="bold" fill="#2ca02c">955</text>
     <text class="callout-label" x="421" y="268.5" dominant-baseline="middle">wall clock</text>
-    <text class="callout-value" x="684" y="268.5" text-anchor="end" dominant-baseline="middle" font-weight="bold" fill="#2ca02c">3m 36s</text>
+    <text class="callout-value" x="684" y="268.5" text-anchor="end" dominant-baseline="middle" font-weight="bold" fill="#2ca02c">1m 1s</text>
   </g>
   <g class="caption" font-family="sans-serif" font-size="12" fill="#555">
     <text x="360" y="348" text-anchor="middle">stop conditions: target error 0.05 · timeout 5 min</text>


### PR DESCRIPTION
# PR Summary — adaptive_mutation: build the initial creature via the NEAT-AI factory (#533)

## Summary

Migrated the `adaptive_mutation` example to seed its fresh run via the NEAT-AI **factory**
`Creature.forDataset(records, { cost: "BINARY_CROSS_ENTROPY" })` instead of a bare
`new Creature(4, 1)`. **Only the seed changes — evolution is untouched:** `evolveDir` keeps its
default MSE scoring and the example still converges (faster, in fact — 955 generations / 1 m 1 s vs
the prior 1440 / 1 m 26 s). This is a deliberate, milestone-sanctioned departure from the
no-warm-start policy, made under the factory-adoption tracker (#517) and matching the merged MNIST
(#518), Stock Market (#519), and XOR (#520) adoptions. Closes #533.

### Cost / activation coupling chosen

The `classification_task` driver is a 4-bit even-parity classifier (4 → 1, binary) with `{0, 1}`
targets, classified via a `>= 0.5` threshold on a single output. So the cost is
**`BINARY_CROSS_ENTROPY`**, which couples the output activation to a **LOGISTIC** sigmoid
([NEAT-AI #2793](https://github.com/stSoftwareAU/NEAT-AI/issues/2793)) — the exact activation the
threshold interface and `{0, 1}` MSE both assume. This is the same cost / activation pairing as the
XOR adoption (#520).

The factory derives, from problem-intrinsic facts only:

- output activation coupled to the cost (LOGISTIC);
- a conservative hidden-capacity budget (Heaton's rule → a small RELU hidden layer);
- per-activation weight-init scaling (He / Xavier).

Seed weights and biases remain **random** — only topology and scaling are factory-derived, and all
structural growth beyond the seed still comes from the unchanged mutation operators.

## Changes

- `adaptive_mutation/adaptive_mutation.ts`
  - Added `CLASSIFICATION_COST = "BINARY_CROSS_ENTROPY"`, `FactoryRecords`,
    `datasetToFactoryRecords()`, `buildSeedCreature()` (factory), and `buildRandomSeedCreature()`
    (the bare-constructor baseline, **retained for test / resume fixtures**).
  - `runAdaptiveMutationDemo` now builds the seed via
    `Creature.fromJSON(buildSeedCreature(datasetToFactoryRecords(trainingSet), config.seed))`. No
    hardcoded hidden-layer sizes remain.
- `adaptive_mutation/README.md` — documents the factory call and the deliberate departure; refreshed
  the "Latest Measured Run" table with the new factory-seeded numbers.
- `AGENTS.md` — added the `adaptive_mutation` factory exception alongside MNIST / Stock Market.
- `docs/factory_adoption.md` — moved `adaptive_mutation` to ✅ Migrated and updated the adoption
  flow diagram.
- Regenerated `docs/screenshots/adaptive_mutation.svg` and
  `.../adaptive_mutation/evolution_summary.svg`.

## Seed change at a glance

```mermaid
flowchart LR
    OLD["🌱 Old seed<br/>new Creature(4, 1)<br/>0 hidden, direct edges"]
    FAC["🏭 Creature.forDataset(records,<br/>{ cost: BINARY_CROSS_ENTROPY })"]
    NEW["🆕 Factory seed<br/>LOGISTIC output<br/>4 hidden, He/Xavier init"]
    EVO["🧬 evolveDir — UNCHANGED<br/>default MSE scoring"]
    OLD -. retained as<br/>buildRandomSeedCreature .-> FIX["test / resume fixtures"]
    FAC --> NEW --> EVO
```

## Evidence

CLI / library change — no web UI to screenshot. Verified by the unit-test suite and a full
end-to-end run of `./adaptive_mutation/run.sh`:

| Metric                   | Value (factory seed)            |
| ------------------------ | ------------------------------- |
| Generations              | 955 (solved — targetError 0.05) |
| Wall-clock               | 1 m 1 s                         |
| Final training accuracy  | 1.0000 (16/16)                  |
| Held-out accuracy        | 1.0000                          |
| Seed neurons / synapses  | 9 / 20 (4 factory hidden)       |
| Final neurons / synapses | 11 / 27                         |

The factory hidden layer ships with random weights, so gen-1 accuracy still sits around chance; the
network grows and tunes from there to 1.0000 — the captured "noise → competent" arc preserved.

## Test Plan

`deno test adaptive_mutation/` — 46 passed, 0 failed. New "what" tests in
`adaptive_mutation/adaptive_mutation_test.ts`:

- `buildSeedCreature` — right arity; LOGISTIC output coupled to `BINARY_CROSS_ENTROPY`; data-derived
  hidden layer (> 0 hidden); deterministic weights/biases per seed; valid finite `[0, 1]` outputs;
  rejects an empty record set.
- `datasetToFactoryRecords` — mirrors the dataset's inputs and targets.
- `buildRandomSeedCreature` (retained baseline) — zero hidden neurons, pinned LOGISTIC output,
  deterministic per seed, valid finite output.
- `CLASSIFICATION_COST` equals `BINARY_CROSS_ENTROPY`.

No existing tests were removed or commented out. Repo-wide `deno lint`, `deno check **/*.ts`, and
`deno fmt --check` (for the changed files) pass.

## Security self-check

- No new external input surface; the factory reads the in-memory deterministic truth-table dataset.
- No secrets, credentials, or hidden files staged.
- No new SQL / shell / HTTP / filesystem injection surface.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mpuqjmzo-9e8e42`<!-- vibe-worker-issue-533 -->