### PR TITLE
Replace source-text grep assertions in mnist_classification_test.ts (Issue #530)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-530.md
+++ b/docs/archive/pr-summaries/pr-summary-530.md
@@ -16,6 +16,7 @@ any granted permission — the test passed on doc text, not behaviour, and would
 fail on a harmless comment reword. The behaviour it stood proxy for (every
 Discovery runner is granted FFI) is already covered behaviourally in
 `common/run_sh_permissions_test.ts`:
+
 - `example runner preamble grants required Deno flags`
 - `every run.sh that loads Discovery uses shared Deno flags with --allow-ffi`
 

--- a/docs/archive/pr-summaries/pr-summary-530.md
+++ b/docs/archive/pr-summaries/pr-summary-530.md
@@ -1,0 +1,73 @@
+# Replace source-text grep assertions in mnist_classification_test.ts
+
+## Summary
+
+Removed two "how" tests (source-text grep-as-assertions, anti-pattern #2) from
+`mnist_classification/mnist_classification_test.ts` and replaced the meaningful
+one with a behavioural "what" test, per the project [Testing Philosophy](../../../AGENTS.md).
+Closes #530.
+
+**1. `--allow-ffi` run.sh test — deleted (issue's Option b).**
+The test asserted the literal substring `--allow-ffi` appears in
+`mnist_classification/run.sh`. The flag has since moved into the shared
+preamble (`NEAT_EXAMPLE_DENO_FLAGS` via `common/example_runner_preamble.sh`),
+so the substring now matches only the *descriptive comment* in `run.sh`, not
+any granted permission — the test passed on doc text, not behaviour, and would
+fail on a harmless comment reword. The behaviour it stood proxy for (every
+Discovery runner is granted FFI) is already covered behaviourally in
+`common/run_sh_permissions_test.ts`:
+- `example runner preamble grants required Deno flags`
+- `every run.sh that loads Discovery uses shared Deno flags with --allow-ffi`
+
+A documenting comment was left in place of the deleted test recording the
+removal and pointing to the behavioural coverage.
+
+**2. README chart-embed test — rewritten behaviourally (issue's Option a).**
+The old test asserted exact relative image paths
+(`../docs/screenshots/mnist_classification/milestones.svg`, …) were present and
+that historical strings (`evolution_summary.svg`, `tracked in #273`) were
+absent — coupling to doc-tree layout and documentation formatting, not
+behaviour. The replacement parses every markdown image embed in the README and
+asserts each local asset resolves to a **non-empty file on disk** — the real
+behaviour (no broken chart links). It couples only to the chart pipeline's
+artefact filenames (`milestones.svg`, `complexity.svg` — a stable output
+contract) to confirm both headline charts stay embedded, not to the brittle
+relative path. The formatting-absence greps were dropped as they assert no
+behaviour.
+
+```mermaid
+flowchart LR
+    A["Old: readme.includes('../docs/.../milestones.svg')"] -->|brittle: path + formatting| X[breaks on harmless reformat]
+    B["New: parse embeds → Deno.stat each asset"] -->|behavioural| Y[fails only on a real broken chart link]
+```
+
+## Why this is in scope
+
+`run.sh`'s FFI permission is validated behaviourally elsewhere
+(`common/run_sh_permissions_test.ts`), so the mnist substring check was
+redundant; the README path/absence checks verify documentation formatting, not
+functionality. Both align with the repo's prohibition on "how" tests.
+
+## Test changes
+
+- **Deleted** `mnist run.sh grants --allow-ffi for Discovery and evolveDir training`
+  (redundant + only matched a comment). Replaced by an explanatory comment.
+- **Replaced** `README embeds the multi-run charts and drops the legacy evolution_summary path`
+  with `every chart embedded in the mnist README resolves to a non-empty asset`
+  — a behavioural broken-embed test.
+- Added `dirname`, `normalize` to the `@std/path` import.
+
+## Test Plan
+
+- `deno test mnist_classification/mnist_classification_test.ts common/run_sh_permissions_test.ts` — 51 passed, 0 failed.
+- Verified the new test **fails** when a referenced asset is removed
+  (temporarily moved `milestones.svg` → `NotFound`/assertion failure), then
+  **passes** once restored — confirming it catches the real regression rather
+  than tracking source text.
+- `./quality.sh` — the only failure was the pre-existing stochastic
+  `evolveCartPoleController champion generalises …` cart_pole test (unrelated to
+  this change; passes on rerun). No mnist or permissions tests regressed.
+
+## Evidence
+
+CLI/test-only change — no UI. Evidence is the test runs above.

--- a/mnist_classification/mnist_classification_test.ts
+++ b/mnist_classification/mnist_classification_test.ts
@@ -29,7 +29,7 @@ import {
   assertThrows,
 } from "@std/assert";
 import { Costs, Creature } from "@stsoftware/neat-ai";
-import { join } from "@std/path";
+import { dirname, join, normalize } from "@std/path";
 
 import { asCreatureExport } from "../common/legacy_types.ts";
 import { createDeterministicRandom } from "../common/deterministic_random.ts";
@@ -762,38 +762,56 @@ Deno.test("assertNoTargetErrorCliOverride rejects --target-error flags", () => {
   assertNoTargetErrorCliOverride(["--timeout=15"]);
 });
 
-Deno.test("mnist run.sh grants --allow-ffi for Discovery and evolveDir training", async () => {
-  const script = await Deno.readTextFile("mnist_classification/run.sh");
-  assert(
-    script.includes("--allow-ffi"),
-    "mnist_classification/run.sh must pass --allow-ffi so NEAT-AI can load Discovery",
-  );
-});
+// The former source-text grep test "mnist run.sh grants --allow-ffi …"
+// was removed under issue #530. It was a "how" test (anti-pattern #2):
+// it asserted the literal `--allow-ffi` substring appears in run.sh, and
+// since the flag moved into the shared preamble (NEAT_EXAMPLE_DENO_FLAGS)
+// it only ever matched the *comment* that mentions the flag — passing on
+// doc text, not on any granted permission. The behaviour it stood proxy
+// for (every Discovery runner is granted FFI via the shared preamble) is
+// already covered behaviourally in `common/run_sh_permissions_test.ts`
+// ("example runner preamble grants required Deno flags" and "every run.sh
+// that loads Discovery uses shared Deno flags with --allow-ffi").
 
-Deno.test("README embeds the multi-run charts and drops the legacy evolution_summary path", () => {
-  const readme = Deno.readTextFileSync("mnist_classification/README.md");
-  assert(
-    readme.includes("../docs/screenshots/mnist_classification/milestones.svg"),
-    "README must embed the multi-run error-curve chart (milestones.svg)",
-  );
-  assert(
-    readme.includes("../docs/screenshots/mnist_classification/complexity.svg"),
-    "README must embed the multi-run complexity chart (complexity.svg)",
-  );
-  // The legacy single-run evolution_summary chart is retired under #327.
-  assert(
-    !readme.includes("evolution_summary.svg"),
-    "README must no longer reference the retired evolution_summary.svg",
-  );
-  // The historical #273 deferred placeholder must stay gone.
-  assert(
-    !readme.includes("Per-generation telemetry — deferred"),
-    "README must no longer contain the deferred placeholder line",
-  );
-  assert(
-    !readme.includes("tracked in #273"),
-    'README must no longer reference the "tracked in #273" deferred placeholder',
-  );
+Deno.test("every chart embedded in the mnist README resolves to a non-empty asset", async () => {
+  // WHAT-test (replaces the former source-text substring/absence greps,
+  // issue #530). The behaviour the old test stood proxy for is that the
+  // charts the README embeds actually exist and render. Parse the
+  // embedded image targets and assert each local asset is a non-empty
+  // file. This is robust to restructuring the docs tree (move the embed
+  // and the asset together) and catches the real regression — a broken
+  // chart link — instead of failing on a harmless path reformat.
+  const readmePath = "mnist_classification/README.md";
+  const readme = await Deno.readTextFile(readmePath);
+  const readmeDir = dirname(readmePath);
+
+  // Markdown image embeds: ![alt](target). Keep only local asset
+  // references (skip absolute URLs and in-page anchors).
+  const embeds = [...readme.matchAll(/!\[[^\]]*\]\(([^)\s]+)\)/g)]
+    .map((m) => m[1])
+    .filter((target) => !/^[a-z][a-z0-9+.-]*:\/\//i.test(target) && !target.startsWith("#"));
+  assert(embeds.length > 0, "mnist README must embed at least one chart asset");
+
+  for (const ref of embeds) {
+    const path = normalize(join(readmeDir, ref));
+    const stat = await Deno.stat(path).catch(() => null);
+    assert(
+      stat?.isFile && stat.size > 0,
+      `mnist README embeds ${ref} but ${path} is missing or empty`,
+    );
+  }
+
+  // The multi-run charts are the headline artefacts of this example, so
+  // both must remain embedded. Couple only to the chart pipeline's
+  // output filenames (a stable contract), not to the brittle relative
+  // doc path the old test asserted.
+  const basenames = embeds.map((ref) => ref.split("/").pop());
+  for (const chart of ["milestones.svg", "complexity.svg"]) {
+    assert(
+      basenames.includes(chart),
+      `mnist README must embed the multi-run ${chart} chart`,
+    );
+  }
 });
 
 Deno.test("top-level README MNIST entries match the real 784 / 28×28 code (Issue #515)", () => {


### PR DESCRIPTION
# Replace source-text grep assertions in mnist_classification_test.ts

## Summary

Removed two "how" tests (source-text grep-as-assertions, anti-pattern #2) from
`mnist_classification/mnist_classification_test.ts` and replaced the meaningful
one with a behavioural "what" test, per the project [Testing Philosophy](../../../AGENTS.md).
Closes #530.

**1. `--allow-ffi` run.sh test — deleted (issue's Option b).**
The test asserted the literal substring `--allow-ffi` appears in
`mnist_classification/run.sh`. The flag has since moved into the shared
preamble (`NEAT_EXAMPLE_DENO_FLAGS` via `common/example_runner_preamble.sh`),
so the substring now matches only the *descriptive comment* in `run.sh`, not
any granted permission — the test passed on doc text, not behaviour, and would
fail on a harmless comment reword. The behaviour it stood proxy for (every
Discovery runner is granted FFI) is already covered behaviourally in
`common/run_sh_permissions_test.ts`:
- `example runner preamble grants required Deno flags`
- `every run.sh that loads Discovery uses shared Deno flags with --allow-ffi`

A documenting comment was left in place of the deleted test recording the
removal and pointing to the behavioural coverage.

**2. README chart-embed test — rewritten behaviourally (issue's Option a).**
The old test asserted exact relative image paths
(`../docs/screenshots/mnist_classification/milestones.svg`, …) were present and
that historical strings (`evolution_summary.svg`, `tracked in #273`) were
absent — coupling to doc-tree layout and documentation formatting, not
behaviour. The replacement parses every markdown image embed in the README and
asserts each local asset resolves to a **non-empty file on disk** — the real
behaviour (no broken chart links). It couples only to the chart pipeline's
artefact filenames (`milestones.svg`, `complexity.svg` — a stable output
contract) to confirm both headline charts stay embedded, not to the brittle
relative path. The formatting-absence greps were dropped as they assert no
behaviour.

```mermaid
flowchart LR
    A["Old: readme.includes('../docs/.../milestones.svg')"] -->|brittle: path + formatting| X[breaks on harmless reformat]
    B["New: parse embeds → Deno.stat each asset"] -->|behavioural| Y[fails only on a real broken chart link]
```

## Why this is in scope

`run.sh`'s FFI permission is validated behaviourally elsewhere
(`common/run_sh_permissions_test.ts`), so the mnist substring check was
redundant; the README path/absence checks verify documentation formatting, not
functionality. Both align with the repo's prohibition on "how" tests.

## Test changes

- **Deleted** `mnist run.sh grants --allow-ffi for Discovery and evolveDir training`
  (redundant + only matched a comment). Replaced by an explanatory comment.
- **Replaced** `README embeds the multi-run charts and drops the legacy evolution_summary path`
  with `every chart embedded in the mnist README resolves to a non-empty asset`
  — a behavioural broken-embed test.
- Added `dirname`, `normalize` to the `@std/path` import.

## Test Plan

- `deno test mnist_classification/mnist_classification_test.ts common/run_sh_permissions_test.ts` — 51 passed, 0 failed.
- Verified the new test **fails** when a referenced asset is removed
  (temporarily moved `milestones.svg` → `NotFound`/assertion failure), then
  **passes** once restored — confirming it catches the real regression rather
  than tracking source text.
- `./quality.sh` — the only failure was the pre-existing stochastic
  `evolveCartPoleController champion generalises …` cart_pole test (unrelated to
  this change; passes on rerun). No mnist or permissions tests regressed.

## Evidence

CLI/test-only change — no UI. Evidence is the test runs above.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mpuyrrw3-19a33d`<!-- vibe-worker-issue-530 -->