### PR TITLE
Pin dtolnay/rust-toolchain to a commit SHA in quality.yml (#552)

### DIFF
--- a/.github/quality_workflow_test.ts
+++ b/.github/quality_workflow_test.ts
@@ -1,0 +1,79 @@
+// Tests for .github/workflows/quality.yml supply-chain hardening (Issue #552).
+//
+// Every third-party action in the repository must be pinned to an
+// immutable 40-character commit SHA rather than a moving branch or tag
+// (see the supply-chain hardening rules in AGENTS.md and GitHub's own
+// guidance). A branch reference such as `@stable` is mutable: whoever
+// controls the upstream repository can repoint the branch at malicious
+// code, which then executes on the runner with the job's GITHUB_TOKEN
+// and any secrets in scope (this job builds rust_scorer and reads
+// CODECOV_TOKEN).
+//
+// These tests pin that contract for quality.yml so a future unpinned
+// action fails the build instead of slipping through review.
+
+import { assert, assertEquals } from "@std/assert";
+import { parse } from "@std/yaml";
+
+const WORKFLOW_PATH = new URL("./workflows/quality.yml", import.meta.url);
+
+// deno-lint-ignore no-explicit-any
+type Workflow = any;
+
+async function loadWorkflow(): Promise<Workflow> {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  return parse(text) as Workflow;
+}
+
+Deno.test("quality workflow — every uses: pins a 40-char commit SHA", async () => {
+  const wf = await loadWorkflow();
+  const jobs = wf.jobs as Record<string, Record<string, unknown>>;
+  const shaPattern = /@[0-9a-f]{40}\b/;
+  for (const [jobKey, job] of Object.entries(jobs)) {
+    const steps = (job as { steps?: Array<Record<string, unknown>> }).steps ??
+      [];
+    for (const step of steps) {
+      const uses = step.uses as string | undefined;
+      if (!uses) continue;
+      assert(
+        shaPattern.test(uses),
+        `job '${jobKey}' step '${step.name ?? uses}' must pin its action ` +
+          `to a 40-character commit SHA (got '${uses}'). See the supply-chain ` +
+          `hardening rules in AGENTS.md.`,
+      );
+    }
+  }
+});
+
+Deno.test("quality workflow — rust-toolchain is SHA-pinned and keeps toolchain: stable", async () => {
+  const wf = await loadWorkflow();
+  const jobs = wf.jobs as Record<string, Record<string, unknown>>;
+  let found: Record<string, unknown> | undefined;
+  for (const job of Object.values(jobs)) {
+    const steps = (job as { steps?: Array<Record<string, unknown>> }).steps ??
+      [];
+    for (const step of steps) {
+      const uses = (step.uses as string | undefined) ?? "";
+      if (uses.startsWith("dtolnay/rust-toolchain@")) {
+        found = step;
+        break;
+      }
+    }
+    if (found) break;
+  }
+  assert(found, "quality workflow must install the Rust toolchain");
+  const uses = found.uses as string;
+  assert(
+    /^dtolnay\/rust-toolchain@[0-9a-f]{40}\b/.test(uses),
+    `dtolnay/rust-toolchain must pin a 40-character commit SHA (got '${uses}')`,
+  );
+  // When pinned to a SHA the action can no longer infer the toolchain
+  // from the ref name (it did so for the `@stable` branch), so the
+  // toolchain must be supplied explicitly to preserve behaviour.
+  const withBlock = found.with as { toolchain?: string } | undefined;
+  assertEquals(
+    withBlock?.toolchain,
+    "stable",
+    "SHA-pinned rust-toolchain must set `with: toolchain: stable` to keep the stable toolchain",
+  );
+});

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -87,7 +87,9 @@ jobs:
           fi
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
 
       - name: Build rust_scorer
         run: RUSTFLAGS="-D warnings" cargo build --release -p rust_scorer

--- a/docs/archive/pr-summaries/pr-summary-552.md
+++ b/docs/archive/pr-summaries/pr-summary-552.md
@@ -1,0 +1,68 @@
+# Pin dtolnay/rust-toolchain to a commit SHA in quality.yml
+
+## Summary
+
+`.github/workflows/quality.yml` pinned the third-party action
+`dtolnay/rust-toolchain` to the moving branch `@stable` — the lone unpinned
+action in a repository where every other third-party action is already pinned
+to an immutable 40-character commit SHA. A mutable branch ref is a supply-chain
+risk: whoever controls the upstream repository can repoint `stable` at malicious
+code, which would then execute on the runner with the job's `GITHUB_TOKEN` and
+the secrets in scope (this job builds `rust_scorer` and reads `CODECOV_TOKEN`).
+
+This change pins the action to the commit SHA at the tip of the upstream
+`stable` branch and, because a SHA-pinned action can no longer infer the
+toolchain from the ref name (as it did from the `@stable` branch), adds an
+explicit `with: toolchain: stable` to preserve identical behaviour. The
+human-readable tag is kept in a trailing comment, matching how the other pins
+in this repository are maintained.
+
+```diff
+-      - name: Install Rust toolchain
+-        uses: dtolnay/rust-toolchain@stable
++      - name: Install Rust toolchain
++        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
++        with:
++          toolchain: stable
+```
+
+The pinned SHA `29eef336d9b2848a0b548edc03f92a220660cdb8` is the tip of
+`dtolnay/rust-toolchain`'s `stable` branch (commit "toolchain: stable",
+2026-03-27) — well outside the dependency-bump quarantine window.
+
+Closes #552.
+
+## Evidence
+
+Backend/CI-only change — no web interface to screenshot. Verification was via
+the new unit tests, `actionlint`, and a YAML parse check:
+
+- New tests fail against the old `@stable` ref and pass after the fix.
+- `actionlint .github/workflows/quality.yml` → OK.
+- YAML parse confirms the step now reads
+  `uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8`
+  with `toolchain: stable`.
+
+```mermaid
+flowchart LR
+    A["@stable (mutable branch)"] -->|upstream repoint| B[Arbitrary code on runner]
+    B --> C[GITHUB_TOKEN + CODECOV_TOKEN exposed]
+    D["@29eef33… (immutable SHA)"] -->|byte-for-byte fixed| E[Reviewed code only]
+```
+
+## Test Plan
+
+Added `.github/quality_workflow_test.ts` (mirrors the existing
+`actionlint_workflow_test.ts` convention — parses the workflow YAML and asserts
+on its contract, never greps source):
+
+- `quality workflow — every uses: pins a 40-char commit SHA` — every `uses:` in
+  `quality.yml` must pin a 40-character commit SHA. Reproduces #552: it fails
+  against `dtolnay/rust-toolchain@stable` and passes after the fix.
+- `quality workflow — rust-toolchain is SHA-pinned and keeps toolchain: stable`
+  — the rust-toolchain step pins a 40-char SHA and sets
+  `with: toolchain: stable` so the stable toolchain is retained.
+
+Gates run (targeted — the full `quality.sh` example suite is unrelated to this
+YAML/test change): `deno fmt --check`, `deno lint`, `deno check`,
+`deno test --frozen` on the new file, and `actionlint` — all pass.


