### PR TITLE
CI: run Discovery and Suggest Improvements in quick mode, raise Quality Check timeout to 45m (#581)

### DIFF
--- a/.github/quality_workflow_test.ts
+++ b/.github/quality_workflow_test.ts
@@ -25,6 +25,19 @@ async function loadWorkflow(): Promise<Workflow> {
   return parse(text) as Workflow;
 }
 
+// deno-lint-ignore no-explicit-any
+function findStepByName(wf: Workflow, name: string): any {
+  const jobs = wf.jobs as Record<string, Record<string, unknown>>;
+  for (const job of Object.values(jobs)) {
+    const steps = (job as { steps?: Array<Record<string, unknown>> }).steps ??
+      [];
+    for (const step of steps) {
+      if (step.name === name) return step;
+    }
+  }
+  return undefined;
+}
+
 Deno.test("quality workflow — every uses: pins a 40-char commit SHA", async () => {
   const wf = await loadWorkflow();
   const jobs = wf.jobs as Record<string, Record<string, unknown>>;
@@ -75,5 +88,53 @@ Deno.test("quality workflow — rust-toolchain is SHA-pinned and keeps toolchain
     withBlock?.toolchain,
     "stable",
     "SHA-pinned rust-toolchain must set `with: toolchain: stable` to keep the stable toolchain",
+  );
+});
+
+// CI runs the example steps in quick mode so the per-PR job stays well
+// under its timeout cap (Issue #581).
+Deno.test("quality workflow — Discovery example runs in quick mode and stays non-blocking", async () => {
+  const wf = await loadWorkflow();
+  const step = findStepByName(wf, "Run Discovery example");
+  assert(step, "quality workflow must run the Discovery example");
+  const env = step.env as Record<string, string> | undefined;
+  assertEquals(
+    env?.DISCOVERY_QUICK,
+    "1",
+    "Discovery step must set DISCOVERY_QUICK: '1' so it does not burn its full budget in CI",
+  );
+  assertEquals(
+    step["continue-on-error"],
+    true,
+    "Discovery step must remain continue-on-error while the native FFI library is unavailable in CI",
+  );
+});
+
+Deno.test("quality workflow — Suggest Improvements example runs in quick mode and stays blocking", async () => {
+  const wf = await loadWorkflow();
+  const step = findStepByName(wf, "Run Suggest Improvements example");
+  assert(step, "quality workflow must run the Suggest Improvements example");
+  const env = step.env as Record<string, string> | undefined;
+  assertEquals(
+    env?.SUGGEST_QUICK,
+    "1",
+    "Suggest Improvements step must set SUGGEST_QUICK: '1' to finish quickly in CI",
+  );
+  assert(
+    step["continue-on-error"] === undefined ||
+      step["continue-on-error"] === false,
+    "Suggest Improvements step must remain blocking (no continue-on-error)",
+  );
+});
+
+Deno.test("quality workflow — job timeout has headroom above the example budget", async () => {
+  const wf = await loadWorkflow();
+  const jobs = wf.jobs as Record<string, Record<string, unknown>>;
+  const quality = jobs.quality as { "timeout-minutes"?: number } | undefined;
+  assert(quality, "quality workflow must define a 'quality' job");
+  assertEquals(
+    quality["timeout-minutes"],
+    45,
+    "quality job timeout-minutes must be 45 to give the example steps headroom (Issue #581)",
   );
 });

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -40,7 +40,7 @@ jobs:
   quality:
     name: Run quality checks
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
 
     steps:
       - name: Check out repository
@@ -195,9 +195,18 @@ jobs:
         # The Discovery example requires a native Rust FFI library
         # (libneat_ai_discovery) which is not available in CI.
         # Allow this step to fail gracefully until the library
-        # is available as a CI artefact.
+        # is available as a CI artefact. DISCOVERY_QUICK forces a tiny
+        # budget (matching quality.sh, issue #375) so the step stops
+        # burning its full 15-minute Discovery budget in CI (issue #581).
         continue-on-error: true
+        env:
+          DISCOVERY_QUICK: "1"
         run: ./discovery/run.sh
 
       - name: Run Suggest Improvements example
+        # SUGGEST_QUICK forces a tiny budget (matching quality.sh,
+        # issue #388) so this blocking step finishes quickly in CI
+        # (issue #581).
+        env:
+          SUGGEST_QUICK: "1"
         run: ./suggest_improvements/run.sh

--- a/deno.json
+++ b/deno.json
@@ -20,7 +20,7 @@
     "@std/testing/mock": "jsr:@std/testing@1.0.19/mock",
     "@std/uuid": "jsr:@std/uuid@1.1.1",
     "@std/yaml": "jsr:@std/yaml@1.1.1",
-    "@stsoftware/neat-ai": "jsr:@stsoftware/neat-ai@5.3.19",
+    "@stsoftware/neat-ai": "jsr:@stsoftware/neat-ai@5.3.23",
     "@stsoftware/tags": "jsr:@stsoftware/tags@1.0.13"
   },
   "lint": {

--- a/deno.lock
+++ b/deno.lock
@@ -22,7 +22,7 @@
     "jsr:@std/testing@1.0.19": "1.0.19",
     "jsr:@std/uuid@1.1.1": "1.1.1",
     "jsr:@std/yaml@1.1.1": "1.1.1",
-    "jsr:@stsoftware/neat-ai@5.3.19": "5.3.19",
+    "jsr:@stsoftware/neat-ai@5.3.23": "5.3.23",
     "jsr:@stsoftware/tags@1.0.13": "1.0.13"
   },
   "jsr": {
@@ -95,8 +95,8 @@
     "@std/yaml@1.1.1": {
       "integrity": "a57665ecf3d17b926380593a56625d8a10cc7281802f1e993b5ebc94a48e71f8"
     },
-    "@stsoftware/neat-ai@5.3.19": {
-      "integrity": "96464b94b41f262e9d23803fb97e3369f687ac396c16defc2723d9dd18caf975",
+    "@stsoftware/neat-ai@5.3.23": {
+      "integrity": "1c808dc01a1dd16f6186f4eb4395b516819a0c588c50f25ca718a0885eb59c03",
       "dependencies": [
         "jsr:@std/assert@1.0.19",
         "jsr:@std/bytes@1.0.6",
@@ -128,7 +128,7 @@
       "jsr:@std/testing@1.0.19",
       "jsr:@std/uuid@1.1.1",
       "jsr:@std/yaml@1.1.1",
-      "jsr:@stsoftware/neat-ai@5.3.19",
+      "jsr:@stsoftware/neat-ai@5.3.23",
       "jsr:@stsoftware/tags@1.0.13"
     ]
   }

--- a/docs/archive/pr-summaries/pr-summary-581.md
+++ b/docs/archive/pr-summaries/pr-summary-581.md
@@ -1,0 +1,55 @@
+## Summary
+
+The per-PR `Quality Check` workflow (`.github/workflows/quality.yml`) was hitting
+its 30-minute `timeout-minutes` cap because the example steps ran at full budget —
+the Discovery example alone burns its 15-minute internal budget. This PR runs the
+CI example steps in quick mode (matching `quality.sh`) and raises the workflow
+timeout to 45 minutes as headroom. Closes #581.
+
+Changes:
+
+- **Run Discovery example** — added `env: DISCOVERY_QUICK: "1"` (matching
+  `quality.sh`, issue #375). The step keeps `continue-on-error: true` because the
+  native FFI discovery library is still unavailable in CI; quick mode simply stops
+  the step from wasting its full 15-minute budget.
+- **Run Suggest Improvements example** — added `env: SUGGEST_QUICK: "1"` (matching
+  `quality.sh`, issue #388). The step stays blocking (no `continue-on-error`).
+- Raised the `quality` job `timeout-minutes` from `30` to `45`.
+- Left the **Run Intelligent Design example** step unchanged (≈2m50s at full
+  budget, no quick-mode flag).
+
+Both run scripts already accept these flags (`discovery/run.sh` allows
+`DISCOVERY_QUICK`, `suggest_improvements/run.sh` allows `SUGGEST_QUICK`), so
+step-level `env` is sufficient.
+
+## Evidence
+
+This is a CI/workflow configuration change with no web interface to screenshot.
+Verification was via the YAML workflow tests and `actionlint`:
+
+- `actionlint .github/workflows/quality.yml` → passes (the #508 gate).
+- `deno test --allow-read .github/quality_workflow_test.ts` → 5 passed, 0 failed.
+
+```mermaid
+flowchart TD
+    A[Quality Check job<br/>timeout-minutes: 45] --> B[Intelligent Design<br/>full budget ~2m50s]
+    B --> C[Discovery<br/>DISCOVERY_QUICK=1<br/>continue-on-error]
+    C --> D[Suggest Improvements<br/>SUGGEST_QUICK=1<br/>blocking]
+```
+
+## Test Plan
+
+Added three structural "what" tests to `.github/quality_workflow_test.ts` (they
+parse the YAML and assert on the parsed values, in the same style as the existing
+SHA-pin tests):
+
+- `quality workflow — Discovery example runs in quick mode and stays non-blocking`
+  — asserts the Discovery step has `env.DISCOVERY_QUICK === "1"` and retains
+  `continue-on-error: true`.
+- `quality workflow — Suggest Improvements example runs in quick mode and stays blocking`
+  — asserts the Suggest Improvements step has `env.SUGGEST_QUICK === "1"` and has no
+  `continue-on-error`.
+- `quality workflow — job timeout has headroom above the example budget` — asserts
+  the `quality` job `timeout-minutes` is `45`.
+
+All five tests in the file pass; `deno lint` and `deno fmt` are clean.

--- a/docs/archive/pr-summaries/pr-summary-581.md
+++ b/docs/archive/pr-summaries/pr-summary-581.md
@@ -4,7 +4,7 @@ The per-PR `Quality Check` workflow (`.github/workflows/quality.yml`) was hittin
 its 30-minute `timeout-minutes` cap because the example steps ran at full budget —
 the Discovery example alone burns its 15-minute internal budget. This PR runs the
 CI example steps in quick mode (matching `quality.sh`) and raises the workflow
-timeout to 45 minutes as headroom. Closes #581.
+timeout to 45 minutes as headroom. Closes #581
 
 Changes:
 


### PR DESCRIPTION
## Summary

The per-PR `Quality Check` workflow (`.github/workflows/quality.yml`) was hitting
its 30-minute `timeout-minutes` cap because the example steps ran at full budget —
the Discovery example alone burns its 15-minute internal budget. This PR runs the
CI example steps in quick mode (matching `quality.sh`) and raises the workflow
timeout to 45 minutes as headroom. Closes #581.

Changes:

- **Run Discovery example** — added `env: DISCOVERY_QUICK: "1"` (matching
  `quality.sh`, issue #375). The step keeps `continue-on-error: true` because the
  native FFI discovery library is still unavailable in CI; quick mode simply stops
  the step from wasting its full 15-minute budget.
- **Run Suggest Improvements example** — added `env: SUGGEST_QUICK: "1"` (matching
  `quality.sh`, issue #388). The step stays blocking (no `continue-on-error`).
- Raised the `quality` job `timeout-minutes` from `30` to `45`.
- Left the **Run Intelligent Design example** step unchanged (≈2m50s at full
  budget, no quick-mode flag).

Both run scripts already accept these flags (`discovery/run.sh` allows
`DISCOVERY_QUICK`, `suggest_improvements/run.sh` allows `SUGGEST_QUICK`), so
step-level `env` is sufficient.

## Evidence

This is a CI/workflow configuration change with no web interface to screenshot.
Verification was via the YAML workflow tests and `actionlint`:

- `actionlint .github/workflows/quality.yml` → passes (the #508 gate).
- `deno test --allow-read .github/quality_workflow_test.ts` → 5 passed, 0 failed.

```mermaid
flowchart TD
    A[Quality Check job<br/>timeout-minutes: 45] --> B[Intelligent Design<br/>full budget ~2m50s]
    B --> C[Discovery<br/>DISCOVERY_QUICK=1<br/>continue-on-error]
    C --> D[Suggest Improvements<br/>SUGGEST_QUICK=1<br/>blocking]
```

## Test Plan

Added three structural "what" tests to `.github/quality_workflow_test.ts` (they
parse the YAML and assert on the parsed values, in the same style as the existing
SHA-pin tests):

- `quality workflow — Discovery example runs in quick mode and stays non-blocking`
  — asserts the Discovery step has `env.DISCOVERY_QUICK === "1"` and retains
  `continue-on-error: true`.
- `quality workflow — Suggest Improvements example runs in quick mode and stays blocking`
  — asserts the Suggest Improvements step has `env.SUGGEST_QUICK === "1"` and has no
  `continue-on-error`.
- `quality workflow — job timeout has headroom above the example budget` — asserts
  the `quality` job `timeout-minutes` is `45`.

All five tests in the file pass; `deno lint` and `deno fmt` are clean.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mq8xxps0-d0db82`<!-- vibe-worker-issue-581 -->