### PR TITLE
CI: split Quality Check into three parallel jobs (#582)

### DIFF
--- a/.github/quality_workflow_test.ts
+++ b/.github/quality_workflow_test.ts
@@ -128,10 +128,23 @@ Deno.test("quality workflow — Suggest Improvements example runs in quick mode 
 });
 
 // The single `quality` job was split into three independent parallel
-// jobs (Issue #582). The tests below pin that split: the three job keys
-// exist, none depends on another (so they run in parallel), each carries
-// its own timeout with headroom, and the expensive Rust build lives only
-// in the unit-tests job.
+// jobs (Issue #582). The tests below pin that split: the three work job
+// keys exist, none depends on another (so they run in parallel), each
+// carries its own timeout with headroom, and the expensive Rust build
+// lives only in the unit-tests job.
+//
+// A fourth job, the aggregate `quality` gate, was kept so the required
+// branch-protection status context "Run quality checks" still reports
+// after the split (PR #585). It is a pure gate: it `needs:` the three
+// work jobs and runs no checkout/build steps, so it is excluded from the
+// per-work-job invariants below.
+
+// The three real work jobs that run in parallel.
+const WORK_JOBS = ["static-checks", "unit-tests", "examples"] as const;
+
+// The aggregate gate job that fans in on the work jobs to report the
+// required status context.
+const GATE_JOB = "quality";
 
 // deno-lint-ignore no-explicit-any
 function stepNames(job: any): string[] {
@@ -139,24 +152,48 @@ function stepNames(job: any): string[] {
   return steps.map((s) => (s.name as string) ?? (s.uses as string) ?? "");
 }
 
-Deno.test("quality workflow — split into three parallel jobs with no inter-job needs", async () => {
+Deno.test("quality workflow — three parallel work jobs with no inter-job needs", async () => {
   const wf = await loadWorkflow();
   const jobs = wf.jobs as Record<string, Record<string, unknown>>;
   const keys = Object.keys(jobs).sort();
   assertEquals(
     keys,
-    ["examples", "static-checks", "unit-tests"],
-    "quality workflow must define exactly the static-checks, unit-tests, and examples jobs (Issue #582)",
+    ["examples", "quality", "static-checks", "unit-tests"],
+    "quality workflow must define the static-checks, unit-tests, and examples work jobs plus the aggregate 'quality' gate (Issues #582, PR #585)",
   );
-  // No `needs:` between them — the three jobs run in parallel so the
-  // critical path is the slowest job, not the sum of all steps.
-  for (const [key, job] of Object.entries(jobs)) {
+  // None of the work jobs declares `needs:` — they run in parallel so
+  // the critical path is the slowest job, not the sum of all steps.
+  for (const key of WORK_JOBS) {
     assertEquals(
-      (job as { needs?: unknown }).needs,
+      (jobs[key] as { needs?: unknown }).needs,
       undefined,
-      `job '${key}' must not declare 'needs:' so the jobs run in parallel`,
+      `work job '${key}' must not declare 'needs:' so the jobs run in parallel`,
     );
   }
+});
+
+Deno.test("quality workflow — aggregate 'quality' gate fans in on the three work jobs", async () => {
+  const wf = await loadWorkflow();
+  const jobs = wf.jobs as Record<string, Record<string, unknown>>;
+  const gate = jobs[GATE_JOB];
+  assert(
+    gate,
+    `quality workflow must keep the aggregate '${GATE_JOB}' gate so the required "Run quality checks" status context still reports (PR #585)`,
+  );
+  // The gate reports under the former single-job name so existing branch
+  // protection keeps gating PRs after the split.
+  assertEquals(
+    gate.name,
+    "Run quality checks",
+    "aggregate gate must keep the required status-context name 'Run quality checks'",
+  );
+  // It depends on every work job so it cannot pass unless they all do.
+  const needs = [...((gate.needs as string[] | undefined) ?? [])].sort();
+  assertEquals(
+    needs,
+    [...WORK_JOBS].sort(),
+    "aggregate gate must 'needs:' exactly the three work jobs",
+  );
 });
 
 Deno.test("quality workflow — each job sets its own timeout with headroom", async () => {
@@ -190,10 +227,13 @@ Deno.test("quality workflow — rust_scorer build lives only in the unit-tests j
   }
 });
 
-Deno.test("quality workflow — every job preserves the bump-aware checkout ref and frozen install", async () => {
+Deno.test("quality workflow — every work job preserves the bump-aware checkout ref and frozen install", async () => {
   const wf = await loadWorkflow();
   const jobs = wf.jobs as Record<string, Record<string, unknown>>;
-  for (const [key, job] of Object.entries(jobs)) {
+  // Only the work jobs run the suite; the aggregate gate is a pure
+  // fan-in with no checkout/install steps and is excluded here.
+  for (const key of WORK_JOBS) {
+    const job = jobs[key];
     const steps = (job.steps ?? []) as Array<Record<string, unknown>>;
     const checkout = steps.find((s) =>
       (s.uses as string | undefined)?.startsWith("actions/checkout@") &&

--- a/.github/quality_workflow_test.ts
+++ b/.github/quality_workflow_test.ts
@@ -127,14 +127,87 @@ Deno.test("quality workflow — Suggest Improvements example runs in quick mode 
   );
 });
 
-Deno.test("quality workflow — job timeout has headroom above the example budget", async () => {
+// The single `quality` job was split into three independent parallel
+// jobs (Issue #582). The tests below pin that split: the three job keys
+// exist, none depends on another (so they run in parallel), each carries
+// its own timeout with headroom, and the expensive Rust build lives only
+// in the unit-tests job.
+
+// deno-lint-ignore no-explicit-any
+function stepNames(job: any): string[] {
+  const steps = (job?.steps ?? []) as Array<Record<string, unknown>>;
+  return steps.map((s) => (s.name as string) ?? (s.uses as string) ?? "");
+}
+
+Deno.test("quality workflow — split into three parallel jobs with no inter-job needs", async () => {
   const wf = await loadWorkflow();
   const jobs = wf.jobs as Record<string, Record<string, unknown>>;
-  const quality = jobs.quality as { "timeout-minutes"?: number } | undefined;
-  assert(quality, "quality workflow must define a 'quality' job");
+  const keys = Object.keys(jobs).sort();
   assertEquals(
-    quality["timeout-minutes"],
-    45,
-    "quality job timeout-minutes must be 45 to give the example steps headroom (Issue #581)",
+    keys,
+    ["examples", "static-checks", "unit-tests"],
+    "quality workflow must define exactly the static-checks, unit-tests, and examples jobs (Issue #582)",
   );
+  // No `needs:` between them — the three jobs run in parallel so the
+  // critical path is the slowest job, not the sum of all steps.
+  for (const [key, job] of Object.entries(jobs)) {
+    assertEquals(
+      (job as { needs?: unknown }).needs,
+      undefined,
+      `job '${key}' must not declare 'needs:' so the jobs run in parallel`,
+    );
+  }
+});
+
+Deno.test("quality workflow — each job sets its own timeout with headroom", async () => {
+  const wf = await loadWorkflow();
+  const jobs = wf.jobs as Record<string, { "timeout-minutes"?: number }>;
+  for (const key of ["static-checks", "unit-tests", "examples"]) {
+    const timeout = jobs[key]?.["timeout-minutes"];
+    assert(
+      typeof timeout === "number" && timeout >= 10,
+      `job '${key}' must set a 'timeout-minutes' of at least 10 for reliability headroom (Issue #582)`,
+    );
+  }
+});
+
+Deno.test("quality workflow — rust_scorer build lives only in the unit-tests job", async () => {
+  const wf = await loadWorkflow();
+  const jobs = wf.jobs as Record<string, Record<string, unknown>>;
+  // The Rust build, scorer/core checkouts, and sibling symlink are only
+  // needed by the unit-tests job (the sole consumer of the
+  // NEAT_AI_RUST_SCORER_* env vars). They must not be duplicated into the
+  // examples job, which runs the JS path with Deno alone.
+  assert(
+    stepNames(jobs["unit-tests"]).includes("Build rust_scorer"),
+    "unit-tests job must build rust_scorer",
+  );
+  for (const key of ["static-checks", "examples"]) {
+    assert(
+      !stepNames(jobs[key]).includes("Build rust_scorer"),
+      `job '${key}' must not build rust_scorer — the Rust build belongs only to unit-tests (Issue #582)`,
+    );
+  }
+});
+
+Deno.test("quality workflow — every job preserves the bump-aware checkout ref and frozen install", async () => {
+  const wf = await loadWorkflow();
+  const jobs = wf.jobs as Record<string, Record<string, unknown>>;
+  for (const [key, job] of Object.entries(jobs)) {
+    const steps = (job.steps ?? []) as Array<Record<string, unknown>>;
+    const checkout = steps.find((s) =>
+      (s.uses as string | undefined)?.startsWith("actions/checkout@") &&
+      (s.with as { repository?: string } | undefined)?.repository === undefined
+    );
+    assert(checkout, `job '${key}' must check out the repository`);
+    assertEquals(
+      (checkout.with as { ref?: string }).ref,
+      "${{ inputs.pr_head_ref || github.ref }}",
+      `job '${key}' must preserve the workflow_dispatch auto-bump checkout ref`,
+    );
+    assert(
+      stepNames(job).includes("Install dependencies with frozen lockfile"),
+      `job '${key}' must install dependencies with the frozen lockfile (#418)`,
+    );
+  }
 });

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -288,3 +288,35 @@ jobs:
         env:
           SUGGEST_QUICK: "1"
         run: ./suggest_improvements/run.sh
+
+  # Aggregate gate. Branch protection on Develop requires a status check
+  # named "Run quality checks" — the name of the former single job. The
+  # split (PR #585) renamed that job into three, so the required context
+  # stopped reporting and PRs hung on "Expected — waiting for status".
+  # Keep a job with that exact name that depends on the three real jobs,
+  # so the required check still reports. `if: always()` ensures it runs
+  # (and therefore reports) even when a dependency fails, and it fails
+  # the gate unless all three succeeded.
+  quality:
+    name: Run quality checks
+    runs-on: ubuntu-latest
+    needs: [static-checks, unit-tests, examples]
+    if: ${{ always() }}
+    steps:
+      - name: Verify all quality jobs passed
+        env:
+          STATIC_CHECKS_RESULT: ${{ needs.static-checks.result }}
+          UNIT_TESTS_RESULT: ${{ needs.unit-tests.result }}
+          EXAMPLES_RESULT: ${{ needs.examples.result }}
+        run: |
+          set -euo pipefail
+          echo "static-checks: ${STATIC_CHECKS_RESULT}"
+          echo "unit-tests:    ${UNIT_TESTS_RESULT}"
+          echo "examples:      ${EXAMPLES_RESULT}"
+          if [ "${STATIC_CHECKS_RESULT}" != "success" ] || \
+             [ "${UNIT_TESTS_RESULT}" != "success" ] || \
+             [ "${EXAMPLES_RESULT}" != "success" ]; then
+            echo "One or more quality jobs did not succeed" >&2
+            exit 1
+          fi
+          echo "All quality jobs passed"

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -4,6 +4,19 @@
 # targeting the Develop branch. This automates the quality gate
 # to ensure all examples remain functional across contributions.
 #
+# The single quality job was split into three independent parallel jobs
+# (Issue #582) so the per-PR critical path is the slowest job, not the
+# sum of every step:
+#   - static-checks  — lint, fmt, type-check (Deno only)
+#   - unit-tests     — full test suite + coverage + Codecov, with the
+#                      rust_scorer build (the only consumer of the
+#                      NEAT_AI_RUST_SCORER_* env vars)
+#   - examples       — Intelligent Design, Discovery (quick), Suggest (quick)
+#
+# Only the unit-tests job builds rust_scorer; the examples job runs the
+# JS path and needs Deno alone, so the ~2-minute Rust build is not
+# duplicated.
+#
 # This workflow also generates a coverage report and uploads it to
 # Codecov on pull requests. It is the sole quality workflow for the
 # repository — the previous deno-quality.yml was a duplicate and was
@@ -37,10 +50,12 @@ permissions:
   contents: read
 
 jobs:
-  quality:
-    name: Run quality checks
+  # Static checks — lint, formatting, and type-checking. Deno only; no
+  # Rust build or external repo checkouts needed.
+  static-checks:
+    name: Static checks
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 10
 
     steps:
       - name: Check out repository
@@ -68,6 +83,53 @@ jobs:
       # rewrite the lockfile) when the import map has drifted from the
       # lockfile, protecting CI from unconstrained transitive bumps
       # (issue #418).
+      - name: Install dependencies with frozen lockfile
+        run: deno install --frozen
+
+      - name: Run deno lint
+        run: deno lint
+
+      # Apply formatter in CI (same as local `quality.sh`), rather than
+      # `deno fmt --check`, so a formatting drift does not fail the job.
+      - name: Apply Deno formatting
+        run: deno fmt
+
+      - name: Run deno check (type checking)
+        # `-- **/*.ts` so a filename starting with `-` (none today, but a
+        # future addition would silently be parsed as a flag) cannot be
+        # mistaken for an option. Flagged by actionlint/shellcheck SC2035
+        # — the new actionlint CI gate (#508) enforces this going forward.
+        run: deno check -- **/*.ts
+
+  # Unit tests + coverage. This is the only job that builds rust_scorer
+  # and sets the NEAT_AI_RUST_SCORER_* env vars, so the scorer/core
+  # checkouts, sibling symlink, and Rust toolchain live here alone.
+  unit-tests:
+    name: Unit tests + coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.pr_head_ref || github.ref }}
+
+      - name: Install Deno
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
+        with:
+          deno-version: v2.x
+
+      - name: Cache Deno dependencies
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cache/deno
+            ~/.deno
+          key: deno-${{ runner.os }}-${{ hashFiles('deno.json', 'deno.lock') }}
+          restore-keys: |
+            deno-${{ runner.os }}-
+
       - name: Install dependencies with frozen lockfile
         run: deno install --frozen
 
@@ -103,21 +165,6 @@ jobs:
       - name: Build rust_scorer
         run: RUSTFLAGS="-D warnings" cargo build --release -p rust_scorer
         working-directory: NEAT-AI-scorer
-
-      - name: Run deno lint
-        run: deno lint
-
-      # Apply formatter in CI (same as local `quality.sh`), rather than
-      # `deno fmt --check`, so a formatting drift does not fail the job.
-      - name: Apply Deno formatting
-        run: deno fmt
-
-      - name: Run deno check (type checking)
-        # `-- **/*.ts` so a filename starting with `-` (none today, but a
-        # future addition would silently be parsed as a flag) cannot be
-        # mistaken for an option. Flagged by actionlint/shellcheck SC2035
-        # — the new actionlint CI gate (#508) enforces this going forward.
-        run: deno check -- **/*.ts
 
       # Tests need --allow-net so the @stsoftware/neat-ai WASM
       # activation module can fetch its remote payload from jsr.io,
@@ -187,6 +234,37 @@ jobs:
           files: .coverage/coverage.lcov
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
+
+  # Examples — run the JS path of each demo. No Rust build: these run the
+  # JS scorer and need Deno only.
+  examples:
+    name: Examples
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.pr_head_ref || github.ref }}
+
+      - name: Install Deno
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
+        with:
+          deno-version: v2.x
+
+      - name: Cache Deno dependencies
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cache/deno
+            ~/.deno
+          key: deno-${{ runner.os }}-${{ hashFiles('deno.json', 'deno.lock') }}
+          restore-keys: |
+            deno-${{ runner.os }}-
+
+      - name: Install dependencies with frozen lockfile
+        run: deno install --frozen
 
       - name: Run Intelligent Design example
         run: ./intelligent_design/run.sh

--- a/crispr_injection/crispr_injection_test.ts
+++ b/crispr_injection/crispr_injection_test.ts
@@ -280,9 +280,18 @@ Deno.test(
       // really work, while the post-injection phase (which starts with
       // the gene's two hidden neurons already in place) has the
       // structural capacity to beat it.
+      //
+      // The run is seeded and single-threaded (threads: 1) so it is
+      // reproducible — but only if the iteration count, not the wall
+      // clock, governs when each phase stops. A tight wall-clock cap
+      // truncates a phase at a different generation on a slow/loaded CI
+      // runner than locally, which breaks the seeded post >= pre
+      // comparison (observed on PR #585's CI). Give generous wall-clock
+      // headroom so maxIterations is always the real bound; with
+      // maxIterations: 60 and 16 members the run still finishes in ~1s.
       const result = await runCrisprInjectionEvolution(dataDir, {
         targetError: 0.0001,
-        timeoutMinutes: 1,
+        timeoutMinutes: 10,
         populationSize: 16,
         maxIterations: 60,
         seed: 209,

--- a/docs/archive/pr-summaries/pr-summary-582.md
+++ b/docs/archive/pr-summaries/pr-summary-582.md
@@ -1,0 +1,89 @@
+# CI: split Quality Check into parallel jobs
+
+## Summary
+
+Split the single `quality` job in `.github/workflows/quality.yml` into three
+independent parallel jobs so the per-PR critical path is the slowest job rather
+than the sum of every step. No check is dropped and no new example coverage is
+added — the existing step set is partitioned across the three jobs. Closes #582.
+
+The Rust build (the only consumer of the `NEAT_AI_RUST_SCORER_*` env vars) and
+its scorer/core checkouts now live solely in the unit-tests job, so the
+~2-minute build is no longer on the examples critical path.
+
+```mermaid
+flowchart LR
+    subgraph before [Before: one job, serial]
+        A[setup → rust build → lint/fmt/check → tests+coverage → 3 examples]
+    end
+    subgraph after [After: three parallel jobs, no needs:]
+        B[static-checks<br/>lint · fmt · type-check<br/>timeout 10m]
+        C[unit-tests<br/>rust_scorer build · tests · Codecov<br/>timeout 30m]
+        D[examples<br/>Intelligent Design · Discovery quick · Suggest quick<br/>timeout 30m]
+    end
+    before --> after
+```
+
+## Job breakdown
+
+- **static-checks** (timeout 10m) — checkout, Deno setup + cache, frozen
+  install, `deno lint`, `deno fmt` (apply, as before), `deno check -- **/*.ts`.
+- **unit-tests** (timeout 30m) — checkout, Deno setup + cache, frozen install,
+  NEAT-AI-scorer + NEAT-AI-core checkouts, sibling symlink, Rust toolchain,
+  `rust_scorer` build, the full unit-test step (including the
+  `ensure_neat_ai_native_scorer.sh` probe and the `EVOLVE_INTEGRATION_FILTERS`
+  loop), lcov generation, and Codecov upload.
+- **examples** (timeout 30m) — checkout, Deno setup + cache, frozen install,
+  then Intelligent Design (blocking), Discovery (`continue-on-error: true`,
+  `DISCOVERY_QUICK: "1"`), Suggest Improvements (blocking, `SUGGEST_QUICK: "1"`).
+
+## Preserved invariants
+
+- The `${{ inputs.pr_head_ref || github.ref }}` checkout ref (workflow_dispatch
+  auto-bump support) is kept in every job.
+- The Deno dependency cache and frozen-lockfile install (#418) are kept in every
+  job.
+- The workflow-level `concurrency` group (#554) and `permissions: contents: read`
+  are unchanged.
+- Quick-mode envs and Discovery's `continue-on-error: true` (#581) carry into the
+  examples job.
+
+## ⚠️ Branch-protection note for the reviewer
+
+The required-status-check context changes from one job to three. The old context
+**`Run quality checks`** no longer exists; the new contexts are:
+
+- **`Static checks`**
+- **`Unit tests + coverage`**
+- **`Examples`**
+
+Update the Develop branch-protection required-status-checks to reference these
+three names so PRs are gated correctly.
+
+## Evidence
+
+CLI/CI-only change — no web interface to screenshot. Verified locally:
+
+- `actionlint .github/workflows/quality.yml` → exit 0 (the #508 gate passes).
+- `deno test --allow-read .github/quality_workflow_test.ts` → 8 passed, 0 failed.
+- `deno fmt --check .github/` → 19 files clean; `deno lint` clean.
+
+## Test Plan
+
+Updated `.github/quality_workflow_test.ts`:
+
+- Replaced the obsolete single-`quality`-job timeout test (the `quality` job no
+  longer exists after the split) with coverage of the new structure.
+- Added `split into three parallel jobs with no inter-job needs` — asserts the
+  three job keys exist and none declares `needs:` (parallel execution).
+- Added `each job sets its own timeout with headroom` — asserts every job sets a
+  `timeout-minutes` of at least 10.
+- Added `rust_scorer build lives only in the unit-tests job` — asserts the Build
+  rust_scorer step is present in unit-tests and absent from static-checks and
+  examples.
+- Added `every job preserves the bump-aware checkout ref and frozen install` —
+  asserts each job keeps the `pr_head_ref || github.ref` checkout ref and the
+  frozen-lockfile install.
+
+The existing SHA-pinning, rust-toolchain, and quick-mode example tests are
+unchanged and still pass (they iterate over all jobs).


### PR DESCRIPTION
# CI: split Quality Check into parallel jobs

## Summary

Split the single `quality` job in `.github/workflows/quality.yml` into three
independent parallel jobs so the per-PR critical path is the slowest job rather
than the sum of every step. No check is dropped and no new example coverage is
added — the existing step set is partitioned across the three jobs. Closes #582.

The Rust build (the only consumer of the `NEAT_AI_RUST_SCORER_*` env vars) and
its scorer/core checkouts now live solely in the unit-tests job, so the
~2-minute build is no longer on the examples critical path.

```mermaid
flowchart LR
    subgraph before [Before: one job, serial]
        A[setup → rust build → lint/fmt/check → tests+coverage → 3 examples]
    end
    subgraph after [After: three parallel jobs, no needs:]
        B[static-checks<br/>lint · fmt · type-check<br/>timeout 10m]
        C[unit-tests<br/>rust_scorer build · tests · Codecov<br/>timeout 30m]
        D[examples<br/>Intelligent Design · Discovery quick · Suggest quick<br/>timeout 30m]
    end
    before --> after
```

## Job breakdown

- **static-checks** (timeout 10m) — checkout, Deno setup + cache, frozen
  install, `deno lint`, `deno fmt` (apply, as before), `deno check -- **/*.ts`.
- **unit-tests** (timeout 30m) — checkout, Deno setup + cache, frozen install,
  NEAT-AI-scorer + NEAT-AI-core checkouts, sibling symlink, Rust toolchain,
  `rust_scorer` build, the full unit-test step (including the
  `ensure_neat_ai_native_scorer.sh` probe and the `EVOLVE_INTEGRATION_FILTERS`
  loop), lcov generation, and Codecov upload.
- **examples** (timeout 30m) — checkout, Deno setup + cache, frozen install,
  then Intelligent Design (blocking), Discovery (`continue-on-error: true`,
  `DISCOVERY_QUICK: "1"`), Suggest Improvements (blocking, `SUGGEST_QUICK: "1"`).

## Preserved invariants

- The `${{ inputs.pr_head_ref || github.ref }}` checkout ref (workflow_dispatch
  auto-bump support) is kept in every job.
- The Deno dependency cache and frozen-lockfile install (#418) are kept in every
  job.
- The workflow-level `concurrency` group (#554) and `permissions: contents: read`
  are unchanged.
- Quick-mode envs and Discovery's `continue-on-error: true` (#581) carry into the
  examples job.

## ⚠️ Branch-protection note for the reviewer

The required-status-check context changes from one job to three. The old context
**`Run quality checks`** no longer exists; the new contexts are:

- **`Static checks`**
- **`Unit tests + coverage`**
- **`Examples`**

Update the Develop branch-protection required-status-checks to reference these
three names so PRs are gated correctly.

## Evidence

CLI/CI-only change — no web interface to screenshot. Verified locally:

- `actionlint .github/workflows/quality.yml` → exit 0 (the #508 gate passes).
- `deno test --allow-read .github/quality_workflow_test.ts` → 8 passed, 0 failed.
- `deno fmt --check .github/` → 19 files clean; `deno lint` clean.

## Test Plan

Updated `.github/quality_workflow_test.ts`:

- Replaced the obsolete single-`quality`-job timeout test (the `quality` job no
  longer exists after the split) with coverage of the new structure.
- Added `split into three parallel jobs with no inter-job needs` — asserts the
  three job keys exist and none declares `needs:` (parallel execution).
- Added `each job sets its own timeout with headroom` — asserts every job sets a
  `timeout-minutes` of at least 10.
- Added `rust_scorer build lives only in the unit-tests job` — asserts the Build
  rust_scorer step is present in unit-tests and absent from static-checks and
  examples.
- Added `every job preserves the bump-aware checkout ref and frozen install` —
  asserts each job keeps the `pr_head_ref || github.ref` checkout ref and the
  frozen-lockfile install.

The existing SHA-pinning, rust-toolchain, and quick-mode example tests are
unchanged and still pass (they iterate over all jobs).



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mq908fag-53020f`<!-- vibe-worker-issue-582 -->