### PR TITLE
Push auto-bump/security PRs with ACTIONS_PUSH PAT (#651)

### DIFF
--- a/.github/deno_outdated_workflow_test.ts
+++ b/.github/deno_outdated_workflow_test.ts
@@ -1,4 +1,4 @@
-// Tests for .github/workflows/deno-outdated.yml (Issue #362, #364).
+// Tests for .github/workflows/deno-outdated.yml (Issue #362, #364, #651).
 //
 // The workflow must:
 //  * trigger only on `pull_request` to Develop (no weekly cron — #364);
@@ -7,7 +7,12 @@
 //    automatically (#362) — not just warned about;
 //  * skip the auto-bump for PRs from forks (push would fail without a
 //    privileged token);
-//  * request `contents: write` so the push succeeds.
+//  * request `contents: write` so the push succeeds; and
+//  * check out / push with the org `ACTIONS_PUSH` PAT so the bumped
+//    commit re-triggers the `pull_request` checks automatically instead
+//    of leaving them held in `action_required` (#651). Because the PAT
+//    push is a write-access event, no `workflow_dispatch` re-dispatch and
+//    no `actions: write` are needed — both removed under #651.
 
 import { assert, assertEquals, assertExists } from "@std/assert";
 import { parse } from "@std/yaml";
@@ -61,14 +66,22 @@ Deno.test("deno-outdated workflow — auto-bump job requests contents:write so i
   assertEquals(contents, "write", "auto-bump must have contents: write to push");
 });
 
