### PR TITLE
Pin semgrep/semgrep container image to a digest (Issue #555)

### DIFF
--- a/.github/semgrep_workflow_test.ts
+++ b/.github/semgrep_workflow_test.ts
@@ -1,0 +1,126 @@
+// Tests for .github/workflows/semgrep.yml (Issue #555).
+//
+// The Semgrep SAST workflow runs inside a job-level container. A
+// container image referenced by a mutable tag (e.g. `semgrep/semgrep`,
+// which resolves to the floating `:latest` tag) carries the same
+// supply-chain risk as an action pinned to a moving tag: the image
+// behind the tag can be republished at any time and the next run will
+// silently pull and execute the new layers — with the optional
+// `SEMGREP_APP_TOKEN` secret in scope.
+//
+// These tests pin the contract:
+//   * the job-level container image is pinned to an immutable
+//     `@sha256:` digest (the focus of Issue #555),
+//   * every `uses:` action is pinned to a 40-character commit SHA,
+//   * the workflow runs on `ubuntu-latest` with read-only `contents`
+//     permission, and
+//   * it actually invokes the `semgrep` CLI so a regression fails CI.
+
+import { assert, assertEquals, assertExists } from "@std/assert";
+import { parse } from "@std/yaml";
+
+const WORKFLOW_PATH = new URL("./workflows/semgrep.yml", import.meta.url);
+
+// deno-lint-ignore no-explicit-any
+type Workflow = any;
+
+async function loadWorkflow(): Promise<Workflow> {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  return parse(text) as Workflow;
+}
+
+Deno.test("semgrep workflow — file exists and parses as YAML", async () => {
+  const wf = await loadWorkflow();
+  assertExists(wf, "workflow YAML must parse to an object");
+  assertExists(wf.jobs, "workflow must declare at least one job");
+});
+
+Deno.test("semgrep workflow — job container image is pinned to a sha256 digest", async () => {
+  const wf = await loadWorkflow();
+  const jobs = wf.jobs as Record<string, Record<string, unknown>>;
+  const digestPattern = /@sha256:[0-9a-f]{64}\b/;
+  let containerCount = 0;
+  for (const [jobKey, job] of Object.entries(jobs)) {
+    const container = (job as { container?: unknown }).container;
+    if (container === undefined) continue;
+    containerCount++;
+    // `container:` may be a bare string or an object with an `image:` key.
+    const image = typeof container === "string"
+      ? container
+      : (container as { image?: string }).image;
+    assertExists(
+      image,
+      `job '${jobKey}' container must declare an image`,
+    );
+    assert(
+      digestPattern.test(image!),
+      `job '${jobKey}' container image must be pinned to an immutable ` +
+        `@sha256: digest, not a floating tag (got '${image}'). See ` +
+        `Issue #555 and the supply-chain hardening rules in AGENTS.md.`,
+    );
+  }
+  assert(
+    containerCount > 0,
+    "expected at least one job to run inside a container",
+  );
+});
+
+Deno.test("semgrep workflow — every uses: pins a 40-char commit SHA", async () => {
+  const wf = await loadWorkflow();
+  const jobs = wf.jobs as Record<string, Record<string, unknown>>;
+  const shaPattern = /@[0-9a-f]{40}\b/;
+  for (const [jobKey, job] of Object.entries(jobs)) {
+    const steps = (job as { steps?: Array<Record<string, unknown>> }).steps ??
+      [];
+    for (const step of steps) {
+      const uses = step.uses as string | undefined;
+      if (!uses) continue;
+      assert(
+        shaPattern.test(uses),
+        `job '${jobKey}' step '${step.name ?? uses}' must pin its action ` +
+          `to a 40-character commit SHA (got '${uses}'). See the supply-chain ` +
+          `hardening rules in AGENTS.md.`,
+      );
+    }
+  }
+});
+
+Deno.test("semgrep workflow — runs on ubuntu-latest with read-only contents", async () => {
+  const wf = await loadWorkflow();
+  const perms = wf.permissions as Record<string, string> | undefined;
+  assertExists(perms, "workflow must declare an explicit permissions block");
+  assertEquals(
+    perms.contents,
+    "read",
+    "semgrep only needs to read repository contents",
+  );
+  const jobs = wf.jobs as Record<string, Record<string, unknown>>;
+  const jobKey = Object.keys(jobs)[0];
+  assertEquals(
+    jobs[jobKey]["runs-on"],
+    "ubuntu-latest",
+    `job '${jobKey}' must run on ubuntu-latest`,
+  );
+});
+
+Deno.test("semgrep workflow — actually invokes the semgrep CLI", async () => {
+  const wf = await loadWorkflow();
+  const jobs = wf.jobs as Record<string, Record<string, unknown>>;
+  let invokesSemgrep = false;
+  for (const job of Object.values(jobs)) {
+    const steps = (job as { steps?: Array<Record<string, unknown>> }).steps ??
+      [];
+    for (const step of steps) {
+      const run = (step.run as string | undefined) ?? "";
+      if (/\bsemgrep\b/.test(run)) {
+        invokesSemgrep = true;
+        break;
+      }
+    }
+    if (invokesSemgrep) break;
+  }
+  assert(
+    invokesSemgrep,
+    "workflow must run the semgrep CLI so SAST regressions fail the build",
+  );
+});

--- a/.github/semgrep_workflow_test.ts
+++ b/.github/semgrep_workflow_test.ts
@@ -14,7 +14,7 @@
 //   * every `uses:` action is pinned to a 40-character commit SHA,
 //   * the workflow runs on `ubuntu-latest` with read-only `contents`
 //     permission, and
-//   * it actually invokes the `semgrep` CLI so a regression fails CI.
+//   * it actually invokes the `semgrep` CLI so a regression fails CI
 
 import { assert, assertEquals, assertExists } from "@std/assert";
 import { parse } from "@std/yaml";

--- a/.github/semgrep_workflow_test.ts
+++ b/.github/semgrep_workflow_test.ts
@@ -1,4 +1,4 @@
-// Tests for .github/workflows/semgrep.yml (Issue #555).
+// Tests for .github/workflows/semgrep.yml (Issue #555)
 //
 // The Semgrep SAST workflow runs inside a job-level container. A
 // container image referenced by a mutable tag (e.g. `semgrep/semgrep`,

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -35,7 +35,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     container:
-      image: semgrep/semgrep
+      # semgrep/semgrep:latest — pinned to an immutable digest (Issue #555).
+      # Bump deliberately, the same way the action SHA pins are maintained:
+      #   docker buildx imagetools inspect semgrep/semgrep:latest
+      image: semgrep/semgrep@sha256:7cad2bc2d1e44f87f0bf4be6d1fa23aa90fb72015bebc89fb91385d813987a03
     steps:
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/docs/archive/pr-summaries/pr-summary-555.md
+++ b/docs/archive/pr-summaries/pr-summary-555.md
@@ -1,0 +1,63 @@
+# Pin the semgrep/semgrep container image to a digest
+
+## Summary
+
+The Semgrep SAST workflow ran its job inside a job-level container pinned to a mutable tag —
+`image: semgrep/semgrep` resolves to the floating `:latest` tag rather than an immutable `@sha256:`
+digest. The image content behind that tag can be republished at any time, and the next run would
+silently pull and execute the new layers on a runner that checks out PR-controlled code and has the
+optional `SEMGREP_APP_TOKEN` secret in scope. The repository already pins every `uses:` action to a
+40-character commit SHA; the container image was the one remaining unpinned third-party execution
+surface.
+
+Pinned the image to its current multi-arch digest, keeping the human-readable tag and the bump
+command in a comment for traceability:
+
+```yaml
+container:
+  # semgrep/semgrep:latest — pinned to an immutable digest (Issue #555).
+  # Bump deliberately, the same way the action SHA pins are maintained:
+  #   docker buildx imagetools inspect semgrep/semgrep:latest
+  image: semgrep/semgrep@sha256:7cad2bc2d1e44f87f0bf4be6d1fa23aa90fb72015bebc89fb91385d813987a03
+```
+
+The digest was resolved against the Docker Hub registry API and confirmed to be the multi-arch OCI
+image index (`application/vnd.oci.image.index.v1+json`), so the runner still resolves the correct
+architecture from the index — no behaviour change, just an immutable pin.
+
+Closes #555.
+
+## Evidence
+
+This is a CI/workflow configuration change with no web interface to screenshot. Verification is via
+the new unit tests below, which parse the workflow YAML and assert the contract.
+
+```mermaid
+flowchart LR
+    A["image: semgrep/semgrep<br/>(floating :latest)"] -->|"republished layers<br/>silently pulled"| B["medium supply-chain risk"]
+    C["image: semgrep/semgrep@sha256:7cad2bc2…<br/>(immutable digest)"] -->|"bytes fixed,<br/>bumped deliberately"| D["pinned execution surface"]
+```
+
+Digest resolution (registry API, no local Docker required):
+
+```
+docker-content-digest: sha256:7cad2bc2d1e44f87f0bf4be6d1fa23aa90fb72015bebc89fb91385d813987a03
+mediaType: application/vnd.oci.image.index.v1+json
+```
+
+## Test Plan
+
+Added `.github/semgrep_workflow_test.ts` (TDD — the digest test failed against the unpinned
+workflow, then passed after the fix):
+
+- **job container image is pinned to a sha256 digest** — the regression test for #555; parses the
+  workflow and asserts every job-level `container.image` matches `@sha256:<64 hex>` rather than a
+  floating tag.
+- **every uses: pins a 40-char commit SHA** — guards the existing action pins.
+- **runs on ubuntu-latest with read-only contents** — pins the runner and least-privilege permission
+  contract.
+- **actually invokes the semgrep CLI** — ensures the SAST scan still runs.
+- **file exists and parses as YAML** — basic structural guard.
+
+All 46 `.github/*_test.ts` tests pass; `deno fmt --check`, `deno lint`, and `deno check` are clean
+on the new file.


### PR DESCRIPTION
# Pin the semgrep/semgrep container image to a digest

## Summary

The Semgrep SAST workflow ran its job inside a job-level container pinned to a mutable tag —
`image: semgrep/semgrep` resolves to the floating `:latest` tag rather than an immutable `@sha256:`
digest. The image content behind that tag can be republished at any time, and the next run would
silently pull and execute the new layers on a runner that checks out PR-controlled code and has the
optional `SEMGREP_APP_TOKEN` secret in scope. The repository already pins every `uses:` action to a
40-character commit SHA; the container image was the one remaining unpinned third-party execution
surface.

Pinned the image to its current multi-arch digest, keeping the human-readable tag and the bump
command in a comment for traceability:

```yaml
container:
  # semgrep/semgrep:latest — pinned to an immutable digest (Issue #555).
  # Bump deliberately, the same way the action SHA pins are maintained:
  #   docker buildx imagetools inspect semgrep/semgrep:latest
  image: semgrep/semgrep@sha256:7cad2bc2d1e44f87f0bf4be6d1fa23aa90fb72015bebc89fb91385d813987a03
```

The digest was resolved against the Docker Hub registry API and confirmed to be the multi-arch OCI
image index (`application/vnd.oci.image.index.v1+json`), so the runner still resolves the correct
architecture from the index — no behaviour change, just an immutable pin.

Closes #555.

## Evidence

This is a CI/workflow configuration change with no web interface to screenshot. Verification is via
the new unit tests below, which parse the workflow YAML and assert the contract.

```mermaid
flowchart LR
    A["image: semgrep/semgrep<br/>(floating :latest)"] -->|"republished layers<br/>silently pulled"| B["medium supply-chain risk"]
    C["image: semgrep/semgrep@sha256:7cad2bc2…<br/>(immutable digest)"] -->|"bytes fixed,<br/>bumped deliberately"| D["pinned execution surface"]
```

Digest resolution (registry API, no local Docker required):

```
docker-content-digest: sha256:7cad2bc2d1e44f87f0bf4be6d1fa23aa90fb72015bebc89fb91385d813987a03
mediaType: application/vnd.oci.image.index.v1+json
```

## Test Plan

Added `.github/semgrep_workflow_test.ts` (TDD — the digest test failed against the unpinned
workflow, then passed after the fix):

- **job container image is pinned to a sha256 digest** — the regression test for #555; parses the
  workflow and asserts every job-level `container.image` matches `@sha256:<64 hex>` rather than a
  floating tag.
- **every uses: pins a 40-char commit SHA** — guards the existing action pins.
- **runs on ubuntu-latest with read-only contents** — pins the runner and least-privilege permission
  contract.
- **actually invokes the semgrep CLI** — ensures the SAST scan still runs.
- **file exists and parses as YAML** — basic structural guard.

All 46 `.github/*_test.ts` tests pass; `deno fmt --check`, `deno lint`, and `deno check` are clean
on the new file.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mpwic7gs-64c404`<!-- vibe-worker-issue-555 -->