### PR TITLE
Milestone: clean up

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-624.md
+++ b/docs/archive/pr-summaries/pr-summary-624.md
@@ -1,0 +1,44 @@
+# Remove dead-code unused export `ensureParentDir`
+
+## Summary
+
+Deleted the unused exported helper `ensureParentDir` from
+`mnist_classification/data.ts`. A repo-wide search confirmed the identifier
+appeared exactly once — its own declaration — with no importer in any `.ts`
+module (production or test), no re-export from a barrel, and no dynamic/string
+reference in any `.sh`/`.md`/`.json` file. The runner creates its output
+directories with its own `ensureDirSync`, so the JSDoc's "Used by the runner"
+claim was stale.
+
+Because the function body (`await ensureDir(dirname(path))`) was the sole
+consumer of the `ensureDir` (`@std/fs`) and `dirname` (`@std/path`) imports at
+`data.ts:17-18`, those two imports were removed alongside it — otherwise
+`deno lint`'s `no-unused-vars` would flag them.
+
+Closes #624
+
+## Evidence
+
+Backend/CLI-only change — no web interface to screenshot. Verification was via
+the quality gates:
+
+- `deno fmt --check` — clean
+- `deno lint` (168 files) — clean
+- `deno check ./**/*.ts` — clean
+- `deno test mnist_classification/mnist_classification_test.ts` — 41 passed, 0 failed
+
+The existing `mnist_classification_test.ts` imports the other public symbols of
+`data.ts` (`parseIdxImages`, `parseIdxLabels`, `buildDigitSamples`,
+`splitDataset`, `readGzippedFile`, …) and never referenced `ensureParentDir`, so
+its continued green run confirms the removal did not disturb the module's public
+surface.
+
+## Test Plan
+
+- No new tests: this is a pure dead-code deletion with no behavioural change to
+  test. Asserting a deleted symbol's absence would be a forbidden "how" test
+  (see AGENTS.md Testing Philosophy).
+- Ran the full `mnist_classification/mnist_classification_test.ts` suite
+  (41 tests) — all pass, confirming the surviving exports are unaffected.
+- Repo-wide `deno lint` / `deno check` confirm no unused imports remain and the
+  module still type-checks.

--- a/docs/archive/pr-summaries/pr-summary-625.md
+++ b/docs/archive/pr-summaries/pr-summary-625.md
@@ -1,0 +1,36 @@
+# Remove dead-code unused export `CALIBRATION_PROBE_GENERATIONS`
+
+## Summary
+
+Removed the unused exported constant `CALIBRATION_PROBE_GENERATIONS` (and its
+leading JSDoc) from `mnist_classification/exploration_campaign.ts`. Module-graph
+analysis and a repo-wide token search confirmed the identifier appeared exactly
+once in the entire repository — its own declaration — with no importer, no
+barrel re-export, and no string/dynamic reference in any `.ts`, `.sh`, `.md`, or
+`.json` file. The neighbouring `CALIBRATION_PROBE_MINUTES` constant is still read
+elsewhere and was left untouched. No calibration code path reads the removed
+value, so its removal is behaviour-preserving. Closes #625.
+
+## Evidence
+
+Backend/CLI change only — no web interface to screenshot.
+
+Verification performed:
+
+- `grep -rn "CALIBRATION_PROBE_GENERATIONS"` across `*.ts`, `*.sh`, `*.md`,
+  `*.json` returns **no matches** after removal (only match before was the
+  declaration itself), confirming no dynamic/reflective lookup exists.
+- `deno check mnist_classification/exploration_campaign.ts` — passes.
+- `deno lint` and `deno fmt --check` on the file — clean.
+- `deno test mnist_classification/exploration_campaign_test.ts` — 10 passed,
+  0 failed.
+
+## Test Plan
+
+No new tests were added: this is a pure dead-code deletion of a constant with no
+importers and no behaviour to exercise. Per the project Testing Philosophy
+(AGENTS.md), a test asserting the symbol is absent would be a forbidden "how"
+test (source inspection), and importing the removed symbol would fail to
+compile. The existing `exploration_campaign_test.ts` suite (10 "what" tests)
+continues to pass unchanged, confirming the surrounding calibration logic is
+unaffected.

