### PR TITLE
feat: add security-only deno audit dependency channel (#573)

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,6 +562,34 @@ the same pipeline on every push and pull request to `Develop`. Failing checks bl
 > The Discovery example needs a native Rust FFI (Foreign Function Interface) library that is not yet
 > available in CI, so its step is allowed to fail gracefully there.
 
+### Dependency-update channels
+
+Dependency hygiene runs on two deliberately separate channels:
+
+- **Routine version bumps** — [`deno-outdated.yml`](.github/workflows/deno-outdated.yml) runs
+  `./bump-deps.sh` only when a pull request is opened against `Develop`. It has no cron, so routine
+  refreshes never arrive as scheduled bot noise (Issue #364).
+- **Security advisories** — [`deno-audit.yml`](.github/workflows/deno-audit.yml) runs `deno audit`
+  on a weekly cron (and on demand via `workflow_dispatch`). This channel is _advisory-driven_: a
+  clean audit produces nothing, so it does not re-introduce bump noise. When `deno audit` finds a
+  known advisory against a pinned dependency, it opens (or updates) a `security`-labelled issue so a
+  freshly-disclosed CVE has an automated path to a remediation issue (Issue #573).
+
+```mermaid
+flowchart LR
+    PR[PR opened to Develop] --> BUMP[deno-outdated.yml<br/>bump-deps.sh]
+    BUMP --> PINS[Pins refreshed on the PR]
+
+    CRON[Weekly cron / manual] --> AUDIT[deno-audit.yml<br/>deno audit]
+    AUDIT -->|advisory found| ISSUE[Open/label security issue]
+    AUDIT -->|clean| QUIET[No issue — no noise]
+
+    style BUMP fill:#3498db,stroke:#333,color:#fff
+    style AUDIT fill:#e67e22,stroke:#333,color:#fff
+    style ISSUE fill:#e74c3c,stroke:#333,color:#fff
+    style QUIET fill:#2ecc71,stroke:#333,color:#fff
+```
+
 <details>
 <summary>🧪 Running tests, lint, fmt, and benchmarks independently</summary>
 

--- a/bump-deps.sh
+++ b/bump-deps.sh
@@ -33,11 +33,11 @@ QUARANTINE_HOURS="${VIBE_BUMP_QUARANTINE_HOURS:-24}"
 
 echo "bump_deps: quarantine window = ${QUARANTINE_HOURS}h (override via VIBE_BUMP_QUARANTINE_HOURS)"
 
-# The only network reach the updater needs is the registries it consults:
-# npm.jsr.io / registry.npmjs.org for publish timestamps, plus jsr.io to
-# confirm a JSR candidate is resolvable by `deno install` before adopting
-# it (Issue #362). Keep the allow-net list explicit so an unexpected
-# outbound call would fail loudly.
+# The only network reach the updater needs is the two registries it
+# consults. `jsr.io` is the authoritative JSR metadata host (the registry
+# `deno install` resolves against); `npm.jsr.io` is the mirror that exposes
+# per-version publish timestamps. Keep the allow-net list explicit so an
+# unexpected outbound call would fail loudly.
 deno run \
   --allow-read \
   --allow-write \

--- a/bump_deps.ts
+++ b/bump_deps.ts
@@ -237,15 +237,25 @@ interface JsrMetadata {
  * JSR import, mapped to whether each is yanked there. This is the source
  * `deno install` resolves against, so any version absent here is not yet
  * installable regardless of what the npm mirror advertises.
+ *
+ * Returns `null` when the `jsr.io` lookup fails (network error or non-OK
+ * response) so the caller falls back to the mirror-only candidate set
+ * rather than blocking every JSR bump on a transient `jsr.io` hiccup
+ * (PR #576).
  */
 export async function fetchJsrAvailableVersions(
   info: ImportInfo,
   fetcher: Fetcher = fetch,
-): Promise<Map<string, { yanked: boolean }>> {
+): Promise<Map<string, { yanked: boolean }> | null> {
   const url = jsrMetaUrl(info);
-  const res = await fetcher(url, { headers: { accept: "application/json" } });
+  let res: Response;
+  try {
+    res = await fetcher(url, { headers: { accept: "application/json" } });
+  } catch {
+    return null;
+  }
   if (!res.ok) {
-    throw new Error(`registry ${url} returned HTTP ${res.status}`);
+    return null;
   }
   const data = (await res.json()) as JsrMetadata;
   const versions = data.versions ?? {};
@@ -320,56 +330,6 @@ export async function fetchVersions(
   return result;
 }
 
-/** Shape of the authoritative JSR package metadata served by `jsr.io`. */
-interface JsrMetadata {
-  versions?: Record<string, { yanked?: boolean } | undefined>;
-}
-
-/**
- * Build the authoritative JSR metadata URL for a package, e.g.
- * `https://jsr.io/@scope/name/meta.json`.
- */
-export function jsrMetaUrl(packageName: string): string {
-  return `https://jsr.io/${packageName}/meta.json`;
-}
-
-/**
- * Fetch the set of versions `deno install` can actually resolve for a JSR
- * package, from the authoritative `jsr.io` metadata.
- *
- * The `npm.jsr.io` mirror this module reads for publish timestamps can be
- * ahead of (or hold versions yanked from) `jsr.io` — the registry
- * `deno install` truly resolves against. Bumping a pin to a version that
- * exists only on the mirror produces an unresolvable pin and fails the
- * auto-bump CI job ("Could not find version ... that matches ...").
- * Constraining JSR candidates to this set closes that gap.
- *
- * Yanked versions are excluded. Returns `null` when the lookup fails so
- * the caller falls back to the mirror-only candidate set rather than
- * blocking every JSR bump on a transient `jsr.io` hiccup.
- */
-export async function fetchJsrResolvableVersions(
-  packageName: string,
-  fetcher: Fetcher = fetch,
-): Promise<Set<string> | null> {
-  const url = jsrMetaUrl(packageName);
-  let res: Response;
-  try {
-    res = await fetcher(url, { headers: { accept: "application/json" } });
-  } catch {
-    return null;
-  }
-  if (!res.ok) return null;
-  const data = (await res.json()) as JsrMetadata;
-  const versions = data.versions ?? {};
-  const resolvable = new Set<string>();
-  for (const [version, entry] of Object.entries(versions)) {
-    if (entry?.yanked) continue;
-    resolvable.add(version);
-  }
-  return resolvable;
-}
-
 /** Outcome of evaluating one import against the registry. */
 export interface BumpDecision {
   readonly info: ImportInfo;
@@ -405,6 +365,10 @@ export async function decideBumps(opts: DecideBumpsOptions): Promise<BumpDecisio
     const internal = isInternalPackage(info.packageName);
     let versions: VersionInfo[];
     try {
+      // `fetchVersions` already cross-checks JSR candidates against the
+      // authoritative `jsr.io` registry (versions absent there — or yanked —
+      // are flagged so `pickTargetVersion` skips them), so a bump never
+      // writes a pin `deno install` cannot resolve (Issue #362).
       versions = await fetchVersions(info, fetcher);
     } catch (err) {
       decisions.push({
@@ -416,16 +380,6 @@ export async function decideBumps(opts: DecideBumpsOptions): Promise<BumpDecisio
         note: `registry lookup failed: ${err instanceof Error ? err.message : String(err)}`,
       });
       continue;
-    }
-    // The mirror that supplies publish timestamps can list JSR versions
-    // that `jsr.io` (and therefore `deno install`) cannot yet resolve.
-    // Restrict JSR candidates to the authoritative resolvable set so a
-    // bump never writes an uninstallable pin.
-    if (info.protocol === "jsr") {
-      const resolvable = await fetchJsrResolvableVersions(info.packageName, fetcher);
-      if (resolvable) {
-        versions = versions.filter((v) => resolvable.has(v.version));
-      }
     }
     const target = pickTargetVersion(versions, info.version, now, quarantineMs, !internal);
     if (target === null) {

--- a/bump_deps.ts
+++ b/bump_deps.ts
@@ -320,6 +320,56 @@ export async function fetchVersions(
   return result;
 }
 
+/** Shape of the authoritative JSR package metadata served by `jsr.io`. */
+interface JsrMetadata {
+  versions?: Record<string, { yanked?: boolean } | undefined>;
+}
+
+/**
+ * Build the authoritative JSR metadata URL for a package, e.g.
+ * `https://jsr.io/@scope/name/meta.json`.
+ */
+export function jsrMetaUrl(packageName: string): string {
+  return `https://jsr.io/${packageName}/meta.json`;
+}
+
+/**
+ * Fetch the set of versions `deno install` can actually resolve for a JSR
+ * package, from the authoritative `jsr.io` metadata.
+ *
+ * The `npm.jsr.io` mirror this module reads for publish timestamps can be
+ * ahead of (or hold versions yanked from) `jsr.io` — the registry
+ * `deno install` truly resolves against. Bumping a pin to a version that
+ * exists only on the mirror produces an unresolvable pin and fails the
+ * auto-bump CI job ("Could not find version ... that matches ...").
+ * Constraining JSR candidates to this set closes that gap.
+ *
+ * Yanked versions are excluded. Returns `null` when the lookup fails so
+ * the caller falls back to the mirror-only candidate set rather than
+ * blocking every JSR bump on a transient `jsr.io` hiccup.
+ */
+export async function fetchJsrResolvableVersions(
+  packageName: string,
+  fetcher: Fetcher = fetch,
+): Promise<Set<string> | null> {
+  const url = jsrMetaUrl(packageName);
+  let res: Response;
+  try {
+    res = await fetcher(url, { headers: { accept: "application/json" } });
+  } catch {
+    return null;
+  }
+  if (!res.ok) return null;
+  const data = (await res.json()) as JsrMetadata;
+  const versions = data.versions ?? {};
+  const resolvable = new Set<string>();
+  for (const [version, entry] of Object.entries(versions)) {
+    if (entry?.yanked) continue;
+    resolvable.add(version);
+  }
+  return resolvable;
+}
+
 /** Outcome of evaluating one import against the registry. */
 export interface BumpDecision {
   readonly info: ImportInfo;
@@ -366,6 +416,16 @@ export async function decideBumps(opts: DecideBumpsOptions): Promise<BumpDecisio
         note: `registry lookup failed: ${err instanceof Error ? err.message : String(err)}`,
       });
       continue;
+    }
+    // The mirror that supplies publish timestamps can list JSR versions
+    // that `jsr.io` (and therefore `deno install`) cannot yet resolve.
+    // Restrict JSR candidates to the authoritative resolvable set so a
+    // bump never writes an uninstallable pin.
+    if (info.protocol === "jsr") {
+      const resolvable = await fetchJsrResolvableVersions(info.packageName, fetcher);
+      if (resolvable) {
+        versions = versions.filter((v) => resolvable.has(v.version));
+      }
     }
     const target = pickTargetVersion(versions, info.version, now, quarantineMs, !internal);
     if (target === null) {

--- a/bump_deps_test.ts
+++ b/bump_deps_test.ts
@@ -14,12 +14,10 @@ import {
   compareVersions,
   decideBumps,
   DEFAULT_QUARANTINE_HOURS,
-  fetchJsrResolvableVersions,
   fetchVersions,
   formatDecision,
   isInternalPackage,
   isPlainSemver,
-  jsrMetaUrl,
   parseSpecifier,
   pickTargetVersion,
   registryUrl,
@@ -471,13 +469,6 @@ Deno.test("formatDecision - human-readable lines for bumped and kept pins", () =
   assert(kept.includes("24h quarantine"));
 });
 
-Deno.test("jsrMetaUrl - builds the authoritative jsr.io metadata URL", () => {
-  assertEquals(
-    jsrMetaUrl("@stsoftware/neat-ai"),
-    "https://jsr.io/@stsoftware/neat-ai/meta.json",
-  );
-});
-
 /**
  * Build a `fetch` that serves npm.jsr.io mirror metadata and jsr.io
  * authoritative metadata from two maps. Unknown URLs return HTTP 500 so a
@@ -501,25 +492,6 @@ function makeDualFetcher(
     );
   };
 }
-
-Deno.test("fetchJsrResolvableVersions - parses versions and excludes yanked", async () => {
-  const fetcher = makeDualFetcher({}, {
-    "https://jsr.io/@stsoftware/neat-ai/meta.json": {
-      versions: { "5.3.18": {}, "5.3.19": {}, "5.3.17": { yanked: true } },
-    },
-  });
-  const out = await fetchJsrResolvableVersions("@stsoftware/neat-ai", fetcher);
-  assert(out !== null);
-  assert(out!.has("5.3.18"));
-  assert(out!.has("5.3.19"));
-  assert(!out!.has("5.3.17"), "yanked versions are excluded");
-});
-
-Deno.test("fetchJsrResolvableVersions - HTTP error returns null (mirror-only fallback)", async () => {
-  const fetcher = () => Promise.resolve(new Response("boom", { status: 503 }));
-  const out = await fetchJsrResolvableVersions("@stsoftware/neat-ai", fetcher);
-  assertEquals(out, null);
-});
 
 Deno.test("decideBumps - JSR bump is constrained to jsr.io-resolvable versions", async () => {
   // Regression for PR #576: the npm.jsr.io mirror advertised 5.3.20 (with an

--- a/bump_deps_test.ts
+++ b/bump_deps_test.ts
@@ -14,7 +14,7 @@ import {
   compareVersions,
   decideBumps,
   DEFAULT_QUARANTINE_HOURS,
-  fetchJsrAvailableVersions,
+  fetchJsrResolvableVersions,
   fetchVersions,
   formatDecision,
   isInternalPackage,
@@ -178,61 +178,21 @@ Deno.test("pickTargetVersion - never downgrades", () => {
  * metadata for the matching URL. Anything else throws so tests fail
  * loud rather than silently calling out to the real registry.
  */
-/**
- * Convert an `npm.jsr.io` mirror URL into the native `jsr.io` `meta.json`
- * URL for the same package, e.g.
- *   https://npm.jsr.io/@jsr/std__cli → https://jsr.io/@std/cli/meta.json
- * Returns null for non-JSR (registry.npmjs.org) URLs.
- */
-function jsrMetaUrlFromNpm(npmUrl: string): string | null {
-  const m = npmUrl.match(/^https:\/\/npm\.jsr\.io\/@jsr\/([^_]+)__(.+)$/);
-  if (!m) return null;
-  return `https://jsr.io/@${m[1]}/${m[2]}/meta.json`;
-}
-
-/**
- * Build an injected fetcher. `map` is keyed by registry (npm.jsr.io /
- * registry.npmjs.org) URL. For JSR packages the updater also fetches the
- * native `jsr.io` meta.json; by default that response is derived from the
- * same version list (all versions available, none yanked), so existing
- * tests need no extra wiring. Pass `jsrMeta` to model a propagation lag —
- * keyed by jsr.io meta URL, listing only the versions the native registry
- * has caught up on (with optional per-version `yanked`).
- */
 function makeFetcher(
   map: Record<string, { versions: Record<string, unknown>; time: Record<string, string> }>,
-  jsrMeta?: Record<string, { versions: Record<string, { yanked?: boolean }> }>,
 ) {
   return (input: string | URL): Promise<Response> => {
     const url = String(input);
-    const ok = (body: unknown) =>
-      Promise.resolve(
-        new Response(JSON.stringify(body), {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        }),
-      );
-
-    // Native jsr.io meta.json request.
-    if (url.startsWith("https://jsr.io/")) {
-      const override = jsrMeta?.[url];
-      if (override) return ok(override);
-      // Derive a default native-registry view from the npm mirror entry.
-      for (const [npmUrl, body] of Object.entries(map)) {
-        if (jsrMetaUrlFromNpm(npmUrl) === url) {
-          const versions: Record<string, Record<string, never>> = {};
-          for (const v of Object.keys(body.versions)) versions[v] = {};
-          return ok({ versions });
-        }
-      }
-      return Promise.resolve(new Response(`unexpected URL ${url}`, { status: 500 }));
-    }
-
     const body = map[url];
     if (!body) {
       return Promise.resolve(new Response(`unexpected URL ${url}`, { status: 500 }));
     }
-    return ok(body);
+    return Promise.resolve(
+      new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
   };
 }
 
@@ -285,114 +245,6 @@ Deno.test("fetchVersions - HTTP error throws", async () => {
     threw = true;
   }
   assert(threw, "expected HTTP 404 to throw");
-});
-
-Deno.test("jsrMetaUrl - builds the native jsr.io meta URL for a JSR import", () => {
-  const url = jsrMetaUrl({
-    key: "@stsoftware/neat-ai",
-    raw: "jsr:@stsoftware/neat-ai@5.3.15",
-    protocol: "jsr",
-    packageName: "@stsoftware/neat-ai",
-    version: "5.3.15",
-    subpath: "",
-  });
-  assertEquals(url, "https://jsr.io/@stsoftware/neat-ai/meta.json");
-});
-
-Deno.test("fetchJsrAvailableVersions - parses native registry version set and yanked flags", async () => {
-  const fetcher = makeFetcher({}, {
-    "https://jsr.io/@stsoftware/neat-ai/meta.json": {
-      versions: { "5.3.18": {}, "5.3.19": { yanked: true } },
-    },
-  });
-  const available = await fetchJsrAvailableVersions(
-    {
-      key: "@stsoftware/neat-ai",
-      raw: "jsr:@stsoftware/neat-ai@5.3.15",
-      protocol: "jsr",
-      packageName: "@stsoftware/neat-ai",
-      version: "5.3.15",
-      subpath: "",
-    },
-    fetcher,
-  );
-  assertEquals(available.get("5.3.18")?.yanked, false);
-  assertEquals(available.get("5.3.19")?.yanked, true);
-  assertEquals(available.has("5.3.20"), false, "absent versions are not present");
-});
-
-Deno.test("fetchVersions - skips a JSR version the native registry has not caught up on", async () => {
-  // Regression for Issue #362: the npm.jsr.io mirror advertises 5.3.20 but
-  // jsr.io (what `deno install` resolves against) only lists up to 5.3.19.
-  // Bumping to 5.3.20 would make the lockfile refresh fail, so 5.3.20 must
-  // be treated as untargetable (yanked) until the native registry catches up.
-  const npmUrl = "https://npm.jsr.io/@jsr/stsoftware__neat-ai";
-  const fetcher = makeFetcher(
-    {
-      [npmUrl]: {
-        versions: { "5.3.19": {}, "5.3.20": {} },
-        time: {
-          "5.3.19": "2026-06-08T00:00:00Z",
-          "5.3.20": "2026-06-10T00:00:00Z",
-        },
-      },
-    },
-    {
-      "https://jsr.io/@stsoftware/neat-ai/meta.json": {
-        // Native registry lags — 5.3.20 not yet present.
-        versions: { "5.3.19": {} },
-      },
-    },
-  );
-  const out = await fetchVersions(
-    {
-      key: "@stsoftware/neat-ai",
-      raw: "jsr:@stsoftware/neat-ai@5.3.15",
-      protocol: "jsr",
-      packageName: "@stsoftware/neat-ai",
-      version: "5.3.15",
-      subpath: "",
-    },
-    fetcher,
-  );
-  assertEquals(out.find((v) => v.version === "5.3.19")?.yanked, false);
-  assertEquals(
-    out.find((v) => v.version === "5.3.20")?.yanked,
-    true,
-    "version absent from the native registry is treated as untargetable",
-  );
-});
-
-Deno.test("decideBumps - internal JSR dep does not bump to a version missing from the native registry", async () => {
-  // End-to-end of the Issue #362 lag: npm mirror shows 5.3.20, native
-  // registry only has 5.3.19 — the bump must land on 5.3.19, the version
-  // `deno install` can actually resolve.
-  const fetcher = makeFetcher(
-    {
-      "https://npm.jsr.io/@jsr/stsoftware__neat-ai": {
-        versions: { "5.3.15": {}, "5.3.19": {}, "5.3.20": {} },
-        time: {
-          "5.3.15": new Date(now.getTime() - 720 * ONE_HOUR).toISOString(),
-          "5.3.19": new Date(now.getTime() - 48 * ONE_HOUR).toISOString(),
-          "5.3.20": new Date(now.getTime() - 1 * ONE_HOUR).toISOString(),
-        },
-      },
-    },
-    {
-      "https://jsr.io/@stsoftware/neat-ai/meta.json": {
-        versions: { "5.3.15": {}, "5.3.19": {} },
-      },
-    },
-  );
-  const decisions = await decideBumps({
-    imports: { "@stsoftware/neat-ai": "jsr:@stsoftware/neat-ai@5.3.15" },
-    quarantineHours: 24,
-    now,
-    fetcher,
-  });
-  const d = decisions.find((x) => x.info.key === "@stsoftware/neat-ai");
-  assertEquals(d?.bumped, true);
-  assertEquals(d?.targetVersion, "5.3.19", "lands on the highest natively-resolvable version");
 });
 
 Deno.test("decideBumps - external dep gated by quarantine, internal dep bumps immediately", async () => {
@@ -617,4 +469,116 @@ Deno.test("formatDecision - human-readable lines for bumped and kept pins", () =
   });
   assert(kept.startsWith("keep"));
   assert(kept.includes("24h quarantine"));
+});
+
+Deno.test("jsrMetaUrl - builds the authoritative jsr.io metadata URL", () => {
+  assertEquals(
+    jsrMetaUrl("@stsoftware/neat-ai"),
+    "https://jsr.io/@stsoftware/neat-ai/meta.json",
+  );
+});
+
+/**
+ * Build a `fetch` that serves npm.jsr.io mirror metadata and jsr.io
+ * authoritative metadata from two maps. Unknown URLs return HTTP 500 so a
+ * stray request fails loudly rather than reaching the network.
+ */
+function makeDualFetcher(
+  mirror: Record<string, { versions: Record<string, unknown>; time: Record<string, string> }>,
+  jsrMeta: Record<string, { versions: Record<string, { yanked?: boolean }> }>,
+) {
+  return (input: string | URL): Promise<Response> => {
+    const url = String(input);
+    const body = mirror[url] ?? jsrMeta[url];
+    if (!body) {
+      return Promise.resolve(new Response(`unexpected URL ${url}`, { status: 500 }));
+    }
+    return Promise.resolve(
+      new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+  };
+}
+
+Deno.test("fetchJsrResolvableVersions - parses versions and excludes yanked", async () => {
+  const fetcher = makeDualFetcher({}, {
+    "https://jsr.io/@stsoftware/neat-ai/meta.json": {
+      versions: { "5.3.18": {}, "5.3.19": {}, "5.3.17": { yanked: true } },
+    },
+  });
+  const out = await fetchJsrResolvableVersions("@stsoftware/neat-ai", fetcher);
+  assert(out !== null);
+  assert(out!.has("5.3.18"));
+  assert(out!.has("5.3.19"));
+  assert(!out!.has("5.3.17"), "yanked versions are excluded");
+});
+
+Deno.test("fetchJsrResolvableVersions - HTTP error returns null (mirror-only fallback)", async () => {
+  const fetcher = () => Promise.resolve(new Response("boom", { status: 503 }));
+  const out = await fetchJsrResolvableVersions("@stsoftware/neat-ai", fetcher);
+  assertEquals(out, null);
+});
+
+Deno.test("decideBumps - JSR bump is constrained to jsr.io-resolvable versions", async () => {
+  // Regression for PR #576: the npm.jsr.io mirror advertised 5.3.20 (with an
+  // old-enough publish time) but jsr.io only resolves up to 5.3.19, so
+  // `deno install @stsoftware/neat-ai@5.3.20` failed. The bump must stop at
+  // the highest version jsr.io can actually resolve.
+  const fetcher = makeDualFetcher({
+    "https://npm.jsr.io/@jsr/stsoftware__neat-ai": {
+      versions: { "5.3.15": {}, "5.3.19": {}, "5.3.20": {} },
+      time: {
+        "5.3.15": new Date(now.getTime() - 720 * ONE_HOUR).toISOString(),
+        "5.3.19": new Date(now.getTime() - 48 * ONE_HOUR).toISOString(),
+        "5.3.20": new Date(now.getTime() - 30 * ONE_HOUR).toISOString(),
+      },
+    },
+  }, {
+    "https://jsr.io/@stsoftware/neat-ai/meta.json": {
+      // jsr.io has not propagated 5.3.20 yet.
+      versions: { "5.3.15": {}, "5.3.19": {} },
+    },
+  });
+  const decisions = await decideBumps({
+    imports: { "@stsoftware/neat-ai": "jsr:@stsoftware/neat-ai@5.3.15" },
+    quarantineHours: 24,
+    now,
+    fetcher,
+  });
+  assertEquals(decisions[0]?.bumped, true);
+  assertEquals(decisions[0]?.targetVersion, "5.3.19", "must not select the unresolvable 5.3.20");
+});
+
+Deno.test("decideBumps - JSR meta lookup failure falls back to mirror candidates", async () => {
+  // When jsr.io is unreachable, do not block the bump entirely — fall back
+  // to the mirror-only candidate set (prior behaviour).
+  const fetcher = (input: string | URL): Promise<Response> => {
+    const url = String(input);
+    if (url === "https://npm.jsr.io/@jsr/stsoftware__neat-ai") {
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            versions: { "5.3.15": {}, "5.3.19": {} },
+            time: {
+              "5.3.15": new Date(now.getTime() - 720 * ONE_HOUR).toISOString(),
+              "5.3.19": new Date(now.getTime() - 48 * ONE_HOUR).toISOString(),
+            },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      );
+    }
+    // jsr.io meta.json is down.
+    return Promise.resolve(new Response("down", { status: 503 }));
+  };
+  const decisions = await decideBumps({
+    imports: { "@stsoftware/neat-ai": "jsr:@stsoftware/neat-ai@5.3.15" },
+    quarantineHours: 24,
+    now,
+    fetcher,
+  });
+  assertEquals(decisions[0]?.bumped, true);
+  assertEquals(decisions[0]?.targetVersion, "5.3.19");
 });

--- a/docs/archive/pr-summaries/pr-summary-573.md
+++ b/docs/archive/pr-summaries/pr-summary-573.md
@@ -3,10 +3,10 @@
 ## Summary
 
 The repo had dependency-bumping automation (`deno-outdated.yml` + `bump-deps.sh`) but **no
-security-specific update channel**. Routine bumps run only when a PR is opened against `Develop`
-and the workflow deliberately carries no cron — "never as scheduled bot noise" (#364). That left a
-gap: when an advisory (CVE) lands against a pin that is already current, nothing proactively raises
-a fix, so the team had to notice it manually.
+security-specific update channel**. Routine bumps run only when a PR is opened against `Develop` and
+the workflow deliberately carries no cron — "never as scheduled bot noise" (#364). That left a gap:
+when an advisory (CVE) lands against a pin that is already current, nothing proactively raises a
+fix, so the team had to notice it manually.
 
 This PR adds [`.github/workflows/deno-audit.yml`](../../../.github/workflows/deno-audit.yml), a
 **security-only** channel that is distinct from routine version churn so the maintainers' "no
@@ -29,8 +29,8 @@ Closes #573.
 
 ## Evidence
 
-This is a CI/workflow change with no web interface to screenshot. Verification is via the Deno
-test suite that pins the workflow contract, plus `actionlint` (with `shellcheck`) on the new YAML.
+This is a CI/workflow change with no web interface to screenshot. Verification is via the Deno test
+suite that pins the workflow contract, plus `actionlint` (with `shellcheck`) on the new YAML.
 
 ```text
 $ actionlint -verbose .github/workflows/deno-audit.yml
@@ -62,8 +62,9 @@ flowchart LR
 
 ### Deno regression avoided
 
-- Chose a Deno-native `deno audit` workflow over re-introducing a Node-tooling `.github/dependabot.yml`
-  security channel (Dependabot has limited Deno/JSR support, and #364 already removed it).
+- Chose a Deno-native `deno audit` workflow over re-introducing a Node-tooling
+  `.github/dependabot.yml` security channel (Dependabot has limited Deno/JSR support, and #364
+  already removed it).
 
 ## Test Plan
 

--- a/docs/archive/pr-summaries/pr-summary-573.md
+++ b/docs/archive/pr-summaries/pr-summary-573.md
@@ -1,0 +1,84 @@
+# Add a security-only dependency-update channel (`deno-audit.yml`)
+
+## Summary
+
+The repo had dependency-bumping automation (`deno-outdated.yml` + `bump-deps.sh`) but **no
+security-specific update channel**. Routine bumps run only when a PR is opened against `Develop`
+and the workflow deliberately carries no cron — "never as scheduled bot noise" (#364). That left a
+gap: when an advisory (CVE) lands against a pin that is already current, nothing proactively raises
+a fix, so the team had to notice it manually.
+
+This PR adds [`.github/workflows/deno-audit.yml`](../../../.github/workflows/deno-audit.yml), a
+**security-only** channel that is distinct from routine version churn so the maintainers' "no
+scheduled bump noise" stance is preserved:
+
+- Runs `deno audit` on a weekly cron (and on demand via `workflow_dispatch`).
+- The channel is **advisory-driven** — a clean audit produces no PR and no issue, so it does not
+  re-introduce the bump noise removed in #364.
+- When `deno audit` finds a known advisory against a pinned dependency, it opens (or updates, to
+  de-duplicate) a `security`-labelled issue, giving a freshly-disclosed CVE an automated path to a
+  remediation issue.
+
+A `deno audit`-gated issue (rather than a `.github/dependabot.yml`) is the more reliable security
+channel here because Dependabot has limited Deno/JSR manifest support — and #364 already removed
+Dependabot from this repo to stop weekly bot PRs.
+
+The routine `deno-outdated.yml` workflow is unchanged: it keeps its no-cron, PR-only behaviour.
+
+Closes #573.
+
+## Evidence
+
+This is a CI/workflow change with no web interface to screenshot. Verification is via the Deno
+test suite that pins the workflow contract, plus `actionlint` (with `shellcheck`) on the new YAML.
+
+```text
+$ actionlint -verbose .github/workflows/deno-audit.yml
+verbose: Found total 0 errors in 38 ms for .github/workflows/deno-audit.yml
+
+$ deno test --no-check --allow-read .github/deno_audit_workflow_test.ts
+ok | 7 passed | 0 failed
+
+$ deno test --no-check --allow-read .github/*_test.ts
+ok | 69 passed | 0 failed
+```
+
+The two dependency-update channels:
+
+```mermaid
+flowchart LR
+    PR[PR opened to Develop] --> BUMP[deno-outdated.yml<br/>bump-deps.sh]
+    BUMP --> PINS[Pins refreshed on the PR]
+
+    CRON[Weekly cron / manual] --> AUDIT[deno-audit.yml<br/>deno audit]
+    AUDIT -->|advisory found| ISSUE[Open/label security issue]
+    AUDIT -->|clean| QUIET[No issue — no noise]
+
+    style BUMP fill:#3498db,stroke:#333,color:#fff
+    style AUDIT fill:#e67e22,stroke:#333,color:#fff
+    style ISSUE fill:#e74c3c,stroke:#333,color:#fff
+    style QUIET fill:#2ecc71,stroke:#333,color:#fff
+```
+
+### Deno regression avoided
+
+- Chose a Deno-native `deno audit` workflow over re-introducing a Node-tooling `.github/dependabot.yml`
+  security channel (Dependabot has limited Deno/JSR support, and #364 already removed it).
+
+## Test Plan
+
+Added `.github/deno_audit_workflow_test.ts` (7 tests) which load and parse the workflow YAML and
+assert real behaviour:
+
+- runs on a weekly `schedule` cron (advisory-driven channel);
+- supports manual `workflow_dispatch`;
+- requests `issues: write` so it can open the remediation issue;
+- invokes `deno audit`;
+- only opens/labels an issue when the audit reports a non-empty result (gated on the step output),
+  and the issue carries a `--label` so it routes to the security channel;
+- pins every third-party action to a 40-char commit SHA;
+- does **not** bump pins (no `bump-deps.sh` / `deno update` / `deno outdated`) — the channel stays
+  advisory-only.
+
+All `.github` workflow tests (69) pass, along with `deno fmt --check`, `deno lint`, `deno check`,
+`markdownlint-cli2`, and `actionlint`.

--- a/docs/screenshots/discovery_at_scale.svg
+++ b/docs/screenshots/discovery_at_scale.svg
@@ -15,8 +15,8 @@
     <rect class="topo-bar topo-bar-seed-synapses" x="231.56" y="90" width="46.13" height="180" fill="#9ecae1"/>
     <text x="254.63" y="86" text-anchor="middle" font-weight="bold">63</text>
     <text x="254.63" y="282" text-anchor="middle">seed</text>
-    <rect class="topo-bar topo-bar-final-synapses" x="323.81" y="95.71" width="46.13" height="174.29" fill="#1f77b4"/>
-    <text x="346.88" y="91.71" text-anchor="middle" font-weight="bold">61</text>
+    <rect class="topo-bar topo-bar-final-synapses" x="323.81" y="98.57" width="46.13" height="171.43" fill="#1f77b4"/>
+    <text x="346.88" y="94.57" text-anchor="middle" font-weight="bold">60</text>
     <text x="346.88" y="282" text-anchor="middle">final</text>
     <text x="300.75" y="292" text-anchor="middle" font-weight="bold">synapses</text>
   </g>
@@ -30,7 +30,7 @@
     <text class="callout-label" x="421" y="213.5" dominant-baseline="middle">generations</text>
     <text class="callout-value" x="684" y="213.5" text-anchor="end" dominant-baseline="middle" font-weight="bold" fill="#2ca02c">83</text>
     <text class="callout-label" x="421" y="268.5" dominant-baseline="middle">wall clock</text>
-    <text class="callout-value" x="684" y="268.5" text-anchor="end" dominant-baseline="middle" font-weight="bold" fill="#2ca02c">6s</text>
+    <text class="callout-value" x="684" y="268.5" text-anchor="end" dominant-baseline="middle" font-weight="bold" fill="#2ca02c">17s</text>
   </g>
   <g class="caption" font-family="sans-serif" font-size="12" fill="#555">
     <text x="360" y="348" text-anchor="middle">stop conditions: target error 0.005 · timeout 20 min</text>

--- a/docs/screenshots/discovery_at_scale/evolution_summary.svg
+++ b/docs/screenshots/discovery_at_scale/evolution_summary.svg
@@ -15,8 +15,8 @@
     <rect class="topo-bar topo-bar-seed-synapses" x="231.56" y="90" width="46.13" height="180" fill="#9ecae1"/>
     <text x="254.63" y="86" text-anchor="middle" font-weight="bold">63</text>
     <text x="254.63" y="282" text-anchor="middle">seed</text>
-    <rect class="topo-bar topo-bar-final-synapses" x="323.81" y="95.71" width="46.13" height="174.29" fill="#1f77b4"/>
-    <text x="346.88" y="91.71" text-anchor="middle" font-weight="bold">61</text>
+    <rect class="topo-bar topo-bar-final-synapses" x="323.81" y="98.57" width="46.13" height="171.43" fill="#1f77b4"/>
+    <text x="346.88" y="94.57" text-anchor="middle" font-weight="bold">60</text>
     <text x="346.88" y="282" text-anchor="middle">final</text>
     <text x="300.75" y="292" text-anchor="middle" font-weight="bold">synapses</text>
   </g>
@@ -30,7 +30,7 @@
     <text class="callout-label" x="421" y="213.5" dominant-baseline="middle">generations</text>
     <text class="callout-value" x="684" y="213.5" text-anchor="end" dominant-baseline="middle" font-weight="bold" fill="#2ca02c">83</text>
     <text class="callout-label" x="421" y="268.5" dominant-baseline="middle">wall clock</text>
-    <text class="callout-value" x="684" y="268.5" text-anchor="end" dominant-baseline="middle" font-weight="bold" fill="#2ca02c">6s</text>
+    <text class="callout-value" x="684" y="268.5" text-anchor="end" dominant-baseline="middle" font-weight="bold" fill="#2ca02c">17s</text>
   </g>
   <g class="caption" font-family="sans-serif" font-size="12" fill="#555">
     <text x="360" y="348" text-anchor="middle">stop conditions: target error 0.005 · timeout 20 min</text>

--- a/docs/screenshots/intelligent_design/evolution_summary.svg
+++ b/docs/screenshots/intelligent_design/evolution_summary.svg
@@ -28,9 +28,9 @@
     <text class="callout-label" x="421" y="158.5" dominant-baseline="middle">final score</text>
     <text class="callout-value" x="684" y="158.5" text-anchor="end" dominant-baseline="middle" font-weight="bold" fill="#2ca02c">1</text>
     <text class="callout-label" x="421" y="213.5" dominant-baseline="middle">generations</text>
-    <text class="callout-value" x="684" y="213.5" text-anchor="end" dominant-baseline="middle" font-weight="bold" fill="#2ca02c">3003</text>
+    <text class="callout-value" x="684" y="213.5" text-anchor="end" dominant-baseline="middle" font-weight="bold" fill="#2ca02c">3002</text>
     <text class="callout-label" x="421" y="268.5" dominant-baseline="middle">wall clock</text>
-    <text class="callout-value" x="684" y="268.5" text-anchor="end" dominant-baseline="middle" font-weight="bold" fill="#2ca02c">1m 44s</text>
+    <text class="callout-value" x="684" y="268.5" text-anchor="end" dominant-baseline="middle" font-weight="bold" fill="#2ca02c">2m 9s</text>
   </g>
   <g class="caption" font-family="sans-serif" font-size="12" fill="#555">
     <text x="360" y="348" text-anchor="middle">stop conditions: target error 0 · timeout 20 min</text>


### PR DESCRIPTION
# Add a security-only dependency-update channel (`deno-audit.yml`)

## Summary

The repo had dependency-bumping automation (`deno-outdated.yml` + `bump-deps.sh`) but **no
security-specific update channel**. Routine bumps run only when a PR is opened against `Develop`
and the workflow deliberately carries no cron — "never as scheduled bot noise" (#364). That left a
gap: when an advisory (CVE) lands against a pin that is already current, nothing proactively raises
a fix, so the team had to notice it manually.

This PR adds [`.github/workflows/deno-audit.yml`](../../../.github/workflows/deno-audit.yml), a
**security-only** channel that is distinct from routine version churn so the maintainers' "no
scheduled bump noise" stance is preserved:

- Runs `deno audit` on a weekly cron (and on demand via `workflow_dispatch`).
- The channel is **advisory-driven** — a clean audit produces no PR and no issue, so it does not
  re-introduce the bump noise removed in #364.
- When `deno audit` finds a known advisory against a pinned dependency, it opens (or updates, to
  de-duplicate) a `security`-labelled issue, giving a freshly-disclosed CVE an automated path to a
  remediation issue.

A `deno audit`-gated issue (rather than a `.github/dependabot.yml`) is the more reliable security
channel here because Dependabot has limited Deno/JSR manifest support — and #364 already removed
Dependabot from this repo to stop weekly bot PRs.

The routine `deno-outdated.yml` workflow is unchanged: it keeps its no-cron, PR-only behaviour.

Closes #573.

## Evidence

This is a CI/workflow change with no web interface to screenshot. Verification is via the Deno
test suite that pins the workflow contract, plus `actionlint` (with `shellcheck`) on the new YAML.

```text
$ actionlint -verbose .github/workflows/deno-audit.yml
verbose: Found total 0 errors in 38 ms for .github/workflows/deno-audit.yml

$ deno test --no-check --allow-read .github/deno_audit_workflow_test.ts
ok | 7 passed | 0 failed

$ deno test --no-check --allow-read .github/*_test.ts
ok | 69 passed | 0 failed
```

The two dependency-update channels:

```mermaid
flowchart LR
    PR[PR opened to Develop] --> BUMP[deno-outdated.yml<br/>bump-deps.sh]
    BUMP --> PINS[Pins refreshed on the PR]

    CRON[Weekly cron / manual] --> AUDIT[deno-audit.yml<br/>deno audit]
    AUDIT -->|advisory found| ISSUE[Open/label security issue]
    AUDIT -->|clean| QUIET[No issue — no noise]

    style BUMP fill:#3498db,stroke:#333,color:#fff
    style AUDIT fill:#e67e22,stroke:#333,color:#fff
    style ISSUE fill:#e74c3c,stroke:#333,color:#fff
    style QUIET fill:#2ecc71,stroke:#333,color:#fff
```

### Deno regression avoided

- Chose a Deno-native `deno audit` workflow over re-introducing a Node-tooling `.github/dependabot.yml`
  security channel (Dependabot has limited Deno/JSR support, and #364 already removed it).

## Test Plan

Added `.github/deno_audit_workflow_test.ts` (7 tests) which load and parse the workflow YAML and
assert real behaviour:

- runs on a weekly `schedule` cron (advisory-driven channel);
- supports manual `workflow_dispatch`;
- requests `issues: write` so it can open the remediation issue;
- invokes `deno audit`;
- only opens/labels an issue when the audit reports a non-empty result (gated on the step output),
  and the issue carries a `--label` so it routes to the security channel;
- pins every third-party action to a 40-char commit SHA;
- does **not** bump pins (no `bump-deps.sh` / `deno update` / `deno outdated`) — the channel stays
  advisory-only.

All `.github` workflow tests (69) pass, along with `deno fmt --check`, `deno lint`, `deno check`,
`markdownlint-cli2`, and `actionlint`.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mq7m1x1y-fff629`<!-- vibe-worker-issue-573 -->