-Deno.test("deno-outdated workflow — requests actions:write so it can re-dispatch checks after push (#485)", async () => {
+Deno.test("deno-outdated workflow — does NOT request actions:write (re-dispatch removed, #651)", async () => {
+  // Business-logic change (#651): the ACTIONS_PUSH PAT push re-triggers the
+  // `pull_request` checks by itself, so the `workflow_dispatch` re-dispatch
+  // step is gone and the `actions: write` permission it required must not be
+  // granted (principle of least privilege).
   const wf = await loadWorkflow();
   const jobs = wf.jobs as Record<string, Record<string, unknown>>;
   const job = jobs[Object.keys(jobs)[0]];
   const jobPerms = (job.permissions ?? {}) as Record<string, string>;
   const wfPerms = (wf.permissions ?? {}) as Record<string, string>;
   const actions = jobPerms.actions ?? wfPerms.actions;
-  assertEquals(actions, "write", "auto-bump must have actions: write to re-dispatch CI");
+  assertEquals(
+    actions,
+    undefined,
+    "auto-bump no longer re-dispatches CI, so it must not request actions: write (#651)",
+  );
 });
 
 Deno.test("deno-outdated workflow — skips PRs from forks", async () => {
@@ -153,48 +166,56 @@ Deno.test("deno-outdated workflow — auto-bump runs bump-deps.sh and commits th
   assertEquals(sha.length, 40, `actions/checkout must be pinned to a 40-char SHA, got "${sha}"`);
 });
 
-Deno.test("deno-outdated workflow — re-dispatches required checks after a bump push (#485)", async () => {
+Deno.test("deno-outdated workflow — commits both deno.json and deno.lock (#418)", async () => {
   const wf = await loadWorkflow();
   const jobs = wf.jobs as Record<string, Record<string, unknown>>;
   const job = jobs[Object.keys(jobs)[0]];
   const steps = job.steps as Array<Record<string, unknown>>;
 
   const bump = steps.find((s) => s.id === "bump");
-  assertExists(bump, "bump step must expose pushed output via id: bump");
+  assertExists(bump, "bump step must expose the bump logic via id: bump");
   const bumpRun = String(bump.run ?? "");
-  assert(
-    bumpRun.includes('echo "pushed=true"') && bumpRun.includes('echo "pushed=false"'),
-    "bump step must record whether a push occurred",
-  );
   assert(
     bumpRun.includes("git add deno.json deno.lock"),
     "bump step must commit both deno.json and deno.lock (issue #418)",
   );
+});
+
+Deno.test("deno-outdated workflow — does NOT re-dispatch checks (PAT push re-triggers them, #651)", async () => {
+  // Business-logic change (#651): pushing the bump with the ACTIONS_PUSH PAT
+  // is a write-access event, so the `pull_request` checks re-run on the
+  // bumped commit automatically. The old `workflow_dispatch` re-dispatch
+  // workaround (#485) was unreliable (Semgrep/Gitleaks/Dependency Review
+  // failed outside PR context) and is removed.
+  const wf = await loadWorkflow();
+  const jobs = wf.jobs as Record<string, Record<string, unknown>>;
+  const job = jobs[Object.keys(jobs)[0]];
+  const steps = job.steps as Array<Record<string, unknown>>;
 
   const redispatch = steps.find((s) =>
     typeof s.run === "string" && (s.run as string).includes("gh workflow run")
   );
-  assertExists(redispatch, "must re-dispatch required workflows after a bump push");
   assertEquals(
-    redispatch.if,
-    "steps.bump.outputs.pushed == 'true'",
-    "re-dispatch must run only when the bump step pushed",
+    redispatch,
+    undefined,
+    "the re-dispatch step must be removed — the ACTIONS_PUSH push re-triggers checks (#651)",
   );
+});
 
-  const dispatchRun = String(redispatch.run ?? "");
-  for (
-    const wfName of [
-      "quality.yml",
-      "shellcheck.yml",
-      "markdown-lint.yml",
-      "semgrep.yml",
-      "gitleaks.yml",
-      "dependency-review.yml",
-    ]
-  ) {
-    assert(
-      dispatchRun.includes(wfName),
-      `re-dispatch must include ${wfName}`,
-    );
-  }
+Deno.test("deno-outdated workflow — checks out with the ACTIONS_PUSH PAT so the bump re-triggers checks (#651)", async () => {
+  const wf = await loadWorkflow();
+  const jobs = wf.jobs as Record<string, Record<string, unknown>>;
+  const job = jobs[Object.keys(jobs)[0]];
+  const steps = job.steps as Array<Record<string, unknown>>;
+
+  const checkout = steps.find((s) =>
+    typeof s.uses === "string" && (s.uses as string).startsWith("actions/checkout@")
+  );
+  assertExists(checkout, "must check out the PR head");
+  const cwith = checkout.with as Record<string, unknown>;
+  assert(
+    String(cwith.token ?? "").includes("secrets.ACTIONS_PUSH"),
+    `checkout must use the ACTIONS_PUSH PAT so the bumped commit re-triggers ` +
+      `the pull_request checks, got: ${cwith.token}`,
+  );
 });

--- a/.github/workflows/deno-outdated.yml
+++ b/.github/workflows/deno-outdated.yml
@@ -12,15 +12,21 @@
 # pushed back to the PR head branch — so the PR ships with up-to-date
 # dependencies automatically (#362).
 #
-# Pushes via GITHUB_TOKEN do not re-trigger other `pull_request`
-# workflows. After a successful push this job dispatches the required
-# checks via `workflow_dispatch` so branch protection still sees fresh
-# results on the bumped HEAD (#485).
+# The bump commit is checked out and pushed with the org `ACTIONS_PUSH`
+# PAT, not `GITHUB_TOKEN` (#651). A `GITHUB_TOKEN` push is attributed to
+# `github-actions[bot]`, which has no write access, so GitHub held the
+# resulting `pull_request` check runs in `action_required` state awaiting
+# a maintainer's "Approve and run". A PAT push is a write-access event,
+# so the `synchronize` runs of the required checks start automatically.
+# This replaces the old #485 `workflow_dispatch` re-dispatch workaround,
+# which was unreliable — Semgrep, Gitleaks and Dependency Review fail
+# when dispatched outside PR context.
 #
 # There is deliberately no weekly cron: dependency refreshes only
 # happen when a PR is raised, never as scheduled bot noise (#364).
 #
-# Forked PRs are skipped because GITHUB_TOKEN cannot push to a fork.
+# Forked PRs are skipped: the PAT is scoped to this repo and must not
+# push to a fork, so external contributions still require approval.
 
 name: Deno Dependency Auto-Bump
 
@@ -49,7 +55,6 @@ concurrency:
 
 permissions:
   contents: write
-  actions: write
 
 jobs:
   auto-bump:
@@ -75,9 +80,11 @@ jobs:
           # dispatched ref/repository (#603).
           ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-          # GITHUB_TOKEN pushes do not re-trigger other workflows; required
-          # checks are re-dispatched explicitly after a bump push (#485).
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Push with the org ACTIONS_PUSH PAT so the bumped HEAD is a
+          # write-access event and the required checks run automatically
+          # instead of stalling in action_required (#651). checkout
+          # persists this credential, so the later `git push` uses it too.
+          token: ${{ secrets.ACTIONS_PUSH }}
 
       - name: Install Deno
         uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
@@ -106,25 +113,3 @@ jobs:
           # dispatched branch name (#603).
           git push origin HEAD:"${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}"
           echo "pushed=true" >> "$GITHUB_OUTPUT"
-
-      - name: Re-dispatch required checks after bump push
-        if: steps.bump.outputs.pushed == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          # GITHUB_HEAD_REF is empty on workflow_dispatch; fall back to the
-          # dispatched branch name (#603).
-          target_ref="${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}"
-          for wf in \
-            quality.yml \
-            shellcheck.yml \
-            markdown-lint.yml \
-            semgrep.yml \
-            gitleaks.yml \
-            dependency-review.yml
-          do
-            echo "Dispatching ${wf} on ${target_ref}"
-            gh workflow run "${wf}" --ref "${target_ref}" \
-              -f pr_head_ref="${target_ref}"
-          done

--- a/.github/workflows/deno-security-update.yml
+++ b/.github/workflows/deno-security-update.yml
@@ -61,7 +61,12 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: Develop
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Push the advisory branch with the org ACTIONS_PUSH PAT, not
+          # GITHUB_TOKEN (#651): a PAT push is a write-access event, so the
+          # daily security PR's checks run automatically instead of
+          # stalling in action_required. checkout persists this credential
+          # for the later `git push`.
+          token: ${{ secrets.ACTIONS_PUSH }}
 
       - name: Install Deno
         uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
@@ -114,7 +119,9 @@ jobs:
       - name: Open security-update PR
         if: steps.bump.outputs.pushed == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Open the PR with the ACTIONS_PUSH PAT so its checks trigger
+          # automatically — a GITHUB_TOKEN-opened PR does not (#651).
+          GH_TOKEN: ${{ secrets.ACTIONS_PUSH }}
         run: |
           set -euo pipefail
           gh pr create \

--- a/deno_workflow_push_credential_test.ts
+++ b/deno_workflow_push_credential_test.ts
@@ -1,0 +1,113 @@
+import { assert, assertEquals } from "@std/assert";
+import { parse } from "@std/yaml";
+
+/**
+ * Verify the auto-bump and security-update workflows push to PR branches
+ * with the org `ACTIONS_PUSH` PAT rather than `GITHUB_TOKEN` (Issue #651).
+ *
+ * Root cause: a `GITHUB_TOKEN` push is attributed to `github-actions[bot]`,
+ * which has no write access, so GitHub holds the resulting `pull_request`
+ * check runs in `action_required` state until a maintainer clicks
+ * "Approve and run". Pushing with a write-access PAT makes the
+ * `synchronize` runs start automatically, matching the other stSoftwareAU
+ * repos.
+ *
+ * These are "what" tests — the workflow YAML is the deliverable, so they
+ * parse it and assert on its structure rather than grepping source text.
+ */
+
+const OUTDATED_PATH = ".github/workflows/deno-outdated.yml";
+const SECURITY_PATH = ".github/workflows/deno-security-update.yml";
+
+// deno-lint-ignore no-explicit-any
+function readWorkflow(path: string): any {
+  return parse(Deno.readTextFileSync(path));
+}
+
+// deno-lint-ignore no-explicit-any
+function stepByUses(steps: any[], needle: string): any {
+  return steps.find((s) => typeof s.uses === "string" && s.uses.includes(needle));
+}
+
+// deno-lint-ignore no-explicit-any
+function stepByName(steps: any[], needle: string): any {
+  return steps.find((s) => typeof s.name === "string" && s.name.includes(needle));
+}
+
+Deno.test("deno-outdated checks out the PR head with the ACTIONS_PUSH PAT", () => {
+  const wf = readWorkflow(OUTDATED_PATH);
+  const checkout = stepByUses(wf.jobs["auto-bump"].steps, "actions/checkout");
+  assert(checkout, "Expected an actions/checkout step");
+  const token = String(checkout.with.token);
+  assert(
+    token.includes("ACTIONS_PUSH"),
+    `Expected checkout to use the ACTIONS_PUSH PAT, got: ${token}`,
+  );
+  assert(
+    !token.includes("GITHUB_TOKEN"),
+    "Checkout must not fall back to GITHUB_TOKEN — that push is what stalls the checks",
+  );
+});
+
+Deno.test("deno-outdated drops the unreliable re-dispatch workaround", () => {
+  const wf = readWorkflow(OUTDATED_PATH);
+  const steps = wf.jobs["auto-bump"].steps;
+  assertEquals(
+    stepByName(steps, "Re-dispatch required checks"),
+    undefined,
+    "The workflow_dispatch re-dispatch step must be removed — a PAT push triggers checks directly",
+  );
+});
+
+Deno.test("deno-outdated no longer requests actions: write", () => {
+  const wf = readWorkflow(OUTDATED_PATH);
+  const perms = wf.permissions;
+  assertEquals(
+    perms.contents,
+    "write",
+    "Still needs contents: write to push the bump commit",
+  );
+  assert(
+    !("actions" in perms),
+    "actions: write was only needed for the removed re-dispatch step",
+  );
+});
+
+Deno.test("deno-outdated keeps the same-repo fork guard", () => {
+  const wf = readWorkflow(OUTDATED_PATH);
+  const guard = String(wf.jobs["auto-bump"].if);
+  assert(
+    guard.includes("github.event.pull_request.head.repo.full_name == github.repository"),
+    "Fork PRs must stay excluded so external contributions still require approval",
+  );
+});
+
+Deno.test("deno-security-update checks out with the ACTIONS_PUSH PAT", () => {
+  const wf = readWorkflow(SECURITY_PATH);
+  const checkout = stepByUses(wf.jobs["security-update"].steps, "actions/checkout");
+  assert(checkout, "Expected an actions/checkout step");
+  const token = String(checkout.with.token);
+  assert(
+    token.includes("ACTIONS_PUSH"),
+    `Expected checkout to use the ACTIONS_PUSH PAT, got: ${token}`,
+  );
+  assert(
+    !token.includes("GITHUB_TOKEN"),
+    "Checkout must not use GITHUB_TOKEN — the advisory branch push must trigger checks",
+  );
+});
+
+Deno.test("deno-security-update opens its PR with the ACTIONS_PUSH PAT", () => {
+  const wf = readWorkflow(SECURITY_PATH);
+  const prStep = stepByName(wf.jobs["security-update"].steps, "Open security-update PR");
+  assert(prStep, "Expected the Open security-update PR step");
+  const ghToken = String(prStep.env.GH_TOKEN);
+  assert(
+    ghToken.includes("ACTIONS_PUSH"),
+    `Expected gh pr create to authenticate with ACTIONS_PUSH, got: ${ghToken}`,
+  );
+  assert(
+    !ghToken.includes("GITHUB_TOKEN"),
+    "A GITHUB_TOKEN-opened PR does not trigger its own checks",
+  );
+});

--- a/docs/archive/pr-summaries/pr-summary-651.md
+++ b/docs/archive/pr-summaries/pr-summary-651.md
@@ -1,0 +1,73 @@
+# PR Summary — Issue #651
+
+## Summary
+
+CI checks on this repo regularly stalled at "This workflow requires approval
+from a maintainer" and needed a manual **Approve and run**, while other
+stSoftwareAU repos run automatically. Root cause: the `Deno Dependency
+Auto-Bump` and `Deno Security Update` workflows pushed to PR branches with
+`secrets.GITHUB_TOKEN`. A `GITHUB_TOKEN` push is attributed to
+`github-actions[bot]`, which has no write access, so GitHub held the
+resulting `pull_request` check runs in `action_required` state.
+
+The fix switches the automation credential to the org `ACTIONS_PUSH` PAT (a
+write-access identity). A PAT push is a write-access event, so the
+`synchronize` runs of the required checks now start automatically — no manual
+approval. This makes the unreliable `workflow_dispatch` re-dispatch workaround
+(#485) redundant, so it is removed along with its now-unneeded `actions: write`
+permission.
+
+Scope (converged 2026-07-02 on the issue): keep bump-on-every-PR, no weekly
+cron, no org/repo-settings changes; `first_time_contributors` approval stays
+for genuinely external fork contributions.
+
+Closes #651.
+
+### Changes
+
+- `.github/workflows/deno-outdated.yml`
+  - Check out / push with `secrets.ACTIONS_PUSH` instead of
+    `secrets.GITHUB_TOKEN` (checkout persists the credential for the later
+    `git push`).
+  - Delete the `Re-dispatch required checks after bump push` step.
+  - Drop the now-unneeded `actions: write` permission (keep `contents: write`).
+  - Refresh the stale #485 header/step comments.
+  - Keep the same-repo fork guard and the `git diff --quiet` no-change guard.
+- `.github/workflows/deno-security-update.yml`
+  - Check out / push the advisory branch with `secrets.ACTIONS_PUSH`.
+  - Run `gh pr create` with `GH_TOKEN: secrets.ACTIONS_PUSH` so the daily
+    security PR's checks trigger automatically.
+
+## Evidence
+
+Backend/CI change — no web interface to screenshot. Verified via the new
+"what" tests (parse the workflow YAML and assert on structure) and
+`actionlint` (exit 0 on both workflows).
+
+```mermaid
+sequenceDiagram
+    participant W as Auto-Bump workflow
+    participant B as PR head branch
+    participant C as Required checks
+    Note over W,C: Before (GITHUB_TOKEN)
+    W->>B: push bump commit as github-actions[bot]
+    B-->>C: checks held in action_required
+    C-->>C: ⏸ awaiting "Approve and run"
+    Note over W,C: After (ACTIONS_PUSH PAT)
+    W->>B: push bump commit as write-access user
+    B-->>C: synchronize event
+    C-->>C: ▶ checks run automatically
+```
+
+## Test Plan
+
+- Added `deno_workflow_push_credential_test.ts`:
+  - `deno-outdated checks out the PR head with the ACTIONS_PUSH PAT`
+  - `deno-outdated drops the unreliable re-dispatch workaround`
+  - `deno-outdated no longer requests actions: write`
+  - `deno-outdated keeps the same-repo fork guard`
+  - `deno-security-update checks out with the ACTIONS_PUSH PAT`
+  - `deno-security-update opens its PR with the ACTIONS_PUSH PAT`
+- Existing `deno_outdated_override_test.ts` still passes (quarantine override
+  behaviour unchanged).
+- `actionlint` passes on both modified workflows.

--- a/docs/archive/pr-summaries/pr-summary-651.md
+++ b/docs/archive/pr-summaries/pr-summary-651.md
@@ -2,47 +2,43 @@
 
 ## Summary
 
-CI checks on this repo regularly stalled at "This workflow requires approval
-from a maintainer" and needed a manual **Approve and run**, while other
-stSoftwareAU repos run automatically. Root cause: the `Deno Dependency
+CI checks on this repo regularly stalled at "This workflow requires approval from a maintainer" and
+needed a manual **Approve and run**, while other stSoftwareAU repos run automatically. Root cause:
+the `Deno Dependency
 Auto-Bump` and `Deno Security Update` workflows pushed to PR branches with
-`secrets.GITHUB_TOKEN`. A `GITHUB_TOKEN` push is attributed to
-`github-actions[bot]`, which has no write access, so GitHub held the
-resulting `pull_request` check runs in `action_required` state.
+`secrets.GITHUB_TOKEN`. A `GITHUB_TOKEN` push is attributed to `github-actions[bot]`, which has no
+write access, so GitHub held the resulting `pull_request` check runs in `action_required` state.
 
-The fix switches the automation credential to the org `ACTIONS_PUSH` PAT (a
-write-access identity). A PAT push is a write-access event, so the
-`synchronize` runs of the required checks now start automatically — no manual
-approval. This makes the unreliable `workflow_dispatch` re-dispatch workaround
-(#485) redundant, so it is removed along with its now-unneeded `actions: write`
+The fix switches the automation credential to the org `ACTIONS_PUSH` PAT (a write-access identity).
+A PAT push is a write-access event, so the `synchronize` runs of the required checks now start
+automatically — no manual approval. This makes the unreliable `workflow_dispatch` re-dispatch
+workaround (#485) redundant, so it is removed along with its now-unneeded `actions: write`
 permission.
 
-Scope (converged 2026-07-02 on the issue): keep bump-on-every-PR, no weekly
-cron, no org/repo-settings changes; `first_time_contributors` approval stays
-for genuinely external fork contributions.
+Scope (converged 2026-07-02 on the issue): keep bump-on-every-PR, no weekly cron, no
+org/repo-settings changes; `first_time_contributors` approval stays for genuinely external fork
+contributions.
 
 Closes #651.
 
 ### Changes
 
 - `.github/workflows/deno-outdated.yml`
-  - Check out / push with `secrets.ACTIONS_PUSH` instead of
-    `secrets.GITHUB_TOKEN` (checkout persists the credential for the later
-    `git push`).
+  - Check out / push with `secrets.ACTIONS_PUSH` instead of `secrets.GITHUB_TOKEN` (checkout
+    persists the credential for the later `git push`).
   - Delete the `Re-dispatch required checks after bump push` step.
   - Drop the now-unneeded `actions: write` permission (keep `contents: write`).
   - Refresh the stale #485 header/step comments.
   - Keep the same-repo fork guard and the `git diff --quiet` no-change guard.
 - `.github/workflows/deno-security-update.yml`
   - Check out / push the advisory branch with `secrets.ACTIONS_PUSH`.
-  - Run `gh pr create` with `GH_TOKEN: secrets.ACTIONS_PUSH` so the daily
-    security PR's checks trigger automatically.
+  - Run `gh pr create` with `GH_TOKEN: secrets.ACTIONS_PUSH` so the daily security PR's checks
+    trigger automatically.
 
 ## Evidence
 
-Backend/CI change — no web interface to screenshot. Verified via the new
-"what" tests (parse the workflow YAML and assert on structure) and
-`actionlint` (exit 0 on both workflows).
+Backend/CI change — no web interface to screenshot. Verified via the new "what" tests (parse the
+workflow YAML and assert on structure) and `actionlint` (exit 0 on both workflows).
 
 ```mermaid
 sequenceDiagram
@@ -68,6 +64,5 @@ sequenceDiagram
   - `deno-outdated keeps the same-repo fork guard`
   - `deno-security-update checks out with the ACTIONS_PUSH PAT`
   - `deno-security-update opens its PR with the ACTIONS_PUSH PAT`
-- Existing `deno_outdated_override_test.ts` still passes (quarantine override
-  behaviour unchanged).
+- Existing `deno_outdated_override_test.ts` still passes (quarantine override behaviour unchanged).
 - `actionlint` passes on both modified workflows.


### PR DESCRIPTION
# PR Summary — Issue #651

## Summary

CI checks on this repo regularly stalled at "This workflow requires approval from a maintainer" and
needed a manual **Approve and run**, while other stSoftwareAU repos run automatically. Root cause:
the `Deno Dependency
Auto-Bump` and `Deno Security Update` workflows pushed to PR branches with
`secrets.GITHUB_TOKEN`. A `GITHUB_TOKEN` push is attributed to `github-actions[bot]`, which has no
write access, so GitHub held the resulting `pull_request` check runs in `action_required` state.

The fix switches the automation credential to the org `ACTIONS_PUSH` PAT (a write-access identity).
A PAT push is a write-access event, so the `synchronize` runs of the required checks now start
automatically — no manual approval. This makes the unreliable `workflow_dispatch` re-dispatch
workaround (#485) redundant, so it is removed along with its now-unneeded `actions: write`
permission.

Scope (converged 2026-07-02 on the issue): keep bump-on-every-PR, no weekly cron, no
org/repo-settings changes; `first_time_contributors` approval stays for genuinely external fork
contributions.

Closes #651.

### Changes

- `.github/workflows/deno-outdated.yml`
  - Check out / push with `secrets.ACTIONS_PUSH` instead of `secrets.GITHUB_TOKEN` (checkout
    persists the credential for the later `git push`).
  - Delete the `Re-dispatch required checks after bump push` step.
  - Drop the now-unneeded `actions: write` permission (keep `contents: write`).
  - Refresh the stale #485 header/step comments.
  - Keep the same-repo fork guard and the `git diff --quiet` no-change guard.
- `.github/workflows/deno-security-update.yml`
  - Check out / push the advisory branch with `secrets.ACTIONS_PUSH`.
  - Run `gh pr create` with `GH_TOKEN: secrets.ACTIONS_PUSH` so the daily security PR's checks
    trigger automatically.

## Evidence

Backend/CI change — no web interface to screenshot. Verified via the new "what" tests (parse the
workflow YAML and assert on structure) and `actionlint` (exit 0 on both workflows).

```mermaid
sequenceDiagram
    participant W as Auto-Bump workflow
    participant B as PR head branch
    participant C as Required checks
    Note over W,C: Before (GITHUB_TOKEN)
    W->>B: push bump commit as github-actions[bot]
    B-->>C: checks held in action_required
    C-->>C: ⏸ awaiting "Approve and run"
    Note over W,C: After (ACTIONS_PUSH PAT)
    W->>B: push bump commit as write-access user
    B-->>C: synchronize event
    C-->>C: ▶ checks run automatically
```

## Test Plan

- Added `deno_workflow_push_credential_test.ts`:
  - `deno-outdated checks out the PR head with the ACTIONS_PUSH PAT`
  - `deno-outdated drops the unreliable re-dispatch workaround`
  - `deno-outdated no longer requests actions: write`
  - `deno-outdated keeps the same-repo fork guard`
  - `deno-security-update checks out with the ACTIONS_PUSH PAT`
  - `deno-security-update opens its PR with the ACTIONS_PUSH PAT`
- Existing `deno_outdated_override_test.ts` still passes (quarantine override behaviour unchanged).
- `actionlint` passes on both modified workflows.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mr2y6ysf-52710f`<!-- vibe-worker-issue-651 -->