--- a/docs/archive/pr-summaries/pr-summary-626.md
+++ b/docs/archive/pr-summaries/pr-summary-626.md
@@ -1,0 +1,48 @@
+# Remove dead export `loadExplorationChampion`
+
+## Summary
+
+Removed the unused exported async function `loadExplorationChampion` (and its JSDoc) from
+`mnist_classification/exploration_campaign.ts`. Module-graph analysis and a repo-wide grep confirmed
+the identifier appeared exactly once — its own declaration — with no importing `.ts` file, no test
+caller, no barrel re-export, and no dynamic/string reference in any `.sh`/`.md`/`.json` file. There
+is no resume/restart flow depending on it. Its symmetric counterpart `saveExplorationChampion`
+remains in active use and is retained. The shared `EXPLORATION_CHAMPION_PATH` constant and the
+`CreatureExport` type are still referenced elsewhere in the module, so no imports were orphaned.
+
+Closes #626.
+
+## Evidence
+
+Backend/library change only — no web interface to screenshot.
+
+Dead-export verification (single self-declaration, no callers):
+
+```
+$ grep -rn "loadExplorationChampion" . --include="*.ts" --include="*.md" --include="*.json" --include="*.sh"
+mnist_classification/exploration_campaign.ts:501:export async function loadExplorationChampion(): ...
+```
+
+After removal, the surviving load/save relationship:
+
+```mermaid
+flowchart LR
+    C[Champion evolution] -->|writes| S["saveExplorationChampion()"]
+    S -->|persists JSON| P["EXPLORATION_CHAMPION_PATH<br/>champion.json"]
+    X["loadExplorationChampion() — removed"]:::gone
+    classDef gone stroke-dasharray: 4 4,color:#888;
+```
+
+Quality gates (all pass):
+
+- `deno fmt --check` — clean
+- `deno lint` — clean
+- `deno check ./**/*.ts` — clean (no orphaned imports across the repo)
+- `deno test mnist_classification/exploration_campaign_test.ts` — 10 passed, 0 failed
+
+## Test Plan
+
+No test referenced the removed symbol, so no test needed modification. The existing behavioural
+suite in `mnist_classification/exploration_campaign_test.ts` (10 tests) continues to pass, serving
+as regression coverage that the deletion did not break the surrounding module. The repo-wide
+`deno check` confirms no other module imported the removed export.

--- a/docs/archive/pr-summaries/pr-summary-627.md
+++ b/docs/archive/pr-summaries/pr-summary-627.md
@@ -1,0 +1,42 @@
+## Summary
+
+Removed the unused exported constant `MULTI_RUN_TIMELINE_SVG_PATH` (and its
+leading JSDoc) from `mnist_classification/recorded_evolution.ts`.
+
+Module-graph analysis in issue #627 flagged the export as dead code. I
+confirmed it:
+
+- No `.ts` file imports `MULTI_RUN_TIMELINE_SVG_PATH`, and it is not
+  re-exported from any barrel.
+- The identifier appeared exactly once in the whole repository — its own
+  declaration.
+- The timeline SVG artefact is written independently via
+  `join(screenshotsDir, "timeline.svg")` (in both
+  `recorded_evolution.ts` and `mnist_classification.ts`), so the constant
+  was never the single source of truth for that path and removing it does
+  not change any behaviour or artefact location.
+
+Closes #627.
+
+## Evidence
+
+Pure dead-code removal — no web interface to screenshot. Verification was
+via type-check, lint, format, and the module's unit tests:
+
+- `deno check mnist_classification/recorded_evolution.ts` — clean.
+- `deno lint mnist_classification/recorded_evolution.ts` — clean.
+- `deno fmt --check mnist_classification/recorded_evolution.ts` — clean.
+- `deno test --allow-all mnist_classification/` — **71 passed, 0 failed**.
+
+The existing mnist tests still cover the chart-writing path that produces
+`timeline.svg`, confirming the artefact is still generated after the
+constant's removal.
+
+## Test Plan
+
+No new tests were added — this is the deletion of an unused export with no
+behaviour to assert (and per `AGENTS.md` a test that greps for the absence
+of a symbol would be a forbidden "how" test). The change is verified by the
+existing `mnist_classification/` unit suite continuing to pass (71/71),
+which exercises the recorded-evolution chart rendering that writes the
+timeline SVG.

