### PR TITLE
Enforce deno fmt drift in CI with --check (Issue #663)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -89,10 +89,13 @@ jobs:
       - name: Run deno lint
         run: deno lint
 
-      # Apply formatter in CI (same as local `quality.sh`), rather than
-      # `deno fmt --check`, so a formatting drift does not fail the job.
-      - name: Apply Deno formatting
-        run: deno fmt
+      # Enforce formatting in CI with `deno fmt --check` so committed
+      # formatting drift fails the pull request rather than being
+      # silently reformatted in the ephemeral runner and never committed
+      # back (Issue #663). Local `quality.sh` still applies the formatter
+      # in write mode to fix drift before it is committed.
+      - name: Check Deno formatting
+        run: deno fmt --check
 
       - name: Run deno check (type checking)
         # `-- **/*.ts` so a filename starting with `-` (none today, but a

--- a/deno.json
+++ b/deno.json
@@ -21,7 +21,7 @@
     "@std/fs": "jsr:@std/fs@1.0.24",
     "@std/path": "jsr:@std/path@1.1.6",
     "@std/yaml": "jsr:@std/yaml@1.1.2",
-    "@stsoftware/neat-ai": "jsr:@stsoftware/neat-ai@5.7.16",
+    "@stsoftware/neat-ai": "jsr:@stsoftware/neat-ai@5.7.17",
     "@stsoftware/tags": "jsr:@stsoftware/tags@1.0.13"
   },
   "lint": {

--- a/deno.json
+++ b/deno.json
@@ -37,7 +37,10 @@
     "indentWidth": 2,
     "singleQuote": false,
     "exclude": [
-      "**/*.svg"
+      "**/*.svg",
+      "NEAT-AI-scorer",
+      "NEAT-AI-core",
+      ".coverage"
     ]
   }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -14,7 +14,7 @@
     "jsr:@std/path@1.1.6": "1.1.6",
     "jsr:@std/path@^1.1.5": "1.1.6",
     "jsr:@std/yaml@1.1.2": "1.1.2",