### PR DESCRIPTION
# Pin dtolnay/rust-toolchain to a commit SHA in quality.yml

## Summary

`.github/workflows/quality.yml` pinned the third-party action
`dtolnay/rust-toolchain` to the moving branch `@stable` — the lone unpinned
action in a repository where every other third-party action is already pinned
to an immutable 40-character commit SHA. A mutable branch ref is a supply-chain
risk: whoever controls the upstream repository can repoint `stable` at malicious
code, which would then execute on the runner with the job's `GITHUB_TOKEN` and
the secrets in scope (this job builds `rust_scorer` and reads `CODECOV_TOKEN`).

This change pins the action to the commit SHA at the tip of the upstream
`stable` branch and, because a SHA-pinned action can no longer infer the
toolchain from the ref name (as it did from the `@stable` branch), adds an
explicit `with: toolchain: stable` to preserve identical behaviour. The
human-readable tag is kept in a trailing comment, matching how the other pins
in this repository are maintained.

```diff
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
```

The pinned SHA `29eef336d9b2848a0b548edc03f92a220660cdb8` is the tip of
`dtolnay/rust-toolchain`'s `stable` branch (commit "toolchain: stable",
2026-03-27) — well outside the dependency-bump quarantine window.

Closes #552.

## Evidence

Backend/CI-only change — no web interface to screenshot. Verification was via
the new unit tests, `actionlint`, and a YAML parse check:

- New tests fail against the old `@stable` ref and pass after the fix.
- `actionlint .github/workflows/quality.yml` → OK.
- YAML parse confirms the step now reads
  `uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8`
  with `toolchain: stable`.

```mermaid
flowchart LR
    A["@stable (mutable branch)"] -->|upstream repoint| B[Arbitrary code on runner]
    B --> C[GITHUB_TOKEN + CODECOV_TOKEN exposed]
    D["@29eef33… (immutable SHA)"] -->|byte-for-byte fixed| E[Reviewed code only]
```

## Test Plan

Added `.github/quality_workflow_test.ts` (mirrors the existing
`actionlint_workflow_test.ts` convention — parses the workflow YAML and asserts
on its contract, never greps source):

- `quality workflow — every uses: pins a 40-char commit SHA` — every `uses:` in
  `quality.yml` must pin a 40-character commit SHA. Reproduces #552: it fails
  against `dtolnay/rust-toolchain@stable` and passes after the fix.
- `quality workflow — rust-toolchain is SHA-pinned and keeps toolchain: stable`
  — the rust-toolchain step pins a 40-char SHA and sets
  `with: toolchain: stable` so the stable toolchain is retained.

Gates run (targeted — the full `quality.sh` example suite is unrelated to this
YAML/test change): `deno fmt --check`, `deno lint`, `deno check`,
`deno test --frozen` on the new file, and `actionlint` — all pass.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mpw02qdm-877554`<!-- vibe-worker-issue-552 -->