--- a/docs/archive/pr-summaries/pr-summary-628.md
+++ b/docs/archive/pr-summaries/pr-summary-628.md
@@ -1,0 +1,49 @@
+# PR Summary — Issue #628
+
+## Summary
+
+Removed the unused exported constant `MILESTONES_SVG_PATH` (and its JSDoc)
+from `tsp_constructive/tsp_constructive.ts`. Module-graph analysis and a
+repo-wide search confirmed the identifier appeared exactly once — its own
+declaration — with no importer in any `.ts` module and no dynamic reference
+in any `.sh`/`.md`/`.json` file.
+
+The dead constant's value was `docs/screenshots/tsp_constructive/milestones.svg`.
+The caveat in the issue — "confirm no runner writes a milestones SVG via a
+separately-hardcoded literal that should instead reference this constant" —
+was checked and cleared: the runner writes the milestone-stats SVG via a
+**dynamically-constructed** path,
+`docs/screenshots/${EXAMPLE_SLUG}_${instanceName}/milestones.svg`
+(e.g. `tsp_constructive_burma14/milestones.svg`), which differs from the
+stale constant. The sibling artefact constants `EXAMPLE_SLUG` and
+`SCREENSHOT_PATH` are genuinely used and remain exported.
+
+Closes #628
+
+## Evidence
+
+Backend/CLI change — no web interface to screenshot. Verified via tests and
+the existing fast quality gates:
+
+- `deno fmt --check` — clean (2 files).
+- `deno lint tsp_constructive/` — clean (8 files).
+- `deno test --allow-all tsp_constructive/tsp_constructive_test.ts` —
+  9 passed, 0 failed.
+
+```mermaid
+flowchart LR
+    A["MILESTONES_SVG_PATH<br/>(static, unused)"] -.->|deleted| X["removed"]
+    B["runMultiRunTsp"] -->|"join(screenshotsDir,'milestones.svg')"| C["docs/screenshots/&lt;slug&gt;_&lt;instance&gt;/milestones.svg"]
+```
+
+## Test Plan
+
+- Added `tsp_constructive/tsp_constructive_test.ts::public exports — dead
+  MILESTONES_SVG_PATH is gone, used siblings remain` — a "what" test that
+  dynamically imports the module and asserts `MILESTONES_SVG_PATH` is no
+  longer in the export surface, while `EXAMPLE_SLUG` and `SCREENSHOT_PATH`
+  remain. This test failed against the unremoved code and passes after the
+  removal, guarding against re-introduction.
+- The pre-existing test `runMultiRunTsp — persists champion + milestones and
+  writes milestone SVG` continues to pass, confirming the real (dynamic)
+  milestone-SVG path is unaffected.

--- a/mnist_classification/data.ts
+++ b/mnist_classification/data.ts
@@ -14,9 +14,6 @@
  * (rendered into the SVG grid).
  */
 
-import { ensureDir } from "@std/fs";
-import { dirname } from "@std/path";
-
 /** Native side length of an MNIST image. */
 export const IMAGE_SIZE = 28;
 
@@ -228,13 +225,4 @@ export async function readGzippedFile(srcPath: string): Promise<Uint8Array> {
     offset += chunk.length;
   }
   return out;
-}
-
-/**
- * Ensure the parent directory of `path` exists. Used by the runner to
- * make sure intermediate output paths are writable before saving the
- * champion creature or confusion matrix.
- */
-export async function ensureParentDir(path: string): Promise<void> {
-  await ensureDir(dirname(path));
 }

--- a/mnist_classification/exploration_campaign.ts
+++ b/mnist_classification/exploration_campaign.ts
@@ -130,9 +130,6 @@ export const POLISH_MAX_GENERATIONS = 2;
 /** Desired structure-phase generation time on full data (ms). ~1–2 s per gen. */
 export const TARGET_MS_PER_GENERATION = 1500;
 
-/** Generations used when probing full-data speed during calibration. */
-export const CALIBRATION_PROBE_GENERATIONS = 2;
-
 /** Wall-clock budget for the calibration probe (minutes). */
 export const CALIBRATION_PROBE_MINUTES = 2;
 