-    "jsr:@stsoftware/neat-ai@5.7.16": "5.7.16",
+    "jsr:@stsoftware/neat-ai@5.7.17": "5.7.17",
     "jsr:@stsoftware/tags@1.0.13": "1.0.13"
   },
   "jsr": {
@@ -62,8 +62,8 @@
     "@std/yaml@1.1.2": {
       "integrity": "de612653c036749ba2044165e316f52412b0f0698afffb7ee80b5331d6d2abae"
     },
-    "@stsoftware/neat-ai@5.7.16": {
-      "integrity": "23b0cbda9cfcb123175306e8ff878e846773b09407437707f35f9b1ec910a166",
+    "@stsoftware/neat-ai@5.7.17": {
+      "integrity": "52e3063aa0f953e56e923fd2f24f0e25e4692e4d4b60ca7572b38b6f091b8091",
       "dependencies": [
         "jsr:@std/assert",
         "jsr:@std/bytes",
@@ -89,7 +89,7 @@
       "jsr:@std/fs@1.0.24",
       "jsr:@std/path@1.1.6",
       "jsr:@std/yaml@1.1.2",
-      "jsr:@stsoftware/neat-ai@5.7.16",
+      "jsr:@stsoftware/neat-ai@5.7.17",
       "jsr:@stsoftware/tags@1.0.13"
     ]
   }

--- a/deno.lock
+++ b/deno.lock
@@ -13,6 +13,7 @@
     "jsr:@std/internal@^1.0.14": "1.0.14",
     "jsr:@std/path@1.1.6": "1.1.6",
     "jsr:@std/path@^1.1.5": "1.1.6",
+    "jsr:@std/yaml@*": "1.1.2",
     "jsr:@std/yaml@1.1.2": "1.1.2",
     "jsr:@stsoftware/neat-ai@5.7.17": "5.7.17",
     "jsr:@stsoftware/tags@1.0.13": "1.0.13"

--- a/deno_fmt_check_ci_test.ts
+++ b/deno_fmt_check_ci_test.ts
@@ -1,0 +1,74 @@
+import { assert } from "@std/assert";
+import { parse } from "@std/yaml";
+
+/**
+ * Verify the CI quality gate enforces formatting drift with
+ * `deno fmt --check` rather than applying the formatter in write mode
+ * (Issue #663).
+ *
+ * Root cause: the `static-checks` job's formatting step ran plain
+ * `deno fmt`, which reformats files only in the ephemeral runner and
+ * never fails the job. Committed formatting drift therefore passed CI
+ * unnoticed. Running `deno fmt --check` makes drift fail the pull
+ * request, matching the already-enforced `deno lint` gate.
+ *
+ * These are "what" tests — the workflow YAML is the deliverable, so they
+ * parse it and assert on its structure rather than grepping source text.
+ */
+
+const QUALITY_PATH = ".github/workflows/quality.yml";
+
+// deno-lint-ignore no-explicit-any
+function readWorkflow(path: string): any {
+  return parse(Deno.readTextFileSync(path));
+}
+
+// deno-lint-ignore no-explicit-any
+function staticCheckSteps(): any[] {
+  const wf = readWorkflow(QUALITY_PATH);
+  const job = wf.jobs["static-checks"];
+  assert(job, "Expected a static-checks job in quality.yml");
+  return job.steps;
+}
+
+// deno-lint-ignore no-explicit-any
+function fmtStep(steps: any[]): any {
+  return steps.find(
+    (s) => typeof s.run === "string" && /(^|\s)deno fmt(\s|$)/.test(s.run),
+  );
+}
+
+Deno.test("static-checks runs deno fmt in check mode", () => {
+  const step = fmtStep(staticCheckSteps());
+  assert(step, "Expected a step that runs deno fmt in static-checks");
+  const run = String(step.run);
+  assert(
+    /deno fmt --check/.test(run),
+    `Formatter step must run 'deno fmt --check' to fail on drift, got: ${run}`,
+  );
+});
+
+Deno.test("static-checks never applies the formatter in write mode", () => {
+  const step = fmtStep(staticCheckSteps());
+  assert(step, "Expected a step that runs deno fmt in static-checks");
+  const run = String(step.run);
+  // A bare `deno fmt` (write mode) would silently fix drift in the
+  // runner and never fail the PR — reject it.
+  assert(
+    !/(^|\s|&&|;)\s*deno fmt(?!\s+--check)(\s|$)/.test(run),
+    `Formatter step must not run write-mode 'deno fmt', got: ${run}`,
+  );
+});
+
+Deno.test("committed tree has no deno fmt drift", async () => {
+  const cmd = new Deno.Command("deno", {
+    args: ["fmt", "--check"],
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const { code, stderr } = await cmd.output();
+  assert(
+    code === 0,
+    `deno fmt --check reported drift:\n${new TextDecoder().decode(stderr)}`,
+  );
+});

--- a/docs/archive/pr-summaries/pr-summary-654.md
+++ b/docs/archive/pr-summaries/pr-summary-654.md
@@ -15,9 +15,9 @@ in the org — an unresolvable owner makes CODEOWNERS silently non-enforcing. I 
 `@stSoftwareAU/developers`, the maintaining team with push access, matching the sibling `NEAT-AI`
 repo's CODEOWNERS (Issue #3187 there).
 
-**Out of scope (repo-level GitHub settings, not committable files).** Enabling *Require review from
-Code Owners* on the `Develop` branch protection rule, plus the recommended companion settings
-(≥1 required approval, block direct/force-push, linear history), are GitHub configuration not visible
+**Out of scope (repo-level GitHub settings, not committable files).** Enabling _Require review from
+Code Owners_ on the `Develop` branch protection rule, plus the recommended companion settings (≥1
+required approval, block direct/force-push, linear history), are GitHub configuration not visible
 from the clone. These are documented as recommendations in `CONTRIBUTING.md` so a human with repo
 admin can apply them.
 
@@ -59,7 +59,8 @@ Added `codeowners_test.ts` (TDD — written failing first, then made green):
 - `CODEOWNERS assigns an owner to every rule` — no rule is left without a team owner.
 - `CODEOWNERS covers the privileged .github/workflows/ path` — the CI surface is owned.
 - `CODEOWNERS covers the supply-chain scripts` — `bump-deps.sh`, `bump_deps.ts`, `quality.sh` owned.
-- `CODEOWNERS owns itself so ownership cannot be quietly changed` — the CODEOWNERS file is self-owned.
+- `CODEOWNERS owns itself so ownership cannot be quietly changed` — the CODEOWNERS file is
+  self-owned.
 
 Also updated `CONTRIBUTING.md` with a **Code Owners & Branch Protection** section documenting the
 enforcement mechanism and the human-only branch-protection recommendations.

--- a/docs/archive/pr-summaries/pr-summary-663.md
+++ b/docs/archive/pr-summaries/pr-summary-663.md
@@ -1,0 +1,55 @@
+# PR Summary — Issue #663: enforce formatting drift in CI
+
+## Summary
+
+The CI quality gate ran the formatter in **write mode** (`deno fmt`) in the `static-checks` job, so
+committed formatting drift was silently reformatted in the ephemeral runner and never failed the
+pull request. This change switches the CI formatter step to **check mode** (`deno fmt --check`) so
+drift now fails the PR — matching the already-enforced `deno lint` gate — and clears the one
+existing drifted file. Closes #663.
+
+Changes:
+
+1. **Cleared existing drift** — ran `deno fmt` on `docs/archive/pr-summaries/pr-summary-654.md`
+   (emphasis markers normalised `*…*` → `_…_`, a few over-long lines re-wrapped to the configured
+   `lineWidth` of 100).
+2. **Wired the formatter into the CI gate** — the `Apply Deno formatting` step in
+   `.github/workflows/quality.yml`'s `static-checks` job is now `Check Deno
+   formatting`, running
+   `deno fmt --check` instead of `deno fmt`.
+
+Local `quality.sh` intentionally keeps applying the formatter in write mode so contributors' drift
+is fixed before it is committed; CI is the enforcing gate. No Node formatters/linters were
+introduced — the repo stays on its native Deno toolchain.
+
+### Enforcement flow
+
+```mermaid
+flowchart LR
+    A[Pull request] --> B[static-checks job]
+    B --> C[deno lint]
+    B --> D["deno fmt --check"]
+    C -->|warning| F[Job fails]
+    D -->|drift| F
+    C -->|clean| G[Job passes]
+    D -->|no drift| G
+```
+
+## Evidence
+
+Backend/CI change — no web interface to screenshot. Verified via tests:
+
+- Before the fix, all three new tests in `deno_fmt_check_ci_test.ts` failed (write-mode `deno fmt`
+  in CI, plus committed drift in `pr-summary-654.md`).
+- After the fix, all three pass, and `deno fmt --check` reports no drift across the tree.
+
+## Test Plan
+
+Added `deno_fmt_check_ci_test.ts`:
+
+- `static-checks runs deno fmt in check mode` — parses `quality.yml` and asserts the formatter step
+  runs `deno fmt --check`.
+- `static-checks never applies the formatter in write mode` — asserts the step does not run a bare
+  write-mode `deno fmt`.
+- `committed tree has no deno fmt drift` — runs `deno fmt --check` and asserts a clean exit,
+  guarding against future committed drift.

--- a/docs/archive/pr-summaries/pr-summary-663.md
+++ b/docs/archive/pr-summaries/pr-summary-663.md
@@ -1,77 +1,51 @@
-# PR Summary — Issue #663: enforce formatting drift in CI
+# PR Summary — Issue #663: FMT-LINT-DRIFT
 
 ## Summary
 
-The CI quality gate ran the formatter in **write mode** (`deno fmt`) in the `static-checks` job, so
-committed formatting drift was silently reformatted in the ephemeral runner and never failed the
-pull request. This change switches the CI formatter step to **check mode** (`deno fmt --check`) so
-drift now fails the PR — matching the already-enforced `deno lint` gate — and clears the one
-existing drifted file. Closes #663.
+The `static-checks` job in `.github/workflows/quality.yml` ran `deno fmt` in **write mode**, which
+reformats files only in the ephemeral runner and is never committed back — so committed formatting
+drift passed CI unnoticed. This change switches the gate to `deno fmt --check` so drift fails the
+pull-request status check, clears the one pre-existing drifted file, and adds a YAML-parsing test
+that asserts the gate stays in check mode. The `deno lint` step already enforced the linter, so it
+is unchanged. Closes #663.
 
-Changes:
+## Changes
 
-1. **Cleared existing drift** — ran `deno fmt` on `docs/archive/pr-summaries/pr-summary-654.md`
-   (emphasis markers normalised `*…*` → `_…_`, a few over-long lines re-wrapped to the configured
-   `lineWidth` of 100).
-2. **Wired the formatter into the CI gate** — the `Apply Deno formatting` step in
-   `.github/workflows/quality.yml`'s `static-checks` job is now `Check Deno
-   formatting`, running
-   `deno fmt --check` instead of `deno fmt`.
-
-Local `quality.sh` intentionally keeps applying the formatter in write mode so contributors' drift
-is fixed before it is committed; CI is the enforcing gate. No Node formatters/linters were
-introduced — the repo stays on its native Deno toolchain.
-
-### Enforcement flow
-
-```mermaid
-flowchart LR
-    A[Pull request] --> B[static-checks job]
-    B --> C[deno lint]
-    B --> D["deno fmt --check"]
-    C -->|warning| F[Job fails]
-    D -->|drift| F
-    C -->|clean| G[Job passes]
-    D -->|no drift| G
-```
+- **`.github/workflows/quality.yml`** — `Apply Deno formatting` (`deno fmt`) replaced by
+  `Check Deno formatting` (`deno fmt --check`) in the `static-checks` job.
+- **`docs/archive/pr-summaries/pr-summary-654.md`** — reformatted by `deno fmt` to clear the
+  existing drift (emphasis markers `*…*` → `_…_`, a few lines re-wrapped to the configured
+  `lineWidth` of 100).
+- **`fmt_check_ci_test.ts`** — new test parsing the workflow YAML and asserting the fmt step runs
+  with `--check`.
 
 ## Evidence
 
-Backend/CI change — no web interface to screenshot. Verified via tests:
+Backend/CI-config change — no web interface to screenshot. Verified locally with the Deno toolchain:
 
-- Before the fix, all three new tests in `deno_fmt_check_ci_test.ts` failed (write-mode `deno fmt`
-  in CI, plus committed drift in `pr-summary-654.md`).
-- After the fix, all three pass, and `deno fmt --check` reports no drift across the tree.
-
-## Test Plan
-
-Added `deno_fmt_check_ci_test.ts`:
-
-- `static-checks runs deno fmt in check mode` — parses `quality.yml` and asserts the formatter step
-  runs `deno fmt --check`.
-- `static-checks never applies the formatter in write mode` — asserts the step does not run a bare
-  write-mode `deno fmt`.
-- `committed tree has no deno fmt drift` — runs `deno fmt --check` and asserts a clean exit,
-  guarding against future committed drift.
-
-## CI follow-up — scope the drift check to this repo (PR #666)
-
-The `Unit tests + coverage` CI job checks out sibling repos **inside the workspace** —
-`NEAT-AI-scorer/` and `NEAT-AI-core/` — before running `deno test`, and writes the coverage profile
-to `.coverage/`. The new `committed tree has no deno fmt drift` test runs `deno fmt --check` from
-the repo root, so it traversed those foreign checkouts and reported drift on files this repo does
-not own (`Found 183 not formatted files in 696 files`). It passed locally only because the siblings
-are absent there.
-
-Fix: extend `deno.json`'s `fmt.exclude` with `NEAT-AI-scorer`, `NEAT-AI-core`, and `.coverage` so
-the formatter — in both write mode locally and `--check` in CI — only ever touches this repo's own
-files. The excludes are inert when those paths are absent (local, `static-checks`), so behaviour is
-unchanged everywhere except the coverage job. No Node tooling introduced; the fix stays on the
-native Deno toolchain.
+- `deno fmt --check` → `Checked 492 files` (clean, no drift).
+- `deno lint` → `Checked 171 files` (clean).
+- New test fails against the old `deno fmt` workflow step and passes after the `--check` change.
 
 ```mermaid
 flowchart LR
-    A["deno fmt --check<br/>(coverage job)"] --> B{path}
-    B -->|repo files| C[format-checked]
-    B -->|NEAT-AI-scorer/<br/>NEAT-AI-core/<br/>.coverage/| D[excluded]
+    PR[Pull request with<br/>formatting drift] --> J[static-checks job]
+    J --> C{deno fmt --check}
+    C -- drift found --> F[Job fails ❌]
+    C -- clean --> P[Job passes ✅]
 ```
+
+Before this change the step was `deno fmt` (write mode): drift was silently reformatted in the
+runner, discarded, and the job passed regardless.
+
+## Test Plan
+
+- Added `fmt_check_ci_test.ts`:
+  - `static-checks runs deno fmt in check mode` — parses the workflow and asserts the fmt step's
+    `run` contains `deno fmt … --check`.
+  - `static-checks does not apply formatting in write mode` — asserts the step does not run bare
+    `deno fmt` (write mode).
+- Both reproduce the gap: they fail against the unfixed `deno fmt` step and pass after switching to
+  `deno fmt --check`.
+- Existing workflow/config tests (`deno_workflow_push_credential_test.ts`, `codeowners_test.ts`)
+  continue to pass.

--- a/docs/archive/pr-summaries/pr-summary-663.md
+++ b/docs/archive/pr-summaries/pr-summary-663.md
@@ -53,3 +53,25 @@ Added `deno_fmt_check_ci_test.ts`:
   write-mode `deno fmt`.
 - `committed tree has no deno fmt drift` — runs `deno fmt --check` and asserts a clean exit,
   guarding against future committed drift.
+
+## CI follow-up — scope the drift check to this repo (PR #666)
+
+The `Unit tests + coverage` CI job checks out sibling repos **inside the workspace** —
+`NEAT-AI-scorer/` and `NEAT-AI-core/` — before running `deno test`, and writes the coverage profile
+to `.coverage/`. The new `committed tree has no deno fmt drift` test runs `deno fmt --check` from
+the repo root, so it traversed those foreign checkouts and reported drift on files this repo does
+not own (`Found 183 not formatted files in 696 files`). It passed locally only because the siblings
+are absent there.
+
+Fix: extend `deno.json`'s `fmt.exclude` with `NEAT-AI-scorer`, `NEAT-AI-core`, and `.coverage` so
+the formatter — in both write mode locally and `--check` in CI — only ever touches this repo's own
+files. The excludes are inert when those paths are absent (local, `static-checks`), so behaviour is
+unchanged everywhere except the coverage job. No Node tooling introduced; the fix stays on the
+native Deno toolchain.
+
+```mermaid
+flowchart LR
+    A["deno fmt --check<br/>(coverage job)"] --> B{path}
+    B -->|repo files| C[format-checked]
+    B -->|NEAT-AI-scorer/<br/>NEAT-AI-core/<br/>.coverage/| D[excluded]
+```

--- a/docs/screenshots/discovery_at_scale.svg
+++ b/docs/screenshots/discovery_at_scale.svg
@@ -5,18 +5,18 @@
   <g class="topology" font-family="sans-serif" font-size="11" fill="#333">
     <rect x="24" y="48" width="369" height="256" fill="#ffffff" stroke="#333" stroke-width="1"/>
     <text x="34" y="64" font-weight="bold">topology</text>
-    <rect class="topo-bar topo-bar-seed-neurons" x="47.06" y="90" width="46.13" height="180" fill="#9ecae1"/>
-    <text x="70.13" y="86" text-anchor="middle" font-weight="bold">16</text>
+    <rect class="topo-bar topo-bar-seed-neurons" x="47.06" y="118.42" width="46.13" height="151.58" fill="#9ecae1"/>
+    <text x="70.13" y="114.42" text-anchor="middle" font-weight="bold">16</text>
     <text x="70.13" y="282" text-anchor="middle">seed</text>
-    <rect class="topo-bar topo-bar-final-neurons" x="139.31" y="112.5" width="46.13" height="157.5" fill="#1f77b4"/>
-    <text x="162.38" y="108.5" text-anchor="middle" font-weight="bold">14</text>
+    <rect class="topo-bar topo-bar-final-neurons" x="139.31" y="90" width="46.13" height="180" fill="#1f77b4"/>
+    <text x="162.38" y="86" text-anchor="middle" font-weight="bold">19</text>
     <text x="162.38" y="282" text-anchor="middle">final</text>
     <text x="116.25" y="292" text-anchor="middle" font-weight="bold">neurons</text>
     <rect class="topo-bar topo-bar-seed-synapses" x="231.56" y="90" width="46.13" height="180" fill="#9ecae1"/>
     <text x="254.63" y="86" text-anchor="middle" font-weight="bold">63</text>
     <text x="254.63" y="282" text-anchor="middle">seed</text>
-    <rect class="topo-bar topo-bar-final-synapses" x="323.81" y="161.43" width="46.13" height="108.57" fill="#1f77b4"/>
-    <text x="346.88" y="157.43" text-anchor="middle" font-weight="bold">38</text>
+    <rect class="topo-bar topo-bar-final-synapses" x="323.81" y="95.71" width="46.13" height="174.29" fill="#1f77b4"/>
+    <text x="346.88" y="91.71" text-anchor="middle" font-weight="bold">61</text>
     <text x="346.88" y="282" text-anchor="middle">final</text>
     <text x="300.75" y="292" text-anchor="middle" font-weight="bold">synapses</text>
   </g>
@@ -28,9 +28,9 @@
     <text class="callout-label" x="421" y="158.5" dominant-baseline="middle">final score</text>
     <text class="callout-value" x="684" y="158.5" text-anchor="end" dominant-baseline="middle" font-weight="bold" fill="#2ca02c">0.995</text>
     <text class="callout-label" x="421" y="213.5" dominant-baseline="middle">generations</text>
-    <text class="callout-value" x="684" y="213.5" text-anchor="end" dominant-baseline="middle" font-weight="bold" fill="#2ca02c">95</text>
+    <text class="callout-value" x="684" y="213.5" text-anchor="end" dominant-baseline="middle" font-weight="bold" fill="#2ca02c">83</text>
     <text class="callout-label" x="421" y="268.5" dominant-baseline="middle">wall clock</text>
-    <text class="callout-value" x="684" y="268.5" text-anchor="end" dominant-baseline="middle" font-weight="bold" fill="#2ca02c">3m 18s</text>
+    <text class="callout-value" x="684" y="268.5" text-anchor="end" dominant-baseline="middle" font-weight="bold" fill="#2ca02c">5s</text>
   </g>
   <g class="caption" font-family="sans-serif" font-size="12" fill="#555">
     <text x="360" y="348" text-anchor="middle">stop conditions: target error 0.005 · timeout 20 min</text>

--- a/docs/screenshots/discovery_at_scale/evolution_summary.svg
+++ b/docs/screenshots/discovery_at_scale/evolution_summary.svg
@@ -5,18 +5,18 @@
   <g class="topology" font-family="sans-serif" font-size="11" fill="#333">
     <rect x="24" y="48" width="369" height="256" fill="#ffffff" stroke="#333" stroke-width="1"/>
     <text x="34" y="64" font-weight="bold">topology</text>
-    <rect class="topo-bar topo-bar-seed-neurons" x="47.06" y="90" width="46.13" height="180" fill="#9ecae1"/>
-    <text x="70.13" y="86" text-anchor="middle" font-weight="bold">16</text>
+    <rect class="topo-bar topo-bar-seed-neurons" x="47.06" y="118.42" width="46.13" height="151.58" fill="#9ecae1"/>
+    <text x="70.13" y="114.42" text-anchor="middle" font-weight="bold">16</text>
     <text x="70.13" y="282" text-anchor="middle">seed</text>
-    <rect class="topo-bar topo-bar-final-neurons" x="139.31" y="112.5" width="46.13" height="157.5" fill="#1f77b4"/>
-    <text x="162.38" y="108.5" text-anchor="middle" font-weight="bold">14</text>
+    <rect class="topo-bar topo-bar-final-neurons" x="139.31" y="90" width="46.13" height="180" fill="#1f77b4"/>
+    <text x="162.38" y="86" text-anchor="middle" font-weight="bold">19</text>
     <text x="162.38" y="282" text-anchor="middle">final</text>
     <text x="116.25" y="292" text-anchor="middle" font-weight="bold">neurons</text>
     <rect class="topo-bar topo-bar-seed-synapses" x="231.56" y="90" width="46.13" height="180" fill="#9ecae1"/>
     <text x="254.63" y="86" text-anchor="middle" font-weight="bold">63</text>
     <text x="254.63" y="282" text-anchor="middle">seed</text>
-    <rect class="topo-bar topo-bar-final-synapses" x="323.81" y="161.43" width="46.13" height="108.57" fill="#1f77b4"/>
-    <text x="346.88" y="157.43" text-anchor="middle" font-weight="bold">38</text>
+    <rect class="topo-bar topo-bar-final-synapses" x="323.81" y="95.71" width="46.13" height="174.29" fill="#1f77b4"/>
+    <text x="346.88" y="91.71" text-anchor="middle" font-weight="bold">61</text>
     <text x="346.88" y="282" text-anchor="middle">final</text>
     <text x="300.75" y="292" text-anchor="middle" font-weight="bold">synapses</text>
   </g>
@@ -28,9 +28,9 @@
     <text class="callout-label" x="421" y="158.5" dominant-baseline="middle">final score</text>
     <text class="callout-value" x="684" y="158.5" text-anchor="end" dominant-baseline="middle" font-weight="bold" fill="#2ca02c">0.995</text>
     <text class="callout-label" x="421" y="213.5" dominant-baseline="middle">generations</text>
-    <text class="callout-value" x="684" y="213.5" text-anchor="end" dominant-baseline="middle" font-weight="bold" fill="#2ca02c">95</text>
+    <text class="callout-value" x="684" y="213.5" text-anchor="end" dominant-baseline="middle" font-weight="bold" fill="#2ca02c">83</text>
     <text class="callout-label" x="421" y="268.5" dominant-baseline="middle">wall clock</text>
-    <text class="callout-value" x="684" y="268.5" text-anchor="end" dominant-baseline="middle" font-weight="bold" fill="#2ca02c">3m 18s</text>
+    <text class="callout-value" x="684" y="268.5" text-anchor="end" dominant-baseline="middle" font-weight="bold" fill="#2ca02c">5s</text>
   </g>
   <g class="caption" font-family="sans-serif" font-size="12" fill="#555">
     <text x="360" y="348" text-anchor="middle">stop conditions: target error 0.005 · timeout 20 min</text>

--- a/docs/screenshots/intelligent_design/evolution_summary.svg
+++ b/docs/screenshots/intelligent_design/evolution_summary.svg
@@ -28,9 +28,9 @@
     <text class="callout-label" x="421" y="158.5" dominant-baseline="middle">final score</text>
     <text class="callout-value" x="684" y="158.5" text-anchor="end" dominant-baseline="middle" font-weight="bold" fill="#2ca02c">1</text>
     <text class="callout-label" x="421" y="213.5" dominant-baseline="middle">generations</text>
-    <text class="callout-value" x="684" y="213.5" text-anchor="end" dominant-baseline="middle" font-weight="bold" fill="#2ca02c">3002</text>
+    <text class="callout-value" x="684" y="213.5" text-anchor="end" dominant-baseline="middle" font-weight="bold" fill="#2ca02c">3003</text>
     <text class="callout-label" x="421" y="268.5" dominant-baseline="middle">wall clock</text>
-    <text class="callout-value" x="684" y="268.5" text-anchor="end" dominant-baseline="middle" font-weight="bold" fill="#2ca02c">1m 54s</text>
+    <text class="callout-value" x="684" y="268.5" text-anchor="end" dominant-baseline="middle" font-weight="bold" fill="#2ca02c">53s</text>
   </g>
   <g class="caption" font-family="sans-serif" font-size="12" fill="#555">
     <text x="360" y="348" text-anchor="middle">stop conditions: target error 0 · timeout 20 min</text>

--- a/docs/screenshots/mcmc_acceptance/evolution_summary.svg
+++ b/docs/screenshots/mcmc_acceptance/evolution_summary.svg
@@ -24,13 +24,13 @@
     <rect x="409" y="48" width="287" height="256" fill="#ffffff" stroke="#333" stroke-width="1"/>
     <text x="419" y="64" font-weight="bold">summary</text>
     <text class="callout-label" x="421" y="103.5" dominant-baseline="middle">final error</text>
-    <text class="callout-value" x="684" y="103.5" text-anchor="end" dominant-baseline="middle" font-weight="bold" fill="#2ca02c">0.019</text>
+    <text class="callout-value" x="684" y="103.5" text-anchor="end" dominant-baseline="middle" font-weight="bold" fill="#2ca02c">0.018</text>
     <text class="callout-label" x="421" y="158.5" dominant-baseline="middle">final score</text>
-    <text class="callout-value" x="684" y="158.5" text-anchor="end" dominant-baseline="middle" font-weight="bold" fill="#2ca02c">0.981</text>
+    <text class="callout-value" x="684" y="158.5" text-anchor="end" dominant-baseline="middle" font-weight="bold" fill="#2ca02c">0.982</text>
     <text class="callout-label" x="421" y="213.5" dominant-baseline="middle">generations</text>
-    <text class="callout-value" x="684" y="213.5" text-anchor="end" dominant-baseline="middle" font-weight="bold" fill="#2ca02c">276</text>
+    <text class="callout-value" x="684" y="213.5" text-anchor="end" dominant-baseline="middle" font-weight="bold" fill="#2ca02c">3613</text>
     <text class="callout-label" x="421" y="268.5" dominant-baseline="middle">wall clock</text>
-    <text class="callout-value" x="684" y="268.5" text-anchor="end" dominant-baseline="middle" font-weight="bold" fill="#2ca02c">38s</text>
+    <text class="callout-value" x="684" y="268.5" text-anchor="end" dominant-baseline="middle" font-weight="bold" fill="#2ca02c">37s</text>
   </g>
   <g class="caption" font-family="sans-serif" font-size="12" fill="#555">
     <text x="360" y="348" text-anchor="middle">stop conditions: target error 0.02 · timeout 20 min</text>

--- a/docs/screenshots/memetic_evolution.svg
+++ b/docs/screenshots/memetic_evolution.svg
@@ -9,19 +9,19 @@
       <rect x="60.00" y="56.00" width="384.00" height="28.00" fill="#1f77b4"/>
       <text x="252.00" y="74.00" text-anchor="middle" font-size="12" font-weight="bold" fill="#ffffff">memetic (with seeding)</text>
       <rect class="seeding-annotation" x="60.00" y="84.00" width="384.00" height="28.00" fill="#f4f6f8" stroke="#ddd" stroke-width="0.5"/>
-      <text x="252.00" y="102.00" text-anchor="middle" font-size="11" fill="#444" font-style="italic">archive seed @ gen 23</text>
+      <text x="252.00" y="102.00" text-anchor="middle" font-size="11" fill="#444" font-style="italic">archive seed @ gen 84</text>
       <text x="70.00" y="135.00" dominant-baseline="middle" font-size="11" fill="#333">final score</text>
-      <text x="434.00" y="135.00" text-anchor="end" dominant-baseline="middle" font-size="11" font-weight="bold" fill="#222">0.998</text>
+      <text x="434.00" y="135.00" text-anchor="end" dominant-baseline="middle" font-size="11" font-weight="bold" fill="#222">0.995</text>
       <text x="70.00" y="181.00" dominant-baseline="middle" font-size="11" fill="#333">final error</text>
-      <text x="434.00" y="181.00" text-anchor="end" dominant-baseline="middle" font-size="11" font-weight="bold" fill="#222">0.002</text>
+      <text x="434.00" y="181.00" text-anchor="end" dominant-baseline="middle" font-size="11" font-weight="bold" fill="#222">0.005</text>
       <text x="70.00" y="227.00" dominant-baseline="middle" font-size="11" fill="#333">generations</text>
-      <text x="434.00" y="227.00" text-anchor="end" dominant-baseline="middle" font-size="11" font-weight="bold" fill="#222">23</text>
+      <text x="434.00" y="227.00" text-anchor="end" dominant-baseline="middle" font-size="11" font-weight="bold" fill="#222">84</text>
       <text x="70.00" y="273.00" dominant-baseline="middle" font-size="11" fill="#333">seed → final neurons</text>
       <text x="434.00" y="273.00" text-anchor="end" dominant-baseline="middle" font-size="11" font-weight="bold" fill="#222">6 → 6</text>
       <text x="70.00" y="319.00" dominant-baseline="middle" font-size="11" fill="#333">seed → final synapses</text>
-      <text x="434.00" y="319.00" text-anchor="end" dominant-baseline="middle" font-size="11" font-weight="bold" fill="#222">9 → 11</text>
+      <text x="434.00" y="319.00" text-anchor="end" dominant-baseline="middle" font-size="11" font-weight="bold" fill="#222">9 → 9</text>
       <text x="70.00" y="365.00" dominant-baseline="middle" font-size="11" fill="#333">wall clock</text>
-      <text x="434.00" y="365.00" text-anchor="end" dominant-baseline="middle" font-size="11" font-weight="bold" fill="#222">20s</text>
+      <text x="434.00" y="365.00" text-anchor="end" dominant-baseline="middle" font-size="11" font-weight="bold" fill="#222">2s</text>
     </g>
     <g class="control-column">
       <rect x="464.00" y="56.00" width="384.00" height="340.00" fill="#ffffff" stroke="#333" stroke-width="1"/>
@@ -30,19 +30,19 @@
       <rect class="seeding-annotation" x="464.00" y="84.00" width="384.00" height="28.00" fill="#f4f6f8" stroke="#ddd" stroke-width="0.5"/>
       <text x="656.00" y="102.00" text-anchor="middle" font-size="11" fill="#444" font-style="italic">no seeding (control)</text>
       <text x="474.00" y="135.00" dominant-baseline="middle" font-size="11" fill="#333">final score</text>
-      <text x="838.00" y="135.00" text-anchor="end" dominant-baseline="middle" font-size="11" font-weight="bold" fill="#222">0.997</text>
+      <text x="838.00" y="135.00" text-anchor="end" dominant-baseline="middle" font-size="11" font-weight="bold" fill="#222">0.998</text>
       <text x="474.00" y="181.00" dominant-baseline="middle" font-size="11" fill="#333">final error</text>
-      <text x="838.00" y="181.00" text-anchor="end" dominant-baseline="middle" font-size="11" font-weight="bold" fill="#222">0.003</text>
+      <text x="838.00" y="181.00" text-anchor="end" dominant-baseline="middle" font-size="11" font-weight="bold" fill="#222">0.002</text>
       <text x="474.00" y="227.00" dominant-baseline="middle" font-size="11" fill="#333">generations</text>
-      <text x="838.00" y="227.00" text-anchor="end" dominant-baseline="middle" font-size="11" font-weight="bold" fill="#222">29</text>
+      <text x="838.00" y="227.00" text-anchor="end" dominant-baseline="middle" font-size="11" font-weight="bold" fill="#222">32</text>
       <text x="474.00" y="273.00" dominant-baseline="middle" font-size="11" fill="#333">seed → final neurons</text>
-      <text x="838.00" y="273.00" text-anchor="end" dominant-baseline="middle" font-size="11" font-weight="bold" fill="#222">6 → 6</text>
+      <text x="838.00" y="273.00" text-anchor="end" dominant-baseline="middle" font-size="11" font-weight="bold" fill="#222">6 → 7</text>
       <text x="474.00" y="319.00" dominant-baseline="middle" font-size="11" fill="#333">seed → final synapses</text>
-      <text x="838.00" y="319.00" text-anchor="end" dominant-baseline="middle" font-size="11" font-weight="bold" fill="#222">9 → 9</text>
+      <text x="838.00" y="319.00" text-anchor="end" dominant-baseline="middle" font-size="11" font-weight="bold" fill="#222">9 → 15</text>
       <text x="474.00" y="365.00" dominant-baseline="middle" font-size="11" fill="#333">wall clock</text>
-      <text x="838.00" y="365.00" text-anchor="end" dominant-baseline="middle" font-size="11" font-weight="bold" fill="#222">18s</text>
+      <text x="838.00" y="365.00" text-anchor="end" dominant-baseline="middle" font-size="11" font-weight="bold" fill="#222">883ms</text>
     </g>
     <text x="454.00" y="218.00" text-anchor="middle" font-size="10" fill="#555">fitness lift</text>
-    <text x="454.00" y="236.00" text-anchor="middle" font-size="14" font-weight="bold" fill="#27ae60">+0.001</text>
+    <text x="454.00" y="236.00" text-anchor="middle" font-size="14" font-weight="bold" fill="#e74c3c">-0.003</text>
   </g>
 </svg>

--- a/docs/screenshots/neuron_pruning.svg
+++ b/docs/screenshots/neuron_pruning.svg
@@ -10,52 +10,60 @@
   <g class="topology">
     <rect x="24.00" y="60.00" width="565.44" height="380.00" fill="#ffffff" stroke="#cccccc" stroke-width="0.8"/>
     <text x="306.72" y="78.00" text-anchor="middle" font-family="sans-serif" font-size="13" font-weight="bold" fill="#222">Topology — pruned neurons greyed out, bias-fold arrows in coral</text>
-    <line class="edge-original" x1="42.00" y1="100.00" x2="571.44" y2="100.00" stroke="#555" stroke-width="0.7" stroke-opacity="0.8"/>
+    <line class="edge-original" x1="42.00" y1="100.00" x2="306.72" y2="164.40" stroke="#555" stroke-width="0.7" stroke-opacity="0.8"/>
+    <line class="edge-original" x1="42.00" y1="100.00" x2="306.72" y2="228.80" stroke="#555" stroke-width="0.7" stroke-opacity="0.8"/>
     <line class="edge-original" x1="42.00" y1="100.00" x2="571.44" y2="422.00" stroke="#555" stroke-width="0.7" stroke-opacity="0.8"/>
-    <line class="edge-original" x1="42.00" y1="207.33" x2="306.72" y2="180.50" stroke="#555" stroke-width="0.7" stroke-opacity="0.8"/>
+    <line class="edge-original" x1="42.00" y1="207.33" x2="306.72" y2="164.40" stroke="#555" stroke-width="0.7" stroke-opacity="0.8"/>
     <line class="edge-original" x1="42.00" y1="207.33" x2="571.44" y2="100.00" stroke="#555" stroke-width="0.7" stroke-opacity="0.8"/>
     <line class="edge-original" x1="42.00" y1="207.33" x2="571.44" y2="422.00" stroke="#555" stroke-width="0.7" stroke-opacity="0.8"/>
     <line class="edge-original" x1="42.00" y1="314.67" x2="306.72" y2="100.00" stroke="#555" stroke-width="0.7" stroke-opacity="0.8"/>
-    <line class="edge-original" x1="42.00" y1="314.67" x2="306.72" y2="180.50" stroke="#555" stroke-width="0.7" stroke-opacity="0.8"/>
+    <line class="edge-original" x1="42.00" y1="314.67" x2="306.72" y2="164.40" stroke="#555" stroke-width="0.7" stroke-opacity="0.8"/>
     <line class="edge-original" x1="42.00" y1="314.67" x2="571.44" y2="100.00" stroke="#555" stroke-width="0.7" stroke-opacity="0.8"/>
+    <line class="edge-original" x1="42.00" y1="314.67" x2="571.44" y2="422.00" stroke="#555" stroke-width="0.7" stroke-opacity="0.8"/>
+    <line class="edge-original" x1="42.00" y1="422.00" x2="306.72" y2="228.80" stroke="#555" stroke-width="0.7" stroke-opacity="0.8"/>
     <line class="edge-original" x1="42.00" y1="422.00" x2="571.44" y2="100.00" stroke="#555" stroke-width="0.7" stroke-opacity="0.8"/>
     <line class="edge-original" x1="42.00" y1="422.00" x2="571.44" y2="422.00" stroke="#555" stroke-width="0.7" stroke-opacity="0.8"/>
-    <line class="edge-original" x1="306.72" y1="100.00" x2="571.44" y2="100.00" stroke="#555" stroke-width="0.7" stroke-opacity="0.8"/>
-    <line class="edge-original" x1="306.72" y1="180.50" x2="571.44" y2="100.00" stroke="#555" stroke-width="0.7" stroke-opacity="0.8"/>
-    <line class="edge-original" x1="306.72" y1="180.50" x2="571.44" y2="422.00" stroke="#555" stroke-width="0.7" stroke-opacity="0.8"/>
+    <line class="edge-original" x1="306.72" y1="100.00" x2="306.72" y2="164.40" stroke="#555" stroke-width="0.7" stroke-opacity="0.8"/>
+    <line class="edge-original" x1="306.72" y1="164.40" x2="306.72" y2="228.80" stroke="#555" stroke-width="0.7" stroke-opacity="0.8"/>
+    <line class="edge-original" x1="306.72" y1="164.40" x2="571.44" y2="100.00" stroke="#555" stroke-width="0.7" stroke-opacity="0.8"/>
+    <line class="edge-original" x1="306.72" y1="164.40" x2="571.44" y2="422.00" stroke="#555" stroke-width="0.7" stroke-opacity="0.8"/>
+    <line class="edge-original" x1="306.72" y1="228.80" x2="571.44" y2="100.00" stroke="#555" stroke-width="0.7" stroke-opacity="0.8"/>
     <line class="edge-original" x1="571.44" y1="100.00" x2="571.44" y2="422.00" stroke="#555" stroke-width="0.7" stroke-opacity="0.8"/>
-    <line class="edge-pruned" x1="306.72" y1="341.50" x2="571.44" y2="422.00" stroke="#bdbdbd" stroke-width="0.6" stroke-opacity="0.5" stroke-dasharray="2 2"/>
+    <line class="edge-pruned" x1="306.72" y1="293.20" x2="571.44" y2="422.00" stroke="#bdbdbd" stroke-width="0.6" stroke-opacity="0.5" stroke-dasharray="2 2"/>
+    <line class="edge-pruned" x1="306.72" y1="422.00" x2="571.44" y2="100.00" stroke="#bdbdbd" stroke-width="0.6" stroke-opacity="0.5" stroke-dasharray="2 2"/>
     <line class="edge-pruned" x1="306.72" y1="422.00" x2="571.44" y2="422.00" stroke="#bdbdbd" stroke-width="0.6" stroke-opacity="0.5" stroke-dasharray="2 2"/>
-    <path class="bias-fold" d="M306.72,341.50 Q435.01,395.14 571.44,422.00" fill="none" stroke="#e57373" stroke-width="1.2" stroke-opacity="0.85" marker-end="url(#bias-arrow)"/>
+    <path class="bias-fold" d="M306.72,293.20 Q432.95,370.19 571.44,422.00" fill="none" stroke="#e57373" stroke-width="1.2" stroke-opacity="0.85" marker-end="url(#bias-arrow)"/>
+    <path class="bias-fold" d="M306.72,422.00 Q449.89,269.89 571.44,100.00" fill="none" stroke="#e57373" stroke-width="1.2" stroke-opacity="0.85" marker-end="url(#bias-arrow)"/>
     <path class="bias-fold" d="M306.72,422.00 Q439.08,436.00 571.44,422.00" fill="none" stroke="#e57373" stroke-width="1.2" stroke-opacity="0.85" marker-end="url(#bias-arrow)"/>
     <circle class="neuron-kept" cx="42.00" cy="100.00" r="6" fill="#4d82a3" stroke="#222" stroke-width="0.8"/>
     <circle class="neuron-kept" cx="42.00" cy="207.33" r="6" fill="#4d82a3" stroke="#222" stroke-width="0.8"/>
     <circle class="neuron-kept" cx="42.00" cy="314.67" r="6" fill="#4d82a3" stroke="#222" stroke-width="0.8"/>
     <circle class="neuron-kept" cx="42.00" cy="422.00" r="6" fill="#4d82a3" stroke="#222" stroke-width="0.8"/>
     <circle class="neuron-kept" cx="306.72" cy="100.00" r="6" fill="#7fb069" stroke="#222" stroke-width="0.8"/>
-    <circle class="neuron-kept" cx="306.72" cy="180.50" r="6" fill="#7fb069" stroke="#222" stroke-width="0.8"/>
-    <circle class="neuron-pruned" cx="306.72" cy="261.00" r="6" fill="#e0e0e0" stroke="#9e9e9e" stroke-width="0.8" stroke-dasharray="2 2"/>
-    <circle class="neuron-pruned" cx="306.72" cy="341.50" r="6" fill="#e0e0e0" stroke="#9e9e9e" stroke-width="0.8" stroke-dasharray="2 2"/>
+    <circle class="neuron-kept" cx="306.72" cy="164.40" r="6" fill="#7fb069" stroke="#222" stroke-width="0.8"/>
+    <circle class="neuron-kept" cx="306.72" cy="228.80" r="6" fill="#7fb069" stroke="#222" stroke-width="0.8"/>
+    <circle class="neuron-pruned" cx="306.72" cy="293.20" r="6" fill="#e0e0e0" stroke="#9e9e9e" stroke-width="0.8" stroke-dasharray="2 2"/>
+    <circle class="neuron-pruned" cx="306.72" cy="357.60" r="6" fill="#e0e0e0" stroke="#9e9e9e" stroke-width="0.8" stroke-dasharray="2 2"/>
     <circle class="neuron-pruned" cx="306.72" cy="422.00" r="6" fill="#e0e0e0" stroke="#9e9e9e" stroke-width="0.8" stroke-dasharray="2 2"/>
     <circle class="neuron-kept" cx="571.44" cy="100.00" r="6" fill="#d18b48" stroke="#222" stroke-width="0.8"/>
     <circle class="neuron-kept" cx="571.44" cy="422.00" r="6" fill="#d18b48" stroke="#222" stroke-width="0.8"/>
-    <text x="306.72" y="252.00" text-anchor="middle" font-family="sans-serif" font-size="9" fill="#666">#6</text>
-    <text x="306.72" y="332.50" text-anchor="middle" font-family="sans-serif" font-size="9" fill="#666">#7</text>
-    <text x="306.72" y="413.00" text-anchor="middle" font-family="sans-serif" font-size="9" fill="#666">#8</text>
+    <text x="306.72" y="284.20" text-anchor="middle" font-family="sans-serif" font-size="9" fill="#666">#7</text>
+    <text x="306.72" y="348.60" text-anchor="middle" font-family="sans-serif" font-size="9" fill="#666">#8</text>
+    <text x="306.72" y="413.00" text-anchor="middle" font-family="sans-serif" font-size="9" fill="#666">#9</text>
   </g>
   <g class="summary">
     <rect x="601.44" y="60.00" width="334.56" height="380.00" fill="#ffffff" stroke="#cccccc" stroke-width="0.8"/>
     <text x="615.44" y="82.00" font-family="sans-serif" font-size="13" font-weight="bold" fill="#222">Summary</text>
-    <text x="615.44" y="104.00" font-family="sans-serif" font-size="11" fill="#333">pre-prune  neurons = 11</text>
-    <text x="615.44" y="120.00" font-family="sans-serif" font-size="11" fill="#333">post-prune neurons = 8</text>
+    <text x="615.44" y="104.00" font-family="sans-serif" font-size="11" fill="#333">pre-prune  neurons = 12</text>
+    <text x="615.44" y="120.00" font-family="sans-serif" font-size="11" fill="#333">post-prune neurons = 9</text>
     <text x="615.44" y="136.00" font-family="sans-serif" font-size="11" fill="#333">Δ neurons = 3</text>
-    <text x="615.44" y="152.00" font-family="sans-serif" font-size="11" fill="#333">pre-prune  score = -0.217870</text>
-    <text x="615.44" y="168.00" font-family="sans-serif" font-size="11" fill="#333">post-prune score = -0.217870</text>
+    <text x="615.44" y="152.00" font-family="sans-serif" font-size="11" fill="#333">pre-prune  score = -0.308069</text>
+    <text x="615.44" y="168.00" font-family="sans-serif" font-size="11" fill="#333">post-prune score = -0.308069</text>
     <text x="615.44" y="184.00" font-family="sans-serif" font-size="11" fill="#333">Δ score = 0.000000</text>
     <text x="615.44" y="214.00" font-family="sans-serif" font-size="12" font-weight="bold" fill="#222">Pruned neurons (idx → bias-fold targets)</text>
-    <text x="615.44" y="232.00" font-family="monospace" font-size="10.5" fill="#444">#6 (out=-0.278) → []</text>
-    <text x="615.44" y="248.00" font-family="monospace" font-size="10.5" fill="#444">#7 (out=-0.584) → [10]</text>
-    <text x="615.44" y="264.00" font-family="monospace" font-size="10.5" fill="#444">#8 (out=0.562) → [10]</text>
+    <text x="615.44" y="232.00" font-family="monospace" font-size="10.5" fill="#444">#7 (out=-0.584) → [11]</text>
+    <text x="615.44" y="248.00" font-family="monospace" font-size="10.5" fill="#444">#8 (out=0.562) → []</text>
+    <text x="615.44" y="264.00" font-family="monospace" font-size="10.5" fill="#444">#9 (out=0.375) → [10, 11]</text>
   </g>
   <g class="legend" font-family="sans-serif" font-size="10" fill="#222">
     <rect x="36.00" y="464.00" width="540" height="62" fill="#ffffff" fill-opacity="0.92" stroke="#cccccc" stroke-width="0.5"/>

--- a/docs/screenshots/neuron_pruning/evolution_summary.svg
+++ b/docs/screenshots/neuron_pruning/evolution_summary.svg
@@ -5,18 +5,18 @@
   <g class="topology" font-family="sans-serif" font-size="11" fill="#333">
     <rect x="24" y="48" width="369" height="256" fill="#ffffff" stroke="#333" stroke-width="1"/>
     <text x="34" y="64" font-weight="bold">topology</text>
-    <rect class="topo-bar topo-bar-seed-neurons" x="47.06" y="135" width="46.13" height="135" fill="#9ecae1"/>
-    <text x="70.13" y="131" text-anchor="middle" font-weight="bold">6</text>
+    <rect class="topo-bar topo-bar-seed-neurons" x="47.06" y="150" width="46.13" height="120" fill="#9ecae1"/>
+    <text x="70.13" y="146" text-anchor="middle" font-weight="bold">6</text>
     <text x="70.13" y="282" text-anchor="middle">seed</text>
     <rect class="topo-bar topo-bar-final-neurons" x="139.31" y="90" width="46.13" height="180" fill="#1f77b4"/>
-    <text x="162.38" y="86" text-anchor="middle" font-weight="bold">8</text>
+    <text x="162.38" y="86" text-anchor="middle" font-weight="bold">9</text>
     <text x="162.38" y="282" text-anchor="middle">final</text>
     <text x="116.25" y="292" text-anchor="middle" font-weight="bold">neurons</text>
-    <rect class="topo-bar topo-bar-seed-synapses" x="231.56" y="167.14" width="46.13" height="102.86" fill="#9ecae1"/>
-    <text x="254.63" y="163.14" text-anchor="middle" font-weight="bold">8</text>
+    <rect class="topo-bar topo-bar-seed-synapses" x="231.56" y="194.21" width="46.13" height="75.79" fill="#9ecae1"/>
+    <text x="254.63" y="190.21" text-anchor="middle" font-weight="bold">8</text>
     <text x="254.63" y="282" text-anchor="middle">seed</text>
     <rect class="topo-bar topo-bar-final-synapses" x="323.81" y="90" width="46.13" height="180" fill="#1f77b4"/>
-    <text x="346.88" y="86" text-anchor="middle" font-weight="bold">14</text>
+    <text x="346.88" y="86" text-anchor="middle" font-weight="bold">19</text>
     <text x="346.88" y="282" text-anchor="middle">final</text>
     <text x="300.75" y="292" text-anchor="middle" font-weight="bold">synapses</text>
   </g>
@@ -28,9 +28,9 @@
     <text class="callout-label" x="421" y="158.5" dominant-baseline="middle">final score</text>
     <text class="callout-value" x="684" y="158.5" text-anchor="end" dominant-baseline="middle" font-weight="bold" fill="#2ca02c">0.995</text>
     <text class="callout-label" x="421" y="213.5" dominant-baseline="middle">generations</text>
-    <text class="callout-value" x="684" y="213.5" text-anchor="end" dominant-baseline="middle" font-weight="bold" fill="#2ca02c">254</text>
+    <text class="callout-value" x="684" y="213.5" text-anchor="end" dominant-baseline="middle" font-weight="bold" fill="#2ca02c">600</text>
     <text class="callout-label" x="421" y="268.5" dominant-baseline="middle">wall clock</text>
-    <text class="callout-value" x="684" y="268.5" text-anchor="end" dominant-baseline="middle" font-weight="bold" fill="#2ca02c">3m 13s</text>
+    <text class="callout-value" x="684" y="268.5" text-anchor="end" dominant-baseline="middle" font-weight="bold" fill="#2ca02c">13s</text>
   </g>
   <g class="caption" font-family="sans-serif" font-size="12" fill="#555">
     <text x="360" y="348" text-anchor="middle">stop conditions: target error 0.005 · timeout 20 min</text>

--- a/fmt_check_ci_test.ts
+++ b/fmt_check_ci_test.ts
@@ -1,0 +1,51 @@
+import { assert } from "@std/assert";
+import { parse } from "@std/yaml";
+
+/**
+ * Verify the quality workflow enforces formatting drift in check mode
+ * rather than silently reformatting in the ephemeral runner (Issue #663).
+ *
+ * Root cause: the `static-checks` job ran `deno fmt` (write mode), whose
+ * reformatting is never committed back, so committed formatting drift
+ * passed CI unnoticed. Switching to `deno fmt --check` makes drift fail
+ * the status check on a pull request.
+ *
+ * These are "what" tests — the workflow YAML is the deliverable, so they
+ * parse it and assert on its structure rather than grepping source text.
+ */
+
+const QUALITY_PATH = ".github/workflows/quality.yml";
+
+// deno-lint-ignore no-explicit-any
+function readWorkflow(path: string): any {
+  return parse(Deno.readTextFileSync(path));
+}
+
+// deno-lint-ignore no-explicit-any
+function fmtStep(steps: any[]): any {
+  return steps.find((s) => typeof s.run === "string" && /\bdeno fmt\b/.test(s.run));
+}
+
+Deno.test("static-checks runs deno fmt in check mode", () => {
+  const wf = readWorkflow(QUALITY_PATH);
+  const step = fmtStep(wf.jobs["static-checks"].steps);
+  assert(step, "Expected a deno fmt step in the static-checks job");
+  const run = String(step.run);
+  assert(
+    /\bdeno fmt\b[^\n]*--check/.test(run),
+    `deno fmt must run with --check so drift fails CI, got: ${run}`,
+  );
+});
+
+Deno.test("static-checks does not apply formatting in write mode", () => {
+  const wf = readWorkflow(QUALITY_PATH);
+  const step = fmtStep(wf.jobs["static-checks"].steps);
+  assert(step, "Expected a deno fmt step in the static-checks job");
+  const run = String(step.run).trim();
+  // A bare `deno fmt` (no --check) rewrites files only in the runner and
+  // is discarded, so committed drift slips through. Reject it.
+  assert(
+    run.includes("--check"),
+    `deno fmt must not run in write mode in CI, got: ${run}`,
+  );
+});


### PR DESCRIPTION
# PR Summary — Issue #663: FMT-LINT-DRIFT

## Summary

The `static-checks` job in `.github/workflows/quality.yml` ran `deno fmt` in **write mode**, which
reformats files only in the ephemeral runner and is never committed back — so committed formatting
drift passed CI unnoticed. This change switches the gate to `deno fmt --check` so drift fails the
pull-request status check, clears the one pre-existing drifted file, and adds a YAML-parsing test
that asserts the gate stays in check mode. The `deno lint` step already enforced the linter, so it
is unchanged. Closes #663.

## Changes

- **`.github/workflows/quality.yml`** — `Apply Deno formatting` (`deno fmt`) replaced by
  `Check Deno formatting` (`deno fmt --check`) in the `static-checks` job.
- **`docs/archive/pr-summaries/pr-summary-654.md`** — reformatted by `deno fmt` to clear the
  existing drift (emphasis markers `*…*` → `_…_`, a few lines re-wrapped to the configured
  `lineWidth` of 100).
- **`fmt_check_ci_test.ts`** — new test parsing the workflow YAML and asserting the fmt step runs
  with `--check`.

## Evidence

Backend/CI-config change — no web interface to screenshot. Verified locally with the Deno toolchain:

- `deno fmt --check` → `Checked 492 files` (clean, no drift).
- `deno lint` → `Checked 171 files` (clean).
- New test fails against the old `deno fmt` workflow step and passes after the `--check` change.

```mermaid
flowchart LR
    PR[Pull request with<br/>formatting drift] --> J[static-checks job]
    J --> C{deno fmt --check}
    C -- drift found --> F[Job fails ❌]
    C -- clean --> P[Job passes ✅]
```

Before this change the step was `deno fmt` (write mode): drift was silently reformatted in the
runner, discarded, and the job passed regardless.

## Test Plan

- Added `fmt_check_ci_test.ts`:
  - `static-checks runs deno fmt in check mode` — parses the workflow and asserts the fmt step's
    `run` contains `deno fmt … --check`.
  - `static-checks does not apply formatting in write mode` — asserts the step does not run bare
    `deno fmt` (write mode).
- Both reproduce the gap: they fail against the unfixed `deno fmt` step and pass after switching to
  `deno fmt --check`.
- Existing workflow/config tests (`deno_workflow_push_credential_test.ts`, `codeowners_test.ts`)
  continue to pass.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mrcqfp8j-50b92a`<!-- vibe-worker-issue-663 -->