### PR TITLE
Narrow unused export campaignRecordPath to module-private (#620)

### DIFF
--- a/common/campaign_record.ts
+++ b/common/campaign_record.ts
@@ -37,8 +37,8 @@ function resolveBaseDir(baseDir?: string): string {
   return "docs";
 }
 
-/** Path to the campaign record JSON for an example. */
-export function campaignRecordPath(exampleSlug: string, baseDir?: string): string {
+/** Path to the campaign record JSON for an example. Module-private helper. */
+function campaignRecordPath(exampleSlug: string, baseDir?: string): string {
   return join(resolveBaseDir(baseDir), "data", exampleSlug, "campaign_record.json");
 }
 

--- a/common/campaign_record_test.ts
+++ b/common/campaign_record_test.ts
@@ -3,6 +3,7 @@
  */
 
 import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
 
 import {
   appendCampaignPhase,
@@ -31,6 +32,20 @@ Deno.test("startCampaignRecord then appendCampaignPhase tracks wall-clock and be
     assertEquals(record?.totalWallClockMs, 150_000);
     assertEquals(record?.bestHoldoutScore, 0.21);
     assertEquals(record?.bestValidationScore, 0.22);
+  } finally {
+    Deno.removeSync(tmp, { recursive: true });
+  }
+});
+
+Deno.test("startCampaignRecord writes to <baseDir>/data/<slug>/campaign_record.json", async () => {
+  const tmp = Deno.makeTempDirSync({ prefix: "campaign_" });
+  try {
+    await startCampaignRecord("xor_classification", tmp);
+    // The path is resolved by the module-private campaignRecordPath helper;
+    // assert the side effect lands at the expected location.
+    const expected = join(tmp, "data", "xor_classification", "campaign_record.json");
+    const stat = await Deno.stat(expected);
+    assertEquals(stat.isFile, true);
   } finally {
     Deno.removeSync(tmp, { recursive: true });
   }

--- a/docs/archive/pr-summaries/pr-summary-620.md
+++ b/docs/archive/pr-summaries/pr-summary-620.md
@@ -1,0 +1,49 @@
+## Summary
+
+Narrowed the unused export `campaignRecordPath` in `common/campaign_record.ts` to a
+module-private helper by removing its `export` keyword. Module-graph analysis confirmed
+the symbol had no importer anywhere in the repository — its only call sites are the sibling
+functions `loadCampaignRecord`, `writeCampaignRecord`, and `wipeCampaignRecord` within the
+same file. The function itself is still required internally, so only the `export` modifier
+was dropped; all three call sites are unaffected.
+
+Closes #620.
+
+### Verification of the dead-code claim
+
+```
+grep -rnw campaignRecordPath .   # zero matches outside common/campaign_record.ts
+```
+
+No `.ts`/`.js`/`.md`/`.json` file references the identifier, there is no barrel re-export,
+and no dynamic/string lookup — so removing the `export` cannot break any consumer.
+
+## Evidence
+
+Backend/library change with no web interface — no screenshot applies. Validated via the
+Deno quality gates:
+
+- `deno lint` — clean (168 files).
+- `deno check ./**/*.ts` — clean.
+- `deno fmt --check common/campaign_record.ts common/campaign_record_test.ts` — clean
+  (the 7 pre-existing unformatted files in `docs/` are unrelated and left untouched per
+  change-scope rules).
+- Full unit suite: `1175 passed | 0 failed`.
+
+```mermaid
+flowchart LR
+    A[campaignRecordPath<br/>module-private helper] --> B[loadCampaignRecord]
+    A --> C[writeCampaignRecord]
+    A --> D[wipeCampaignRecord]
+    B & C & D --> E[Public campaign-record API]
+```
+
+## Test Plan
+
+- Existing tests retained unchanged: `startCampaignRecord then appendCampaignPhase tracks
+  wall-clock and best score` and `wipeCampaignRecord removes the JSON file` — these exercise
+  the now-private helper indirectly through the public API.
+- Added `common/campaign_record_test.ts::startCampaignRecord writes to
+  <baseDir>/data/<slug>/campaign_record.json`, which asserts the path-resolution side effect
+  lands at the expected location, keeping the private helper's behaviour covered.
+- All three tests pass: `ok | 3 passed | 0 failed`.


### PR DESCRIPTION
## Summary

Narrowed the unused export `campaignRecordPath` in `common/campaign_record.ts` to a
module-private helper by removing its `export` keyword. Module-graph analysis confirmed
the symbol had no importer anywhere in the repository — its only call sites are the sibling
functions `loadCampaignRecord`, `writeCampaignRecord`, and `wipeCampaignRecord` within the
same file. The function itself is still required internally, so only the `export` modifier
was dropped; all three call sites are unaffected.

Closes #620.

### Verification of the dead-code claim

```
grep -rnw campaignRecordPath .   # zero matches outside common/campaign_record.ts
```

No `.ts`/`.js`/`.md`/`.json` file references the identifier, there is no barrel re-export,
and no dynamic/string lookup — so removing the `export` cannot break any consumer.

## Evidence

Backend/library change with no web interface — no screenshot applies. Validated via the
Deno quality gates:

- `deno lint` — clean (168 files).
- `deno check ./**/*.ts` — clean.
- `deno fmt --check common/campaign_record.ts common/campaign_record_test.ts` — clean
  (the 7 pre-existing unformatted files in `docs/` are unrelated and left untouched per
  change-scope rules).
- Full unit suite: `1175 passed | 0 failed`.

```mermaid
flowchart LR
    A[campaignRecordPath<br/>module-private helper] --> B[loadCampaignRecord]
    A --> C[writeCampaignRecord]
    A --> D[wipeCampaignRecord]
    B & C & D --> E[Public campaign-record API]
```

## Test Plan

- Existing tests retained unchanged: `startCampaignRecord then appendCampaignPhase tracks
  wall-clock and best score` and `wipeCampaignRecord removes the JSON file` — these exercise
  the now-private helper indirectly through the public API.
- Added `common/campaign_record_test.ts::startCampaignRecord writes to
  <baseDir>/data/<slug>/campaign_record.json`, which asserts the path-resolution side effect
  lands at the expected location, keeping the private helper's behaviour covered.
- All three tests pass: `ok | 3 passed | 0 failed`.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mr0h3a80-73e2d7`<!-- vibe-worker-issue-620 -->