--- a/mnist_classification/exploration_campaign.ts
+++ b/mnist_classification/exploration_campaign.ts
@@ -497,16 +497,6 @@ export async function appendPhaseRecord(record: ExplorationPhaseRecord): Promise
   );
 }
 
-/** Load the exploration champion, or `undefined` when none exists. */
-export async function loadExplorationChampion(): Promise<CreatureExport | undefined> {
-  try {
-    const text = await Deno.readTextFile(EXPLORATION_CHAMPION_PATH);
-    return JSON.parse(text) as CreatureExport;
-  } catch {
-    return undefined;
-  }
-}
-
 /** Persist the exploration champion (working copy only). */
 export async function saveExplorationChampion(creature: Creature): Promise<void> {
   ensureDirSync(EXPLORATION_ROOT);

--- a/mnist_classification/recorded_evolution.ts
+++ b/mnist_classification/recorded_evolution.ts
@@ -43,9 +43,6 @@ export interface HoldoutScores {
   testAccuracy: number;
 }
 
-/** Timeline chart path — hold-out score vs cumulative wall-clock. */
-export const MULTI_RUN_TIMELINE_SVG_PATH = "docs/screenshots/mnist_classification/timeline.svg";
-
 /** Build a multi-run milestone from one exploration phase. */
 export function phaseResultToMultiRunSample(
   evolveResult: MnistEvolveResult,

--- a/tsp_constructive/tsp_constructive.ts
+++ b/tsp_constructive/tsp_constructive.ts
@@ -144,9 +144,6 @@ export const EXAMPLE_SLUG = "tsp_constructive";
 /** Path to the deterministic champion-tour SVG checked into docs. */
 export const SCREENSHOT_PATH = "docs/screenshots/tsp_constructive.svg";
 
-/** Path to the milestone-stats SVG checked into docs. */
-export const MILESTONES_SVG_PATH = "docs/screenshots/tsp_constructive/milestones.svg";
-
 /** Default `targetError` for a multi-run invocation (issue #322 cadence). */
 export const DEFAULT_MULTI_RUN_TARGET_ERROR = DEFAULT_TARGET_ERROR;
 

--- a/tsp_constructive/tsp_constructive_test.ts
+++ b/tsp_constructive/tsp_constructive_test.ts
@@ -138,6 +138,18 @@ Deno.test(
 );
 
 Deno.test(
+  "public exports — dead MILESTONES_SVG_PATH is gone, used siblings remain",
+  async () => {
+    const mod = await import("./tsp_constructive.ts") as Record<string, unknown>;
+    // The dead constant (issue #628) must not be re-introduced.
+    assertEquals("MILESTONES_SVG_PATH" in mod, false);
+    // The genuinely-used sibling artefact constants stay exported.
+    assertEquals(mod.EXAMPLE_SLUG, "tsp_constructive");
+    assertEquals(typeof mod.SCREENSHOT_PATH, "string");
+  },
+);
+
+Deno.test(
   "runMultiRunTsp — persists champion + milestones and writes milestone SVG",
   async () => {
     const tmp = await Deno.makeTempDir({ prefix: "tsp_constructive_test_" });


### PR DESCRIPTION
## Milestone: clean up

This PR merges the completed milestone branch into Develop.
Closes #643

### Issues addressed
- #628: 🟢 dead-code: unused export `MILESTONES_SVG_PATH` in tsp_constructive/tsp_constructive.ts
- #627: 🟢 dead-code: unused export `MULTI_RUN_TIMELINE_SVG_PATH` in mnist_classification/recorded_evolution.ts
- #626: 🟢 dead-code: unused export `loadExplorationChampion` in mnist_classification/exploration_campaign.ts
- #625: 🟢 dead-code: unused export `CALIBRATION_PROBE_GENERATIONS` in mnist_classification/exploration_campaign.ts
- #624: 🟡 dead-code: unused export `ensureParentDir` in mnist_classification/data.ts

### Review notes
All individual issues were reviewed and merged into the milestone branch via separate PRs.
This final PR consolidates all changes for a comprehensive review before merging to Develop.