### PR TITLE
Make campaignRecordPath module-private (Issue #620)

### DIFF
--- a/common/campaign_record.ts
+++ b/common/campaign_record.ts
@@ -37,8 +37,8 @@ function resolveBaseDir(baseDir?: string): string {
   return "docs";
 }
 
-/** Path to the campaign record JSON for an example. */
-export function campaignRecordPath(exampleSlug: string, baseDir?: string): string {
+/** Path to the campaign record JSON for an example (module-private helper). */
+function campaignRecordPath(exampleSlug: string, baseDir?: string): string {
   return join(resolveBaseDir(baseDir), "data", exampleSlug, "campaign_record.json");
 }
 

--- a/docs/archive/pr-summaries/pr-summary-620.md
+++ b/docs/archive/pr-summaries/pr-summary-620.md
@@ -1,0 +1,47 @@
+# Make `campaignRecordPath` module-private
+
+## Summary
+
+Removed the unused `export` modifier from `campaignRecordPath` in
+`common/campaign_record.ts`, narrowing it to a module-private helper.
+Module-graph analysis confirmed it has **no importer** anywhere in the
+repository — `grep -rnw campaignRecordPath` across `.ts`/`.js`/`.md`/`.json`
+returns hits only inside its own file, and `deno doc` no longer lists it on
+the public surface after the change. Its three internal call sites
+(`loadCampaignRecord`, `writeCampaignRecord`, `wipeCampaignRecord`) are
+unaffected, so behaviour is unchanged. Closes #620.
+
+## Evidence
+
+Backend/library change only — no web interface to screenshot.
+
+Verification commands (all clean):
+
+- `deno fmt --check` — clean
+- `deno lint` — checked 168 files, no findings
+- `deno check ./**/*.ts` — type-checks across the repo
+- `deno doc common/campaign_record.ts` — `campaignRecordPath` no longer
+  appears in the public surface
+- `deno test --parallel --allow-all common/` — **202 passed, 0 failed**
+
+```mermaid
+flowchart LR
+    L[loadCampaignRecord] --> P[campaignRecordPath\nmodule-private]
+    W[writeCampaignRecord] --> P
+    X[wipeCampaignRecord] --> P
+    P -. no external importer .-> E[(other modules)]
+```
+
+## Test Plan
+
+No new tests were added — the change is a pure public-surface narrowing
+with no behavioural change, and the AGENTS.md testing policy forbids
+source-grep ("how") tests. The existing
+`common/campaign_record_test.ts` already exercises `campaignRecordPath`
+indirectly through the public functions that call it:
+
+- `startCampaignRecord then appendCampaignPhase tracks wall-clock and best score`
+- `wipeCampaignRecord removes the JSON file`
+
+Both pass after the change, confirming the now-private helper still
+resolves the JSON path correctly.


### PR DESCRIPTION
# Make `campaignRecordPath` module-private

## Summary

Removed the unused `export` modifier from `campaignRecordPath` in
`common/campaign_record.ts`, narrowing it to a module-private helper.
Module-graph analysis confirmed it has **no importer** anywhere in the
repository — `grep -rnw campaignRecordPath` across `.ts`/`.js`/`.md`/`.json`
returns hits only inside its own file, and `deno doc` no longer lists it on
the public surface after the change. Its three internal call sites
(`loadCampaignRecord`, `writeCampaignRecord`, `wipeCampaignRecord`) are
unaffected, so behaviour is unchanged. Closes #620.

## Evidence

Backend/library change only — no web interface to screenshot.

Verification commands (all clean):

- `deno fmt --check` — clean
- `deno lint` — checked 168 files, no findings
- `deno check ./**/*.ts` — type-checks across the repo
- `deno doc common/campaign_record.ts` — `campaignRecordPath` no longer
  appears in the public surface
- `deno test --parallel --allow-all common/` — **202 passed, 0 failed**

```mermaid
flowchart LR
    L[loadCampaignRecord] --> P[campaignRecordPath\nmodule-private]
    W[writeCampaignRecord] --> P
    X[wipeCampaignRecord] --> P
    P -. no external importer .-> E[(other modules)]
```

## Test Plan

No new tests were added — the change is a pure public-surface narrowing
with no behavioural change, and the AGENTS.md testing policy forbids
source-grep ("how") tests. The existing
`common/campaign_record_test.ts` already exercises `campaignRecordPath`
indirectly through the public functions that call it:

- `startCampaignRecord then appendCampaignPhase tracks wall-clock and best score`
- `wipeCampaignRecord removes the JSON file`

Both pass after the change, confirming the now-private helper still
resolves the JSON path correctly.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mr0h1ehy-82de01`<!-- vibe-worker-issue-620 -->